### PR TITLE
feat: 管理ツールにDB即時投入・リモートDB登録機能を追加

### DIFF
--- a/docs/update-history.md
+++ b/docs/update-history.md
@@ -363,3 +363,16 @@
 - `src/lib/gcal.ts`: 削除（GCal API連携廃止）
 - `src/lib/__tests__/gcal.test.ts`: 削除（同上）
 - `src/lib/__tests__/auth.test.ts`: calendar.events スコープのアサーションを削除し、基本スコープの確認に更新
+
+## 2026-04-13 管理ツール DB即時投入機能追加（Issue #16）
+
+- `tools/admin-server.js`
+  - `syncLocalDb()`: `seed-races.sql` → `seed-races-all.sql` に修正
+  - `syncLocalDb()` / `syncRemoteDb()`: `exec` パラメータを注入可能にしてテスト容易性を向上
+  - `syncRemoteDb()` 関数を新規追加（`wrangler d1 execute --remote`）
+  - `POST /api/sync-remote` エンドポイントを追加
+  - `module.exports` に `syncLocalDb` / `syncRemoteDb` を追加
+- `tools/admin/index.html`: 「☁ リモートDB登録」ボタン（`btn-sync-remote`）を追加
+- `tools/admin/app.js`: `syncRemoteDb()` 関数を追加（確認ダイアログ・ステータス表示付き）
+- `tools/admin/style.css`: `.btn-warning` スタイルを追加
+- `tools/admin-server.test.js`: `syncLocalDb` / `syncRemoteDb` のユニットテストを追加（9件）

--- a/tools/admin-server.js
+++ b/tools/admin-server.js
@@ -291,23 +291,41 @@ function getMissingFields(r) {
 }
 
 // ── ローカルDB同期 ────────────────────────────────────────────────
-function syncLocalDb() {
+function syncLocalDb(exec = execSync) {
   const persistPath = path.join(
     process.env.USERPROFILE || process.env.HOME || '',
     '.wrangler', 'states', 'krote-run'
   );
   try {
     console.log('[DB同期] シードSQL生成中...');
-    execSync('node scripts/generate-seed-races.js', { cwd: ROOT, stdio: 'pipe' });
+    exec('node scripts/generate-seed-races.js', { cwd: ROOT, stdio: 'pipe' });
     console.log('[DB同期] ローカルDBに反映中...');
-    execSync(
-      `npx wrangler d1 execute krote-run-db --local --file=./migrations/seed-races.sql --persist-to "${persistPath}"`,
+    exec(
+      `npx wrangler d1 execute krote-run-db --local --file=./migrations/seed-races-all.sql --persist-to "${persistPath}"`,
       { cwd: ROOT, stdio: 'pipe' }
     );
     console.log('[DB同期] 完了');
     return { ok: true };
   } catch (err) {
     console.error('[DB同期] エラー:', err.stderr?.toString() || err.message);
+    return { ok: false, error: err.message };
+  }
+}
+
+// ── リモートDB同期 ────────────────────────────────────────────────
+function syncRemoteDb(exec = execSync) {
+  try {
+    console.log('[リモートDB同期] シードSQL生成中...');
+    exec('node scripts/generate-seed-races.js', { cwd: ROOT, stdio: 'pipe' });
+    console.log('[リモートDB同期] リモートDBに反映中...');
+    exec(
+      'npx wrangler d1 execute krote-run-db --remote --file=./migrations/seed-races-all.sql',
+      { cwd: ROOT, stdio: 'pipe' }
+    );
+    console.log('[リモートDB同期] 完了');
+    return { ok: true };
+  } catch (err) {
+    console.error('[リモートDB同期] エラー:', err.stderr?.toString() || err.message);
     return { ok: false, error: err.message };
   }
 }
@@ -548,6 +566,12 @@ const server = http.createServer(async (req, res) => {
       return jsonRes(res, { error: '不正なmode' }, 400);
     }
 
+    // ── API: リモートDB同期 ──
+    if (method === 'POST' && pathname === '/api/sync-remote') {
+      const sync = syncRemoteDb();
+      return jsonRes(res, sync, sync.ok ? 200 : 500);
+    }
+
     // ── API: 翻訳 ──
     if (method === 'POST' && pathname === '/api/translate') {
       const { text, field } = JSON.parse(await readBody(req));
@@ -710,5 +734,5 @@ if (require.main === module) {
   });
 } else {
   // テスト用エクスポート
-  module.exports = { getMissingFields };
+  module.exports = { getMissingFields, syncLocalDb, syncRemoteDb };
 }

--- a/tools/admin-server.js
+++ b/tools/admin-server.js
@@ -318,10 +318,8 @@ function syncRemoteDb(exec = execSync) {
     console.log('[リモートDB同期] シードSQL生成中...');
     exec('node scripts/generate-seed-races.js', { cwd: ROOT, stdio: 'pipe' });
     console.log('[リモートDB同期] リモートDBに反映中...');
-    exec(
-      'npx wrangler d1 execute krote-run-db --remote --file=./migrations/seed-races-all.sql',
-      { cwd: ROOT, stdio: 'pipe' }
-    );
+    // npm run 経由で実行することで cmd.exe 上の wrangler 認証情報を正しく引き継ぐ
+    exec('npm run db:seed-races:remote', { cwd: ROOT, stdio: 'pipe' });
     console.log('[リモートDB同期] 完了');
     return { ok: true };
   } catch (err) {

--- a/tools/admin-server.test.js
+++ b/tools/admin-server.test.js
@@ -229,29 +229,30 @@ describe('syncLocalDb', () => {
 // ── syncRemoteDb ユニットテスト ───────────────────────────────────────
 
 describe('syncRemoteDb', () => {
-  test('seed-races-all.sql を使用する', () => {
+  test('npm run db:seed-races:remote を使用する', () => {
     const cmds = [];
     const mockExec = (cmd) => cmds.push(cmd);
     syncRemoteDb(mockExec);
-    const wranglerCmd = cmds.find(c => c.includes('wrangler'));
-    assert.ok(wranglerCmd, 'wrangler コマンドが実行されること');
-    assert.ok(wranglerCmd.includes('seed-races-all.sql'), 'seed-races-all.sql を参照すること');
+    const remoteCmd = cmds.find(c => c.includes('db:seed-races:remote'));
+    assert.ok(remoteCmd, 'db:seed-races:remote コマンドが実行されること');
   });
 
-  test('--remote フラグを使用する', () => {
+  test('npm run を使用する（wrangler を直接呼ばない）', () => {
     const cmds = [];
     const mockExec = (cmd) => cmds.push(cmd);
     syncRemoteDb(mockExec);
-    const wranglerCmd = cmds.find(c => c.includes('wrangler'));
-    assert.ok(wranglerCmd.includes('--remote'), '--remote フラグが含まれること');
+    const directWrangler = cmds.find(c => c.startsWith('npx wrangler') && c.includes('--remote'));
+    assert.ok(!directWrangler, 'npx wrangler --remote を直接呼ばないこと');
   });
 
-  test('--local フラグを使用しない', () => {
+  test('generate-seed-races.js を先に実行する', () => {
     const cmds = [];
     const mockExec = (cmd) => cmds.push(cmd);
     syncRemoteDb(mockExec);
-    const wranglerCmd = cmds.find(c => c.includes('wrangler'));
-    assert.ok(!wranglerCmd.includes('--local'), '--local フラグが含まれないこと');
+    const genIdx = cmds.findIndex(c => c.includes('generate-seed-races.js'));
+    const syncIdx = cmds.findIndex(c => c.includes('db:seed-races:remote'));
+    assert.ok(genIdx !== -1, 'generate-seed-races.js が実行されること');
+    assert.ok(genIdx < syncIdx, 'generate-seed-races.js が先に実行されること');
   });
 
   test('execSync が成功すると { ok: true } を返す', () => {

--- a/tools/admin-server.test.js
+++ b/tools/admin-server.test.js
@@ -8,7 +8,7 @@ const { test, describe } = require('node:test');
 const assert = require('node:assert/strict');
 const http = require('node:http');
 
-const { getMissingFields } = require('./admin-server');
+const { getMissingFields, syncLocalDb, syncRemoteDb } = require('./admin-server');
 
 // ── ヘルパー: HTTPリクエスト ──────────────────────────────────────────
 function httpGet(port, path) {
@@ -190,6 +190,79 @@ describe('getMissingFields', () => {
       const r = { entry_periods: [], entry_start_date: null, entry_fee_by_category: true, official_url: null, entry_capacity: 0, description_ja: '' };
       assert.doesNotThrow(() => getMissingFields(r));
     });
+  });
+});
+
+// ── syncLocalDb ユニットテスト ────────────────────────────────────────
+
+describe('syncLocalDb', () => {
+  test('seed-races-all.sql を使用する', () => {
+    const cmds = [];
+    const mockExec = (cmd) => cmds.push(cmd);
+    syncLocalDb(mockExec);
+    const wranglerCmd = cmds.find(c => c.includes('wrangler'));
+    assert.ok(wranglerCmd, 'wrangler コマンドが実行されること');
+    assert.ok(wranglerCmd.includes('seed-races-all.sql'), 'seed-races-all.sql を参照すること');
+    assert.ok(!wranglerCmd.replace('seed-races-all.sql', '').includes('seed-races.sql'), '古い seed-races.sql を参照しないこと');
+  });
+
+  test('--local フラグを使用する', () => {
+    const cmds = [];
+    const mockExec = (cmd) => cmds.push(cmd);
+    syncLocalDb(mockExec);
+    const wranglerCmd = cmds.find(c => c.includes('wrangler'));
+    assert.ok(wranglerCmd.includes('--local'), '--local フラグが含まれること');
+  });
+
+  test('execSync が成功すると { ok: true } を返す', () => {
+    const result = syncLocalDb(() => {});
+    assert.deepEqual(result, { ok: true });
+  });
+
+  test('execSync がエラーを投げると { ok: false, error: string } を返す', () => {
+    const result = syncLocalDb(() => { throw new Error('wrangler failed'); });
+    assert.equal(result.ok, false);
+    assert.ok(typeof result.error === 'string');
+  });
+});
+
+// ── syncRemoteDb ユニットテスト ───────────────────────────────────────
+
+describe('syncRemoteDb', () => {
+  test('seed-races-all.sql を使用する', () => {
+    const cmds = [];
+    const mockExec = (cmd) => cmds.push(cmd);
+    syncRemoteDb(mockExec);
+    const wranglerCmd = cmds.find(c => c.includes('wrangler'));
+    assert.ok(wranglerCmd, 'wrangler コマンドが実行されること');
+    assert.ok(wranglerCmd.includes('seed-races-all.sql'), 'seed-races-all.sql を参照すること');
+  });
+
+  test('--remote フラグを使用する', () => {
+    const cmds = [];
+    const mockExec = (cmd) => cmds.push(cmd);
+    syncRemoteDb(mockExec);
+    const wranglerCmd = cmds.find(c => c.includes('wrangler'));
+    assert.ok(wranglerCmd.includes('--remote'), '--remote フラグが含まれること');
+  });
+
+  test('--local フラグを使用しない', () => {
+    const cmds = [];
+    const mockExec = (cmd) => cmds.push(cmd);
+    syncRemoteDb(mockExec);
+    const wranglerCmd = cmds.find(c => c.includes('wrangler'));
+    assert.ok(!wranglerCmd.includes('--local'), '--local フラグが含まれないこと');
+  });
+
+  test('execSync が成功すると { ok: true } を返す', () => {
+    const result = syncRemoteDb(() => {});
+    assert.deepEqual(result, { ok: true });
+  });
+
+  test('execSync がエラーを投げると { ok: false, error: string } を返す', () => {
+    const result = syncRemoteDb(() => { throw new Error('wrangler failed'); });
+    assert.equal(result.ok, false);
+    assert.ok(typeof result.error === 'string');
   });
 });
 

--- a/tools/admin/app.js
+++ b/tools/admin/app.js
@@ -476,6 +476,33 @@ async function saveRace() {
   }
 }
 
+// ── リモートDB登録 ────────────────────────────────────────────────
+document.getElementById('btn-sync-remote').addEventListener('click', syncRemoteDb);
+
+async function syncRemoteDb() {
+  if (!confirm('全レースデータをリモートDB（本番）に反映します。\nよろしいですか？')) return;
+
+  const btn = document.getElementById('btn-sync-remote');
+  const status = document.getElementById('save-status');
+  btn.disabled = true;
+  status.textContent = 'リモートDB登録中…';
+  status.className = 'save-status';
+
+  try {
+    const res = await fetch('/api/sync-remote', { method: 'POST' });
+    const data = await res.json();
+    if (!res.ok || !data.ok) throw new Error(data.error || 'リモートDB登録に失敗しました');
+    status.textContent = '✓ リモートDBに登録しました';
+    status.className = 'save-status success';
+    setTimeout(() => { status.textContent = ''; status.className = 'save-status'; }, 5000);
+  } catch (err) {
+    status.textContent = `エラー: ${err.message}`;
+    status.className = 'save-status error';
+  } finally {
+    btn.disabled = false;
+  }
+}
+
 function buildRaceData() {
   // カテゴリ収集
   const categories = [...document.querySelectorAll('.category-row')].map(row => ({

--- a/tools/admin/index.html
+++ b/tools/admin/index.html
@@ -55,6 +55,7 @@
             <span class="save-status" id="save-status"></span>
             <button class="btn btn-secondary" id="btn-toggle-preview" title="公式サイトプレビューを表示/非表示">🌐 公式サイト</button>
             <button class="btn btn-primary" id="btn-save">保存</button>
+            <button class="btn btn-warning" id="btn-sync-remote" title="全レースデータをリモートDBに反映します">☁ リモートDB登録</button>
             <button class="btn btn-danger" id="btn-delete">削除</button>
           </div>
         </div>

--- a/tools/admin/style.css
+++ b/tools/admin/style.css
@@ -326,6 +326,7 @@ textarea { resize: vertical; line-height: 1.6; }
 .btn-secondary { background: var(--cream); color: var(--ink2); border: 1px solid var(--border); }
 .btn-translate { background: #eff6ff; color: #1d4ed8; border: 1px solid #bfdbfe; font-size: 11px; padding: 6px 10px; flex-shrink: 0; }
 .btn-danger { background: #fee2e2; color: #dc2626; border: 1px solid #fecaca; font-size: 11px; padding: 4px 8px; }
+.btn-warning { background: #fef3c7; color: #92400e; border: 1px solid #fde68a; font-size: 13px; padding: 8px 14px; }
 
 /* ── カテゴリ ── */
 .category-row {


### PR DESCRIPTION
## Summary

- `syncLocalDb()` が参照する SQL ファイルを `seed-races.sql` → `seed-races-all.sql` に修正
- `syncRemoteDb()` 関数を新規追加（`wrangler d1 execute --remote`）
- `POST /api/sync-remote` エンドポイントを追加
- 管理ツール UI に「☁ リモートDB登録」ボタンを追加（確認ダイアログ・ステータス表示付き）

## Test plan

- [x] `node --test tools/admin-server.test.js` — 全37件パス（うち新規9件）
- [x] `npm run admin` でサーバー起動後、大会を編集して保存 → ローカルDBに反映されることを確認
- [x] 「☁ リモートDB登録」ボタン押下 → 確認ダイアログが表示されることを確認
- [x] OKを押すと `/api/sync-remote` が呼ばれ、ステータスメッセージが表示されることを確認

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)