### PR TITLE
fix: カレンダーの本日ハイライトをJST基準に修正

### DIFF
--- a/docs/update-history.md
+++ b/docs/update-history.md
@@ -376,3 +376,9 @@
 - `tools/admin/app.js`: `syncRemoteDb()` 関数を追加（確認ダイアログ・ステータス表示付き）
 - `tools/admin/style.css`: `.btn-warning` スタイルを追加
 - `tools/admin-server.test.js`: `syncLocalDb` / `syncRemoteDb` のユニットテストを追加（9件）
+
+## 2026-04-14 カレンダー本日ハイライトのJST対応（Issue #11）
+
+- `src/lib/utils.ts`: `getTodayJST()` 関数を追加（`Asia/Tokyo` タイムゾーンで YYYY-MM-DD を返す）
+- `src/app/[locale]/calendar/page.tsx`: `isToday` 判定を `new Date()` の UTC 基準から `getTodayJST()` によるJST基準に変更
+- `src/lib/__tests__/utils.date.test.ts`: `getTodayJST` のユニットテストを追加（UTC/JSTまたがり・年またぎを含む5件）

--- a/src/app/[locale]/calendar/page.tsx
+++ b/src/app/[locale]/calendar/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 import { getRaces } from '@/lib/data';
+import { getTodayJST } from '@/lib/utils';
 import { Link } from '@/i18n/navigation';
 import type { Race, EntryPeriod } from '@/lib/types';
 
@@ -39,9 +40,10 @@ export default async function CalendarPage({
 }) {
   const { locale } = await params;
   const sp = await searchParams;
-  const now = new Date();
-  const year = parseInt(sp.year ?? String(now.getFullYear()));
-  const month = parseInt(sp.month ?? String(now.getMonth())); // 0-indexed
+  const todayJST = getTodayJST(); // 例: '2026-04-14'
+  const [todayYear, todayMonth0] = todayJST.split('-').map(Number);
+  const year = parseInt(sp.year ?? String(todayYear));
+  const month = parseInt(sp.month ?? String(todayMonth0 - 1)); // 0-indexed
 
   const t = await getTranslations({ locale, namespace: 'calendar' });
   const tNav = await getTranslations({ locale, namespace: 'nav' });
@@ -205,8 +207,7 @@ export default async function CalendarPage({
             const dateStr = `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
             const dayRaces = raceDaysByDate.get(dateStr) ?? [];
             const entryBands = entryBandsByDate.get(dateStr) ?? [];
-            const isToday =
-              day === now.getDate() && month === now.getMonth() && year === now.getFullYear();
+            const isToday = dateStr === todayJST;
             const dayOfWeek = (firstDay + i) % 7;
 
 

--- a/src/lib/__tests__/utils.date.test.ts
+++ b/src/lib/__tests__/utils.date.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { getTodayJST } from '../utils';
+
+describe('getTodayJST', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('YYYY-MM-DD 形式の文字列を返す', () => {
+    const result = getTodayJST();
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('UTC 2026-04-14T00:00:00Z → JST 2026-04-14 を返す（UTCの午前はJSTと同日）', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-14T00:00:00Z')); // JST 09:00
+    expect(getTodayJST()).toBe('2026-04-14');
+  });
+
+  it('UTC 2026-04-13T15:00:00Z → JST 2026-04-14 を返す（UTC深夜はJSTで翌日）', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-13T15:00:00Z')); // JST 2026-04-14T00:00:00
+    expect(getTodayJST()).toBe('2026-04-14');
+  });
+
+  it('UTC 2026-04-13T14:59:59Z → JST 2026-04-13 を返す（JST まだ前日）', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-13T14:59:59Z')); // JST 2026-04-13T23:59:59
+    expect(getTodayJST()).toBe('2026-04-13');
+  });
+
+  it('年またぎ: UTC 2025-12-31T15:00:00Z → JST 2026-01-01 を返す', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-12-31T15:00:00Z')); // JST 2026-01-01T00:00:00
+    expect(getTodayJST()).toBe('2026-01-01');
+  });
+});

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,15 @@
 import type { RaceCategory, Race, RaceFilter, RaceStatus, Locale, DistanceType, RaceSortKey } from './types';
 
 // ==================
+// Date utilities
+// ==================
+
+/** 現在の日本時刻（JST）を YYYY-MM-DD 形式で返す。Cloudflare Workers の UTC 環境でも正しく動作する */
+export function getTodayJST(): string {
+  return new Date().toLocaleDateString('sv-SE', { timeZone: 'Asia/Tokyo' });
+}
+
+// ==================
 // Date formatting
 // ==================
 


### PR DESCRIPTION
## Summary

- Cloudflare Workers は UTC 動作のため `new Date()` が UTC 日付を返し、日本時間深夜 0〜9 時に本日ハイライトが1日ずれる問題を修正
- `getTodayJST()` を `utils.ts` に追加し、`Asia/Tokyo` タイムゾーンで今日の日付（YYYY-MM-DD）を取得
- レース日付・エントリー期間はすべてJST基準のため、海外アクセス時もローカル時刻ではなくJSTで比較するのが正しい動作

## Test plan

- [x] `npm run test` — 全131件パス（新規5件含む）
- [x] `npm run lint` — エラーなし
- [ ] UTC 深夜（JST 深夜0〜9時）に表示して正しい日付がハイライトされることを確認

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)