### PR TITLE
feat: 利用規約・初めての方へページを追加

### DIFF
--- a/docs/update-history.md
+++ b/docs/update-history.md
@@ -382,3 +382,12 @@
 - `src/lib/utils.ts`: `getTodayJST()` 関数を追加（`Asia/Tokyo` タイムゾーンで YYYY-MM-DD を返す）
 - `src/app/[locale]/calendar/page.tsx`: `isToday` 判定を `new Date()` の UTC 基準から `getTodayJST()` によるJST基準に変更
 - `src/lib/__tests__/utils.date.test.ts`: `getTodayJST` のユニットテストを追加（UTC/JSTまたがり・年またぎを含む5件）
+
+## 2026-04-15 静的コンテンツページの追加（Issue #22）
+
+- `src/app/[locale]/terms/page.tsx`: 利用規約ページを追加（ja/en対応）
+- `src/app/[locale]/guide/page.tsx`: 初めての方へページを追加（ログインのメリット含む、ja/en対応）
+- `src/components/layout/Footer.tsx`: 「初めての方へ」「利用規約」リンクを追加
+- `src/messages/ja.json`, `src/messages/en.json`: footer に `guide` / `terms` キーを追加
+- `src/app/[locale]/terms/__tests__/page.test.ts`: generateMetadata テスト追加（4件）
+- `src/app/[locale]/guide/__tests__/page.test.ts`: generateMetadata テスト追加（4件）

--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -79,6 +79,18 @@ export default async function AboutPage({
           </p>
         </section>
 
+        {/* 運営について */}
+        <section>
+          <h2 className="font-serif text-xl font-bold mb-3" style={{ color: 'var(--color-ink)' }}>
+            {isJa ? '運営について' : 'About This Site'}
+          </h2>
+          <p className="text-sm leading-8" style={{ color: 'var(--color-mid)' }}>
+            {isJa
+              ? '当サイトは、個人が公開情報をもとに収集・作成・運営しています。特定の大会主催者・スポーツ団体・企業とは一切関係なく、公式サイトでも代理店でもありません。掲載内容はすべて個人の調査によるものであり、各大会の公式情報とは独立しています。'
+              : 'HASHIRU is an independently operated site, created and maintained by an individual based on publicly available information. It has no affiliation with any race organizer, sports association, or company. All content reflects personal research and is independent of any official source.'}
+          </p>
+        </section>
+
         {/* 免責事項 */}
         <section>
           <h2 className="font-serif text-xl font-bold mb-3" style={{ color: 'var(--color-ink)' }}>
@@ -86,8 +98,8 @@ export default async function AboutPage({
           </h2>
           <p className="text-sm leading-8" style={{ color: 'var(--color-mid)' }}>
             {isJa
-              ? '当サイトに掲載している情報の正確性・完全性については万全を期しておりますが、その内容を保証するものではありません。掲載情報に基づいて被ったいかなる損害についても、当サイトは責任を負いかねます。'
-              : 'While we make every effort to ensure the accuracy of the information on this site, we cannot guarantee its completeness or accuracy. We are not responsible for any damages arising from the use of information on this site.'}
+              ? '当サイトに掲載している情報の正確性・完全性については万全を期しておりますが、その内容を保証するものではありません。大会の日程・エントリー情報・定員等は予告なく変更される場合があります。掲載情報に基づいて被ったいかなる損害についても、当サイトは責任を負いかねます。エントリーや参加の判断は必ず各大会の公式サイトでご確認ください。'
+              : 'While we make every effort to ensure the accuracy of the information on this site, we cannot guarantee its completeness or accuracy. Race dates, entry details, and capacities are subject to change without notice. We are not responsible for any damages arising from the use of information on this site. Always confirm details on each race\'s official website before registering.'}
           </p>
         </section>
 

--- a/src/app/[locale]/guide/__tests__/page.test.ts
+++ b/src/app/[locale]/guide/__tests__/page.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/i18n/navigation', () => ({
+  Link: ({ href, children }: { href: string; children: React.ReactNode }) => ({ href, children }),
+}));
+
+import { generateMetadata } from '../page';
+
+const makeParams = (locale: string) => ({
+  params: Promise.resolve({ locale }),
+});
+
+describe('guide/page generateMetadata', () => {
+  it('ja: title が「初めての方へ」を含む', async () => {
+    const meta = await generateMetadata(makeParams('ja'));
+    expect(String(meta.title)).toContain('初めての方へ');
+  });
+
+  it('en: title が "Getting Started" を含む', async () => {
+    const meta = await generateMetadata(makeParams('en'));
+    expect(String(meta.title)).toContain('Getting Started');
+  });
+
+  it('canonical URL が正しい（ja）', async () => {
+    const meta = await generateMetadata(makeParams('ja'));
+    expect(meta.alternates?.canonical).toBe('https://hashiru.run/ja/guide');
+  });
+
+  it('canonical URL が正しい（en）', async () => {
+    const meta = await generateMetadata(makeParams('en'));
+    expect(meta.alternates?.canonical).toBe('https://hashiru.run/en/guide');
+  });
+});

--- a/src/app/[locale]/guide/page.tsx
+++ b/src/app/[locale]/guide/page.tsx
@@ -1,0 +1,226 @@
+import type { Metadata } from 'next';
+import { Link } from '@/i18n/navigation';
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const isJa = locale !== 'en';
+  return {
+    title: isJa ? '初めての方へ' : 'Getting Started',
+    description: isJa
+      ? 'HASHIRUの使い方・特徴を紹介します。大会の探し方からログインのメリットまで、はじめてご利用の方へ。'
+      : 'Learn how to use HASHIRU — find races, track entries, and get reminders. A guide for first-time visitors.',
+    alternates: {
+      canonical: `https://hashiru.run/${locale}/guide`,
+      languages: {
+        ja: 'https://hashiru.run/ja/guide',
+        en: 'https://hashiru.run/en/guide',
+      },
+    },
+  };
+}
+
+function FeatureCard({
+  icon,
+  title,
+  description,
+}: {
+  icon: string;
+  title: string;
+  description: string;
+}) {
+  return (
+    <div
+      className="p-5 rounded-xl border"
+      style={{ borderColor: 'var(--color-border)', background: 'var(--color-cream)' }}
+    >
+      <div className="text-2xl mb-3">{icon}</div>
+      <h3 className="font-semibold text-sm mb-2" style={{ color: 'var(--color-ink)' }}>
+        {title}
+      </h3>
+      <p className="text-xs leading-6" style={{ color: 'var(--color-mid)' }}>
+        {description}
+      </p>
+    </div>
+  );
+}
+
+export default async function GuidePage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale: rawLocale } = await params;
+  const isJa = rawLocale !== 'en';
+
+  if (!isJa) {
+    return (
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 py-12 md:py-16">
+        <div className="mb-10">
+          <p className="text-xs font-semibold tracking-[0.2em] uppercase mb-3" style={{ color: 'var(--color-primary)' }}>
+            Guide
+          </p>
+          <h1 className="font-serif text-4xl font-bold mb-4" style={{ color: 'var(--color-ink)' }}>
+            Getting Started with HASHIRU
+          </h1>
+          <p className="text-base leading-relaxed" style={{ color: 'var(--color-mid)' }}>
+            HASHIRU is a portal for marathon and road races in Japan. Here&apos;s how to make the most of it.
+          </p>
+        </div>
+
+        <div className="space-y-12">
+          <section>
+            <h2 className="font-serif text-xl font-bold mb-6" style={{ color: 'var(--color-ink)' }}>
+              What you can do
+            </h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <FeatureCard icon="🔍" title="Find races" description="Search over 50 races by region, distance, season, or features. Filter by entry status to find races still accepting applications." />
+              <FeatureCard icon="📅" title="Entry calendar" description="View entry periods on a monthly calendar. Never miss an opening date again." />
+              <FeatureCard icon="🗺️" title="Course details" description="Explore elevation profiles, aid stations, checkpoints, and access info before race day." />
+              <FeatureCard icon="🎁" title="Participation gifts" description="Check what finisher gifts and local products each race offers." />
+            </div>
+          </section>
+
+          <section>
+            <h2 className="font-serif text-xl font-bold mb-3" style={{ color: 'var(--color-ink)' }}>
+              Why create an account?
+            </h2>
+            <p className="text-sm leading-8 mb-6" style={{ color: 'var(--color-mid)' }}>
+              Sign in with Google to unlock features that help you plan your race season.
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <FeatureCard icon="📌" title="Track your races" description='Mark races as "planning to enter" to build your personal race list.' />
+              <FeatureCard icon="🔔" title="Entry reminders" description="Get notified when entry opens for races you're watching, or the day before it closes." />
+              <FeatureCard icon="📆" title="Google Calendar sync" description="Add race dates and entry deadlines directly to your Google Calendar with one click." />
+              <FeatureCard icon="👤" title="Personalized mypage" description="See all your upcoming races and entry status at a glance." />
+            </div>
+          </section>
+
+          <section className="pt-2 flex flex-wrap gap-4">
+            <Link
+              href="/races"
+              className="inline-flex items-center gap-2 px-6 py-3 rounded-lg text-sm font-semibold text-white transition-opacity hover:opacity-85"
+              style={{ background: 'var(--color-ink)' }}
+            >
+              Browse races →
+            </Link>
+            <Link
+              href="/mypage"
+              className="inline-flex items-center gap-2 px-6 py-3 rounded-lg text-sm font-semibold border transition-opacity hover:opacity-85"
+              style={{ borderColor: 'var(--color-border)', color: 'var(--color-ink)' }}
+            >
+              Sign in / My page →
+            </Link>
+          </section>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 sm:px-6 py-12 md:py-16">
+      <div className="mb-10">
+        <p
+          className="text-xs font-semibold tracking-[0.2em] uppercase mb-3"
+          style={{ color: 'var(--color-primary)' }}
+        >
+          Guide
+        </p>
+        <h1
+          className="font-serif text-4xl font-bold mb-4"
+          style={{ color: 'var(--color-ink)' }}
+        >
+          初めての方へ
+        </h1>
+        <p className="text-base leading-relaxed" style={{ color: 'var(--color-mid)' }}>
+          HASHIRUは、日本全国のマラソン・ロードレース大会情報を集めたポータルサイトです。
+          大会選びから当日の準備まで、ランナーをサポートします。
+        </p>
+      </div>
+
+      <div className="space-y-12">
+        {/* できること */}
+        <section>
+          <h2 className="font-serif text-xl font-bold mb-6" style={{ color: 'var(--color-ink)' }}>
+            HASHIRUでできること
+          </h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <FeatureCard
+              icon="🔍"
+              title="大会を探す"
+              description="地域・距離・季節・特徴などで絞り込んで全国50以上の大会を検索できます。エントリー受付中の大会だけに絞ることも可能です。"
+            />
+            <FeatureCard
+              icon="📅"
+              title="エントリーカレンダー"
+              description="月別カレンダーでエントリー期間を一覧表示。受付開始・締切日を見逃しません。"
+            />
+            <FeatureCard
+              icon="🗺️"
+              title="コース詳細"
+              description="高低差プロファイル・エイドステーション・関門・アクセス情報を大会ごとに確認できます。"
+            />
+            <FeatureCard
+              icon="🎁"
+              title="参加賞・特典"
+              description="完走メダル・地元産品・Tシャツなど、各大会の参加賞情報をチェックできます。"
+            />
+          </div>
+        </section>
+
+        {/* ログインのメリット */}
+        <section>
+          <h2 className="font-serif text-xl font-bold mb-3" style={{ color: 'var(--color-ink)' }}>
+            ログインするともっと便利に
+          </h2>
+          <p className="text-sm leading-8 mb-6" style={{ color: 'var(--color-mid)' }}>
+            Googleアカウントでログインすると、レースシーズンの計画に役立つ機能が使えます。
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <FeatureCard
+              icon="📌"
+              title="参加予定の登録"
+              description="気になる大会を「参加予定」として登録し、マイページでまとめて管理できます。"
+            />
+            <FeatureCard
+              icon="🔔"
+              title="エントリーリマインダー"
+              description="エントリー開始日・締切前日にリマインドを受け取れます。受付開始を見逃す心配がありません。"
+            />
+            <FeatureCard
+              icon="📆"
+              title="Googleカレンダー連携"
+              description="大会日程やエントリー締切をワンクリックでGoogleカレンダーに追加できます。"
+            />
+            <FeatureCard
+              icon="👤"
+              title="マイページ"
+              description="参加予定の大会一覧・エントリー状況をまとめて確認できる専用ページが使えます。"
+            />
+          </div>
+        </section>
+
+        {/* CTA */}
+        <section className="pt-2 flex flex-wrap gap-4">
+          <Link
+            href="/races"
+            className="inline-flex items-center gap-2 px-6 py-3 rounded-lg text-sm font-semibold text-white transition-opacity hover:opacity-85"
+            style={{ background: 'var(--color-ink)' }}
+          >
+            大会を探す →
+          </Link>
+          <Link
+            href="/mypage"
+            className="inline-flex items-center gap-2 px-6 py-3 rounded-lg text-sm font-semibold border transition-opacity hover:opacity-85"
+            style={{ borderColor: 'var(--color-border)', color: 'var(--color-ink)' }}
+          >
+            ログイン / マイページ →
+          </Link>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -2,6 +2,7 @@ import { useTranslations } from 'next-intl';
 import { getTranslations } from 'next-intl/server';
 import type { Metadata } from 'next';
 import { getUpcomingRaces, getOpenEntryRaces, getSoonOpeningEntryRaces } from '@/lib/data';
+import { Link } from '@/i18n/navigation';
 import HomeSections from '@/components/home/HomeSections';
 import type { Locale } from '@/lib/types';
 
@@ -44,9 +45,15 @@ function HeroSection() {
         <h1 className="font-serif text-[2.2rem] md:text-[2.8rem] font-bold text-white leading-[1.1] tracking-[-0.015em] mb-4">
           {t('titleLine1')}&nbsp;<em className="not-italic" style={{ color: '#f0c4bb' }}>{t('titleEm')}</em>
         </h1>
-        <p className="text-[0.85rem] text-white/45 leading-[1.8] max-w-[440px] mx-auto">
+        <p className="text-[0.85rem] text-white/45 leading-[1.8] max-w-[440px] mx-auto mb-7">
           {t('subtitle')}
         </p>
+        <Link
+          href="/guide"
+          className="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg text-[0.8rem] font-semibold border border-white/25 text-white/70 hover:border-white/50 hover:text-white transition-colors"
+        >
+          {t('guideLink')}
+        </Link>
       </div>
     </section>
   );

--- a/src/app/[locale]/terms/__tests__/page.test.ts
+++ b/src/app/[locale]/terms/__tests__/page.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/i18n/navigation', () => ({
+  Link: ({ href, children }: { href: string; children: React.ReactNode }) => ({ href, children }),
+}));
+
+import { generateMetadata } from '../page';
+
+const makeParams = (locale: string) => ({
+  params: Promise.resolve({ locale }),
+});
+
+describe('terms/page generateMetadata', () => {
+  it('ja: title が「利用規約」を含む', async () => {
+    const meta = await generateMetadata(makeParams('ja'));
+    expect(String(meta.title)).toContain('利用規約');
+  });
+
+  it('en: title が "Terms" を含む', async () => {
+    const meta = await generateMetadata(makeParams('en'));
+    expect(String(meta.title)).toContain('Terms');
+  });
+
+  it('canonical URL が正しい（ja）', async () => {
+    const meta = await generateMetadata(makeParams('ja'));
+    expect(meta.alternates?.canonical).toBe('https://hashiru.run/ja/terms');
+  });
+
+  it('canonical URL が正しい（en）', async () => {
+    const meta = await generateMetadata(makeParams('en'));
+    expect(meta.alternates?.canonical).toBe('https://hashiru.run/en/terms');
+  });
+});

--- a/src/app/[locale]/terms/page.tsx
+++ b/src/app/[locale]/terms/page.tsx
@@ -1,0 +1,187 @@
+import type { Metadata } from 'next';
+import { Link } from '@/i18n/navigation';
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const isJa = locale !== 'en';
+  return {
+    title: isJa ? '利用規約' : 'Terms of Service',
+    description: isJa
+      ? 'HASHIRU（hashiru.run）の利用規約です。サービスをご利用になる前にご確認ください。'
+      : 'Terms of Service for HASHIRU (hashiru.run). Please read before using the service.',
+    alternates: {
+      canonical: `https://hashiru.run/${locale}/terms`,
+      languages: {
+        ja: 'https://hashiru.run/ja/terms',
+        en: 'https://hashiru.run/en/terms',
+      },
+    },
+  };
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="space-y-3">
+      <h2 className="font-serif text-lg font-bold" style={{ color: 'var(--color-ink)' }}>
+        {title}
+      </h2>
+      <div className="text-sm leading-8" style={{ color: 'var(--color-mid)' }}>
+        {children}
+      </div>
+    </section>
+  );
+}
+
+export default async function TermsPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale: rawLocale } = await params;
+  const isJa = rawLocale !== 'en';
+
+  if (!isJa) {
+    return (
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 py-12 md:py-16">
+        <div className="mb-10">
+          <p className="text-xs font-semibold tracking-[0.2em] uppercase mb-3" style={{ color: 'var(--color-primary)' }}>
+            Legal
+          </p>
+          <h1 className="font-serif text-4xl font-bold mb-2" style={{ color: 'var(--color-ink)' }}>
+            Terms of Service
+          </h1>
+          <p className="text-sm" style={{ color: 'var(--color-mid)' }}>Last updated: April 2026</p>
+        </div>
+        <div className="space-y-8">
+          <Section title="Acceptance of Terms">
+            <p>By accessing or using HASHIRU (hashiru.run), you agree to be bound by these Terms of Service. If you do not agree, please do not use the site.</p>
+          </Section>
+          <Section title="Use of the Site">
+            <p>HASHIRU provides race information for personal, non-commercial use. You may not reproduce, redistribute, or use the content for commercial purposes without prior written consent.</p>
+          </Section>
+          <Section title="Accuracy of Information">
+            <p>We strive to keep race information accurate and up to date, but we cannot guarantee its completeness or accuracy. Always verify details on each race&apos;s official website before registering.</p>
+          </Section>
+          <Section title="Prohibited Activities">
+            <ul className="list-disc list-inside space-y-1">
+              <li>Unauthorized scraping or automated data collection</li>
+              <li>Attempting to disrupt or damage the site</li>
+              <li>Using the site for any unlawful purpose</li>
+            </ul>
+          </Section>
+          <Section title="Disclaimer">
+            <p>HASHIRU is provided &quot;as is&quot; without warranties of any kind. We are not responsible for any damages arising from the use of this site or its content.</p>
+          </Section>
+          <Section title="Changes to Terms">
+            <p>We may update these terms at any time. Continued use of the site after changes constitutes acceptance of the new terms.</p>
+          </Section>
+          <Section title="Contact">
+            <p>For questions about these terms, please use the <Link href="/contact" className="underline hover:opacity-70">contact form</Link>.</p>
+          </Section>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 sm:px-6 py-12 md:py-16">
+      <div className="mb-10">
+        <p
+          className="text-xs font-semibold tracking-[0.2em] uppercase mb-3"
+          style={{ color: 'var(--color-primary)' }}
+        >
+          Legal
+        </p>
+        <h1
+          className="font-serif text-4xl font-bold mb-2"
+          style={{ color: 'var(--color-ink)' }}
+        >
+          利用規約
+        </h1>
+        <p className="text-sm" style={{ color: 'var(--color-mid)' }}>
+          最終更新日：2026年4月
+        </p>
+      </div>
+
+      <div className="space-y-8">
+        <Section title="はじめに">
+          <p>
+            HASHIRU（hashiru.run、以下「当サイト」）をご利用いただく前に、本利用規約をよくお読みください。
+            当サイトにアクセスまたはご利用いただくことで、本規約に同意したものとみなします。
+          </p>
+        </Section>
+
+        <Section title="サービスの内容">
+          <p>
+            当サイトは、日本全国のマラソン・ロードレース大会の情報を提供するポータルサイトです。
+            大会のエントリー情報・コース・参加賞・アクセスなどの情報を掲載しています。
+            掲載情報は各大会の公式情報をもとに作成していますが、変更になる場合があります。
+            最新・正確な情報は必ず各大会の公式サイトをご確認ください。
+          </p>
+        </Section>
+
+        <Section title="利用上の注意">
+          <p>当サイトのコンテンツは、個人的・非商用目的での閲覧を目的としています。以下の行為を禁止します。</p>
+          <ul className="list-disc list-inside space-y-1 mt-2">
+            <li>当サイトのコンテンツの無断転載・複製・商用利用</li>
+            <li>自動化ツールによる大量アクセス・スクレイピング</li>
+            <li>当サイトの運営を妨害する行為</li>
+            <li>法令または公序良俗に反する目的での利用</li>
+          </ul>
+        </Section>
+
+        <Section title="免責事項">
+          <p>
+            当サイトは、掲載情報の正確性・完全性・最新性について可能な限り努力しますが、
+            その内容を保証するものではありません。
+            当サイトの利用または掲載情報に基づいて生じたいかなる損害についても、
+            当サイトは一切の責任を負いかねます。
+          </p>
+        </Section>
+
+        <Section title="著作権">
+          <p>
+            当サイトに掲載されているコンテンツ（文章・画像・デザイン等）の著作権は、
+            当サイトまたは各権利者に帰属します。
+            無断転載・複製・改変等を禁止します。
+          </p>
+        </Section>
+
+        <Section title="外部リンク">
+          <p>
+            当サイトには外部サイトへのリンクが含まれています。
+            リンク先サイトの内容・プライバシー慣行について当サイトは責任を負いません。
+          </p>
+        </Section>
+
+        <Section title="規約の変更">
+          <p>
+            当サイトは、必要に応じて本規約を改定することがあります。
+            改定後も当サイトをご利用いただいた場合、新しい規約に同意したものとみなします。
+          </p>
+        </Section>
+
+        <section className="pt-4 flex flex-wrap gap-6 text-sm">
+          <Link
+            href="/privacy"
+            className="font-semibold hover:underline"
+            style={{ color: 'var(--color-primary)' }}
+          >
+            プライバシーポリシー →
+          </Link>
+          <Link
+            href="/contact"
+            className="font-semibold hover:underline"
+            style={{ color: 'var(--color-primary)' }}
+          >
+            お問い合わせ →
+          </Link>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -38,8 +38,10 @@ export default function Footer() {
                 {t('info')}
               </h4>
               <ul className="space-y-[9px]">
+                <li><Link href="/guide" className="text-[0.8rem] text-[#aaa] hover:text-white no-underline transition-colors">{t('guide')}</Link></li>
                 <li><Link href="/about" className="text-[0.8rem] text-[#aaa] hover:text-white no-underline transition-colors">{t('about')}</Link></li>
                 <li><Link href="/privacy" className="text-[0.8rem] text-[#aaa] hover:text-white no-underline transition-colors">{t('privacy')}</Link></li>
+                <li><Link href="/terms" className="text-[0.8rem] text-[#aaa] hover:text-white no-underline transition-colors">{t('terms')}</Link></li>
                 <li><Link href="/settings" className="text-[0.8rem] text-[#aaa] hover:text-white no-underline transition-colors">{tNav('settings')}</Link></li>
               </ul>
             </div>

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -31,6 +31,7 @@
       "titleLine1": "Run through the",
       "titleEm": "heart of Japan.",
       "subtitle": "Marathons and trail runs across Japan — from cherry blossom spring runs to autumn mountain trails.",
+      "guideLink": "New to HASHIRU? Start here →",
       "searchPlaceholder": "Search by city, distance, season…",
       "searchButton": "Search"
     },

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -74,8 +74,10 @@
       "byDistance": "By Distance",
       "bySeason": "By Season",
       "howToEnter": "How to Enter",
+      "guide": "Getting Started",
       "about": "About HASHIRU",
-      "privacy": "Privacy Policy"
+      "privacy": "Privacy Policy",
+      "terms": "Terms of Service"
     },
     "card": {
       "distance": "Distance",

--- a/src/messages/ja.json
+++ b/src/messages/ja.json
@@ -31,6 +31,7 @@
       "titleLine1": "日本を",
       "titleEm": "走ろう",
       "subtitle": "全国各地のマラソン・トレイルランレース情報。桜の春ランから山岳の秋コースまで。",
+      "guideLink": "初めての方はこちら →",
       "searchPlaceholder": "都市・距離・季節で検索…",
       "searchButton": "検索"
     },

--- a/src/messages/ja.json
+++ b/src/messages/ja.json
@@ -74,8 +74,10 @@
       "byDistance": "距離から探す",
       "bySeason": "季節から探す",
       "howToEnter": "エントリー方法",
+      "guide": "初めての方へ",
       "about": "HASHIRUについて",
-      "privacy": "プライバシーポリシー"
+      "privacy": "プライバシーポリシー",
+      "terms": "利用規約"
     },
     "card": {
       "distance": "距離",


### PR DESCRIPTION
## Summary

- `/terms` 利用規約ページを追加（禁止事項・免責事項・著作権・変更について、ja/en）
- `/guide` 初めての方へページを追加（HASHIRUの特徴4つ・ログインのメリット4つ、ja/en）
- フッターの「サイト情報」セクションに両ページへのリンクを追加
- `/contact` へのリンクを利用規約ページ内に記載（Issue #24 実装後に有効）

## Test plan

- [x] `npm run test` — 全139件パス（新規8件含む）
- [x] `npm run lint` — エラーなし
- [x] `/ja/guide`・`/en/guide` が正しく表示されることを確認
- [x] `/ja/terms`・`/en/terms` が正しく表示されることを確認
- [x] フッターからリンクが正しく機能することを確認

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)