### PR TITLE
feat: 管理ツールに周辺スポット編集機能を追加

### DIFF
--- a/docs/update-history.md
+++ b/docs/update-history.md
@@ -391,3 +391,11 @@
 - `src/messages/ja.json`, `src/messages/en.json`: footer に `guide` / `terms` キーを追加
 - `src/app/[locale]/terms/__tests__/page.test.ts`: generateMetadata テスト追加（4件）
 - `src/app/[locale]/guide/__tests__/page.test.ts`: generateMetadata テスト追加（4件）
+
+## 2026-04-15 管理ツールに周辺スポット編集機能を追加（Issue #19）
+
+- `tools/admin/app.js`: `renderNearbySpots` / `addNearbySpotRow` / `collectNearbySpots` を追加。`populateForm` と `buildRaceData` に連携を追加
+- `tools/admin/index.html`: 周辺スポットセクション（`#nearby-spots-container`）を追加
+- `tools/admin/style.css`: `.nearby-spot-row` / `.nearby-spot-fields` スタイルを追加
+- `tools/admin-server.js`: `getMissingFields()` に nearby_spots チェック（0件 → medium）を追加
+- `tools/admin-server.test.js`: nearby_spots の getMissingFields テストを追加（3件）

--- a/tools/admin-server.js
+++ b/tools/admin-server.js
@@ -287,6 +287,11 @@ function getMissingFields(r) {
     medium.push({ field: 'description', label: '説明文' });
   }
 
+  // 周辺スポット
+  if (!r.nearby_spots || r.nearby_spots.length === 0) {
+    medium.push({ field: 'nearby_spots', label: '周辺スポット' });
+  }
+
   return { high, medium };
 }
 

--- a/tools/admin-server.test.js
+++ b/tools/admin-server.test.js
@@ -163,6 +163,26 @@ describe('getMissingFields', () => {
     });
   });
 
+  describe('周辺スポット（medium）', () => {
+    test('nearby_spots が空配列 → medium に追加', () => {
+      const r = { entry_periods: [{ start_date: '2026-01-01' }], entry_start_date: null, entry_fee_by_category: true, categories: [{ entry_fee: 5000, time_limit_minutes: 360 }], official_url: 'https://example.com', entry_capacity: 100, description_ja: '説明', nearby_spots: [] };
+      const { medium } = getMissingFields(r);
+      assert.ok(medium.some(f => f.field === 'nearby_spots'));
+    });
+
+    test('nearby_spots が undefined → medium に追加', () => {
+      const r = { entry_periods: [{ start_date: '2026-01-01' }], entry_start_date: null, entry_fee_by_category: true, categories: [{ entry_fee: 5000, time_limit_minutes: 360 }], official_url: 'https://example.com', entry_capacity: 100, description_ja: '説明' };
+      const { medium } = getMissingFields(r);
+      assert.ok(medium.some(f => f.field === 'nearby_spots'));
+    });
+
+    test('nearby_spots に1件以上あり → 追加しない', () => {
+      const r = { entry_periods: [{ start_date: '2026-01-01' }], entry_start_date: null, entry_fee_by_category: true, categories: [{ entry_fee: 5000, time_limit_minutes: 360 }], official_url: 'https://example.com', entry_capacity: 100, description_ja: '説明', nearby_spots: [{ type: '観光地', name_ja: 'テスト' }] };
+      const { medium } = getMissingFields(r);
+      assert.ok(!medium.some(f => f.field === 'nearby_spots'));
+    });
+  });
+
   describe('すべて整備済み', () => {
     test('全フィールド揃っている場合は high/medium ともに空配列', () => {
       const r = {
@@ -173,6 +193,7 @@ describe('getMissingFields', () => {
         official_url: 'https://marathon.example.com',
         entry_capacity: 38000,
         description_ja: '世界的に有名な都市型マラソン大会',
+        nearby_spots: [{ type: '観光地', name_ja: 'テスト神社' }],
       };
       const { high, medium } = getMissingFields(r);
       assert.deepEqual(high, []);

--- a/tools/admin/app.js
+++ b/tools/admin/app.js
@@ -187,6 +187,9 @@ function populateForm(r) {
   // 参加賞
   renderGifts(r.participation_gifts ?? []);
 
+  // 周辺スポット
+  renderNearbySpots(r.nearby_spots ?? []);
+
   // コース
   setVal('f-course_gpx_file', r.course_gpx_file ?? '');
 
@@ -432,6 +435,163 @@ document.getElementById('btn-add-gift').addEventListener('click', () => {
   markDirty();
 });
 
+// ── 周辺スポット ────────────────────────────────────────────────
+
+const NEARBY_SPOT_TYPES = [
+  { value: '観光地', icon: '🏛️' },
+  { value: '温泉',   icon: '♨️' },
+  { value: 'グルメ', icon: '🍜' },
+  { value: '宿泊',   icon: '🏨' },
+];
+
+function renderNearbySpots(spots) {
+  const container = document.getElementById('nearby-spots-container');
+  container.innerHTML = '';
+  spots.forEach(spot => addNearbySpotRow(spot));
+}
+
+function addNearbySpotRow(spot = {}) {
+  const container = document.getElementById('nearby-spots-container');
+  const row = document.createElement('div');
+  row.className = 'nearby-spot-row';
+
+  const typeOptions = NEARBY_SPOT_TYPES.map(t =>
+    `<option value="${t.value}" ${spot.type === t.value ? 'selected' : ''}>${t.icon} ${t.value}</option>`
+  ).join('');
+
+  row.innerHTML = `
+    <div class="gift-row-header">
+      <span class="gift-row-label">スポット ${container.children.length + 1}</span>
+      <button class="btn btn-danger btn-remove-spot">削除</button>
+    </div>
+    <div class="nearby-spot-fields">
+      <div class="field">
+        <label>タイプ</label>
+        <select class="spot-type">${typeOptions}</select>
+      </div>
+      <div class="field">
+        <label>会場からの距離</label>
+        <input type="text" class="spot-distance" placeholder="例: 徒歩5分、車で15分" value="${spot.distance_from_venue ?? ''}">
+      </div>
+      <div class="field">
+        <label>名前（日本語）</label>
+        <input type="text" class="spot-name-ja" value="${spot.name_ja ?? ''}">
+      </div>
+      <div class="field">
+        <label>名前（English）</label>
+        <div class="input-row">
+          <input type="text" class="spot-name-en" value="${spot.name_en ?? ''}">
+          <button class="btn btn-translate spot-translate-name">🔄 翻訳</button>
+        </div>
+      </div>
+      <div class="field full">
+        <label>説明（日本語）</label>
+        <textarea class="spot-desc-ja" rows="2">${spot.description_ja ?? ''}</textarea>
+      </div>
+      <div class="field full">
+        <label>説明（English）</label>
+        <div class="input-row align-top">
+          <textarea class="spot-desc-en" rows="2">${spot.description_en ?? ''}</textarea>
+          <button class="btn btn-translate spot-translate-desc">🔄 翻訳</button>
+        </div>
+      </div>
+      <div class="field full">
+        <label>URL（任意）</label>
+        <input type="url" class="spot-url" placeholder="https://..." value="${spot.url ?? ''}">
+      </div>
+      <div class="field">
+        <label>緯度（任意）</label>
+        <input type="number" class="spot-lat" step="0.0001" value="${spot.latitude ?? ''}">
+      </div>
+      <div class="field">
+        <label>経度（任意）</label>
+        <input type="number" class="spot-lng" step="0.0001" value="${spot.longitude ?? ''}">
+      </div>
+    </div>
+  `;
+
+  // 翻訳ボタン（名前）
+  row.querySelector('.spot-translate-name').addEventListener('click', async (e) => {
+    const btn = e.currentTarget;
+    const srcEl = row.querySelector('.spot-name-ja');
+    const dstEl = row.querySelector('.spot-name-en');
+    const text = srcEl.value.trim();
+    if (!text) return alert('翻訳する日本語テキストを入力してください');
+    btn.disabled = true; btn.textContent = '翻訳中…';
+    try {
+      const res = await fetch('/api/translate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text, field: 'name' }),
+      });
+      const data = await res.json();
+      if (data.error) throw new Error(data.error);
+      dstEl.value = data.translated;
+      markDirty();
+    } catch (err) {
+      alert(`翻訳エラー: ${err.message}`);
+    } finally {
+      btn.disabled = false; btn.textContent = '🔄 翻訳';
+    }
+  });
+
+  // 翻訳ボタン（説明）
+  row.querySelector('.spot-translate-desc').addEventListener('click', async (e) => {
+    const btn = e.currentTarget;
+    const srcEl = row.querySelector('.spot-desc-ja');
+    const dstEl = row.querySelector('.spot-desc-en');
+    const text = srcEl.value.trim();
+    if (!text) return alert('翻訳する日本語テキストを入力してください');
+    btn.disabled = true; btn.textContent = '翻訳中…';
+    try {
+      const res = await fetch('/api/translate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text, field: 'description' }),
+      });
+      const data = await res.json();
+      if (data.error) throw new Error(data.error);
+      dstEl.value = data.translated;
+      markDirty();
+    } catch (err) {
+      alert(`翻訳エラー: ${err.message}`);
+    } finally {
+      btn.disabled = false; btn.textContent = '🔄 翻訳';
+    }
+  });
+
+  // 削除ボタン
+  row.querySelector('.btn-remove-spot').addEventListener('click', () => {
+    row.remove();
+    document.querySelectorAll('.nearby-spot-row .gift-row-label').forEach((el, i) => {
+      el.textContent = `スポット ${i + 1}`;
+    });
+    markDirty();
+  });
+
+  row.querySelectorAll('input, textarea, select').forEach(el => el.addEventListener('input', markDirty));
+  container.appendChild(row);
+}
+
+function collectNearbySpots() {
+  return [...document.querySelectorAll('.nearby-spot-row')].map(row => ({
+    type: row.querySelector('.spot-type').value,
+    name_ja: row.querySelector('.spot-name-ja').value,
+    name_en: row.querySelector('.spot-name-en').value,
+    description_ja: row.querySelector('.spot-desc-ja').value,
+    description_en: row.querySelector('.spot-desc-en').value,
+    distance_from_venue: row.querySelector('.spot-distance').value,
+    url: row.querySelector('.spot-url').value || null,
+    latitude: parseFloat(row.querySelector('.spot-lat').value) || null,
+    longitude: parseFloat(row.querySelector('.spot-lng').value) || null,
+  }));
+}
+
+document.getElementById('btn-add-nearby-spot').addEventListener('click', () => {
+  addNearbySpotRow();
+  markDirty();
+});
+
 // ── 保存 ───────────────────────────────────────────────────────────
 document.getElementById('btn-save').addEventListener('click', saveRace);
 
@@ -554,6 +714,7 @@ function buildRaceData() {
     tags,
     course_gpx_file: getVal('f-course_gpx_file') || null,
     participation_gifts: collectGifts(),
+    nearby_spots: collectNearbySpots(),
   };
 }
 

--- a/tools/admin/index.html
+++ b/tools/admin/index.html
@@ -188,6 +188,13 @@
             <button class="btn btn-secondary" id="btn-add-gift">＋ 参加賞を追加</button>
           </section>
 
+          <!-- 周辺スポット -->
+          <section class="form-section">
+            <h2 class="section-title">周辺スポット</h2>
+            <div id="nearby-spots-container"></div>
+            <button class="btn btn-secondary" id="btn-add-nearby-spot">＋ スポットを追加</button>
+          </section>
+
           <!-- アイキャッチ画像 -->
           <section class="form-section">
             <h2 class="section-title">アイキャッチ画像</h2>

--- a/tools/admin/style.css
+++ b/tools/admin/style.css
@@ -418,6 +418,24 @@ textarea { resize: vertical; line-height: 1.6; }
 
 .gift-fields { display: flex; flex-direction: column; gap: 8px; }
 
+/* ── 周辺スポット ── */
+.nearby-spot-row {
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 14px;
+  margin-bottom: 10px;
+  background: var(--cream);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.nearby-spot-fields {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+.nearby-spot-fields .field.full { grid-column: 1 / -1; }
+
 /* ── タグ ── */
 .tag-grid {
   display: flex;


### PR DESCRIPTION
## Summary

- 管理ツールに「周辺スポット」セクションを追加し、編集・追加・削除が可能に
- 各スポットで編集できる項目: タイプ（観光地/温泉/グルメ/宿泊）、名前（ja/en）、説明文（ja/en）、会場からの距離、**URLリンク**、緯度・経度
- 名前・説明文フィールドに翻訳ボタンを配置（Claude API経由）
- `getMissingFields()` に周辺スポット0件チェックを追加（medium 警告）

## Test plan

- [x] `node --test tools/admin-server.test.js` — 全40件パス（新規3件含む）
- [x] `npm run admin` で管理サーバーを起動し、大会を選択して周辺スポットセクションが表示されることを確認
- [x] スポット追加 → 各フィールド入力 → 保存でJSONに反映されることを確認
- [x] URLフィールドに入力した値がレース詳細ページの「詳細 →」リンクに反映されることを確認
- [ ] 翻訳ボタンが動作することを確認

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)