### PR TITLE
fix: 説明欄の改行が表示されない問題を修正（Issue #29）

### DIFF
--- a/src/app/[locale]/races/[id]/page.tsx
+++ b/src/app/[locale]/races/[id]/page.tsx
@@ -275,7 +275,7 @@ export default async function RaceDetailPage({
           <section>
             <SectionLabel>{locale === 'ja' ? '概要' : 'Overview'}</SectionLabel>
             <SectionTitle>{t('overview')}</SectionTitle>
-            <p className="text-base leading-relaxed" style={{ color: 'var(--color-ink2)' }}>
+            <p className="text-base leading-relaxed whitespace-pre-line" style={{ color: 'var(--color-ink2)' }}>
               {raceDesc}
             </p>
           </section>
@@ -625,7 +625,7 @@ export default async function RaceDetailPage({
                   })}
                 </div>
                 {(locale === 'ja' ? gift.description_ja : gift.description_en) && (
-                  <p className="text-sm leading-relaxed" style={{ color: 'var(--color-ink2)' }}>
+                  <p className="text-sm leading-relaxed whitespace-pre-line" style={{ color: 'var(--color-ink2)' }}>
                     {locale === 'ja' ? gift.description_ja : gift.description_en}
                   </p>
                 )}
@@ -661,7 +661,7 @@ export default async function RaceDetailPage({
                         <p className="text-xs mb-1" style={{ color: 'var(--color-light)' }}>
                           {spot.distance_from_venue}
                         </p>
-                        <p className="text-xs leading-relaxed" style={{ color: 'var(--color-ink2)' }}>
+                        <p className="text-xs leading-relaxed whitespace-pre-line" style={{ color: 'var(--color-ink2)' }}>
                           {locale === 'ja' ? spot.description_ja : spot.description_en}
                         </p>
                         {spot.url && (


### PR DESCRIPTION
## Summary

- 概要・参加賞・周辺スポットの description テキストに `whitespace-pre-line` クラスを追加
- テキスト中の `\n` 改行が HTML 上で正しく描画されるようになる

## 変更箇所

`src/app/[locale]/races/[id]/page.tsx` の3箇所:
- 概要（Overview）セクション
- 参加賞（Gift）セクション
- 周辺スポット（Nearby Spots）セクション

## Test plan

- [x] 複数行テキストを持つレース詳細ページで改行が反映されていることを確認
- [x] `npm run lint` エラーなし

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)