### PR TITLE
feat: お問い合わせフォームを実装（Issue #24）

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -272,6 +272,27 @@ ER図は `docs/er-diagram.drawio` で管理しています。[draw.io](https://a
 
 ---
 
+## contact_submissions テーブル
+
+お問い合わせ送信データを保存する。
+
+| カラム | 型 | NULL | デフォルト | 備考 |
+|---|---|---|---|---|
+| id | integer | NO | autoincrement | PK |
+| name | text | NO | — | 送信者名 |
+| email | text | NO | — | 送信者メールアドレス |
+| category | text | NO | — | `race_error` / `race_suggestion` / `site_bug` / `other` |
+| message | text | NO | — | 本文（10〜5000文字） |
+| user_id | text | YES | — | FK → user.id（SET NULL）。ログイン済みユーザーのみ |
+| status | text | NO | `"pending"` | `pending` / `in_progress` / `resolved` |
+| created_at | text | NO | — | ISO8601 |
+
+**インデックス**
+- `contact_submissions_status_idx` → status
+- `contact_submissions_created_at_idx` → created_at
+
+---
+
 ## マイグレーション履歴
 
 | ファイル | 内容 |
@@ -283,3 +304,4 @@ ER図は `docs/er-diagram.drawio` で管理しています。[draw.io](https://a
 | `migrations/0002_lyrical_korath.sql` | user_races テーブルを追加（Phase 2: 参加予定・受付開始前日リマインド） |
 | `migrations/0003_sloppy_jack_power.sql` | user_races に planning_category_id / entry_reminder_period_ids を追加、entry_reminder / gcal_entry_event_id を削除 |
 | `migrations/0004_complex_justin_hammer.sql` | user_races から gcal_race_event_id / gcal_entry_event_ids を削除 |
+| `migrations/0005_boring_corsair.sql` | contact_submissions テーブルを追加 |

--- a/docs/update-history.md
+++ b/docs/update-history.md
@@ -410,3 +410,17 @@
 ## 2026-04-17 説明欄の改行表示を修正（Issue #29）
 
 - `src/app/[locale]/races/[id]/page.tsx`: 概要・参加賞・周辺スポットの description に `whitespace-pre-line` を追加し、テキスト中の `\n` を改行として描画
+
+## 2026-04-16 お問い合わせフォーム実装（Issue #24）
+
+- `src/lib/db/schema.ts`: `contact_submissions` テーブルを追加（id, name, email, category, message, user_id, status, created_at）
+- `migrations/0005_boring_corsair.sql`: 上記テーブルのDrizzleマイグレーションを生成
+- `migrations/meta/0004_snapshot.json`: スナップショット衝突（prevId重複）を修正
+- `src/lib/contact-actions.ts`: Server Action `submitContact` を新規作成。バリデーション・D1保存・Resend通知（APIキー未設定時はスキップ）
+- `src/components/contact/ContactForm.tsx`: お問い合わせフォームのClient Component（useActionState使用）
+- `src/components/contact/ContactFormWrapper.tsx`: useSession()でログイン情報を取得しContactFormに渡すラッパー
+- `src/app/[locale]/contact/page.tsx`: `/contact` ページを新規作成
+- `src/messages/ja.json` / `src/messages/en.json`: `contact` ネームスペース、`nav.contact` キーを追加
+- `src/components/layout/Footer.tsx`: フッターのInfoセクションにお問い合わせリンクを追加
+- `docs/schema.md`: contact_submissions テーブルの定義・マイグレーション履歴を追記
+- `package.json`: `resend` パッケージを追加（メール通知用）

--- a/migrations/0005_boring_corsair.sql
+++ b/migrations/0005_boring_corsair.sql
@@ -1,0 +1,94 @@
+CREATE TABLE `account` (
+	`id` text PRIMARY KEY NOT NULL,
+	`accountId` text NOT NULL,
+	`providerId` text NOT NULL,
+	`userId` text NOT NULL,
+	`accessToken` text,
+	`refreshToken` text,
+	`idToken` text,
+	`accessTokenExpiresAt` integer,
+	`refreshTokenExpiresAt` integer,
+	`scope` text,
+	`password` text,
+	`createdAt` integer NOT NULL,
+	`updatedAt` integer NOT NULL,
+	FOREIGN KEY (`userId`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `contact_submissions` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`name` text NOT NULL,
+	`email` text NOT NULL,
+	`category` text NOT NULL,
+	`message` text NOT NULL,
+	`user_id` text,
+	`status` text DEFAULT 'pending' NOT NULL,
+	`created_at` text NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX `contact_submissions_status_idx` ON `contact_submissions` (`status`);--> statement-breakpoint
+CREATE INDEX `contact_submissions_created_at_idx` ON `contact_submissions` (`created_at`);--> statement-breakpoint
+CREATE TABLE `passkey` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text,
+	`publicKey` text NOT NULL,
+	`userId` text NOT NULL,
+	`webAuthnUserID` text NOT NULL,
+	`counter` integer NOT NULL,
+	`deviceType` text NOT NULL,
+	`backedUp` integer NOT NULL,
+	`transports` text,
+	`createdAt` integer,
+	FOREIGN KEY (`userId`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `session` (
+	`id` text PRIMARY KEY NOT NULL,
+	`expiresAt` integer NOT NULL,
+	`token` text NOT NULL,
+	`createdAt` integer NOT NULL,
+	`updatedAt` integer NOT NULL,
+	`ipAddress` text,
+	`userAgent` text,
+	`userId` text NOT NULL,
+	FOREIGN KEY (`userId`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `session_token_unique` ON `session` (`token`);--> statement-breakpoint
+CREATE TABLE `user` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`email` text NOT NULL,
+	`emailVerified` integer DEFAULT false NOT NULL,
+	`image` text,
+	`createdAt` integer NOT NULL,
+	`updatedAt` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `user_email_unique` ON `user` (`email`);--> statement-breakpoint
+CREATE TABLE `user_races` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`race_id` text NOT NULL,
+	`is_planning` integer DEFAULT false NOT NULL,
+	`planning_category_id` integer,
+	`entry_reminder_period_ids` text DEFAULT '[]' NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`race_id`) REFERENCES `races`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`planning_category_id`) REFERENCES `race_categories`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX `user_races_user_id_idx` ON `user_races` (`user_id`);--> statement-breakpoint
+CREATE INDEX `user_races_race_id_idx` ON `user_races` (`race_id`);--> statement-breakpoint
+CREATE INDEX `user_races_user_race_idx` ON `user_races` (`user_id`,`race_id`);--> statement-breakpoint
+CREATE TABLE `verification` (
+	`id` text PRIMARY KEY NOT NULL,
+	`identifier` text NOT NULL,
+	`value` text NOT NULL,
+	`expiresAt` integer NOT NULL,
+	`createdAt` integer,
+	`updatedAt` integer
+);

--- a/migrations/meta/0004_snapshot.json
+++ b/migrations/meta/0004_snapshot.json
@@ -2,7 +2,7 @@
   "version": "6",
   "dialect": "sqlite",
   "id": "dbbf7015-4312-41ea-ab41-3cb9fe6d72e9",
-  "prevId": "a8ee9d1b-efa7-4db2-877c-4462cb4a966f",
+  "prevId": "451e9778-aa9d-493c-b3de-caab536a8304",
   "tables": {
     "access_points": {
       "name": "access_points",

--- a/migrations/meta/0005_snapshot.json
+++ b/migrations/meta/0005_snapshot.json
@@ -1,8 +1,8 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "a8ee9d1b-efa7-4db2-877c-4462cb4a966f",
-  "prevId": "0b81fc09-0b27-41d3-85aa-53ab4074da92",
+  "id": "be139410-d719-4b0d-9c96-c66aadda0a7c",
+  "prevId": "a8ee9d1b-efa7-4db2-877c-4462cb4a966f",
   "tables": {
     "access_points": {
       "name": "access_points",
@@ -101,6 +101,121 @@
           "tableTo": "races",
           "columnsFrom": [
             "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
           ],
           "columnsTo": [
             "id"
@@ -243,6 +358,102 @@
             "id"
           ],
           "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "contact_submissions": {
+      "name": "contact_submissions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "contact_submissions_status_idx": {
+          "name": "contact_submissions_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "contact_submissions_created_at_idx": {
+          "name": "contact_submissions_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "contact_submissions_user_id_user_id_fk": {
+          "name": "contact_submissions_user_id_user_id_fk",
+          "tableFrom": "contact_submissions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
           "onUpdate": "no action"
         }
       },
@@ -476,6 +687,100 @@
           "tableTo": "races",
           "columnsFrom": [
             "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkey": {
+      "name": "passkey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "webAuthnUserID": {
+          "name": "webAuthnUserID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deviceType": {
+          "name": "deviceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backedUp": {
+          "name": "backedUp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "passkey_userId_user_id_fk": {
+          "name": "passkey_userId_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
           ],
           "columnsTo": [
             "id"
@@ -1273,6 +1578,345 @@
           "onUpdate": "no action"
         }
       },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_races": {
+      "name": "user_races",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_planning": {
+          "name": "is_planning",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "planning_category_id": {
+          "name": "planning_category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_reminder_period_ids": {
+          "name": "entry_reminder_period_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_races_user_id_idx": {
+          "name": "user_races_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "user_races_race_id_idx": {
+          "name": "user_races_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        },
+        "user_races_user_race_idx": {
+          "name": "user_races_user_race_idx",
+          "columns": [
+            "user_id",
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_races_user_id_user_id_fk": {
+          "name": "user_races_user_id_user_id_fk",
+          "tableFrom": "user_races",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_races_race_id_races_id_fk": {
+          "name": "user_races_race_id_races_id_fk",
+          "tableFrom": "user_races",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_races_planning_category_id_race_categories_id_fk": {
+          "name": "user_races_planning_category_id_race_categories_id_fk",
+          "tableFrom": "user_races",
+          "tableTo": "race_categories",
+          "columnsFrom": [
+            "planning_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "checkConstraints": {}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1775892105480,
       "tag": "0004_complex_justin_hammer",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1776381028337,
+      "tag": "0005_boring_corsair",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react-dom": "19.2.3",
         "react-leaflet": "^5.0.0",
         "recharts": "^3.8.0",
+        "resend": "^6.12.0",
         "wrangler": "^4.65.0"
       },
       "devDependencies": {
@@ -5965,6 +5966,12 @@
       "integrity": "sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA==",
       "license": "CC0-1.0"
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -9973,6 +9980,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-xml-builder": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
@@ -12906,6 +12919,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
@@ -13254,6 +13273,27 @@
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
       "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
+    },
+    "node_modules/resend": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.0.tgz",
+      "integrity": "sha512-CaxEvX1z+/MGbgnhsM/bvmkbnZd1v1sEXELAjBNSDBQNMaB7MgqOyrBgI27CYikEgdaDnBrXghAXYWTBs/h5Bw==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "svix": "1.90.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
+      }
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -13797,6 +13837,16 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -14106,6 +14156,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.90.0.tgz",
+      "integrity": "sha512-ljkZuyy2+IBEoESkIpn8sLM+sxJHQcPxlZFxU+nVDhltNfUMisMBzWX/UR8SjEnzoI28ZjCzMbmYAPwSTucoMw==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0",
+        "uuid": "^10.0.0"
       }
     },
     "node_modules/symbol-tree": {
@@ -14658,6 +14718,19 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "react-dom": "19.2.3",
     "react-leaflet": "^5.0.0",
     "recharts": "^3.8.0",
+    "resend": "^6.12.0",
     "wrangler": "^4.65.0"
   },
   "devDependencies": {

--- a/src/app/[locale]/contact/page.tsx
+++ b/src/app/[locale]/contact/page.tsx
@@ -1,0 +1,54 @@
+import { getTranslations } from 'next-intl/server';
+import { type Locale } from '@/i18n/routing';
+import ContactFormWrapper from '@/components/contact/ContactFormWrapper';
+
+type Props = {
+  params: Promise<{ locale: string }>;
+};
+
+export async function generateMetadata({ params }: Props) {
+  const { locale: rawLocale } = await params;
+  const locale = rawLocale as Locale;
+  const t = await getTranslations({ locale, namespace: 'contact' });
+  return { title: t('title') };
+}
+
+export default async function ContactPage({ params }: Props) {
+  const { locale: rawLocale } = await params;
+  const locale = rawLocale as Locale;
+  const t = await getTranslations({ locale, namespace: 'contact' });
+  const tNav = await getTranslations({ locale, namespace: 'nav' });
+
+  return (
+    <main className="min-h-screen py-16 px-4" style={{ background: 'var(--color-cream)' }}>
+      <div className="max-w-2xl mx-auto">
+        {/* ヘッダー */}
+        <div className="mb-10">
+          <p
+            className="text-xs font-semibold tracking-[0.18em] uppercase mb-3"
+            style={{ color: 'var(--color-primary)' }}
+          >
+            {tNav('contact')}
+          </p>
+          <h1
+            className="font-serif text-3xl sm:text-4xl mb-4"
+            style={{ color: 'var(--color-ink)' }}
+          >
+            {t('title')}
+          </h1>
+          <p className="text-sm leading-7" style={{ color: '#555' }}>
+            {t('subtitle')}
+          </p>
+        </div>
+
+        {/* フォーム */}
+        <div
+          className="rounded-2xl p-8 sm:p-10"
+          style={{ background: 'white', border: '1px solid var(--color-border)' }}
+        >
+          <ContactFormWrapper />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/components/contact/ContactForm.tsx
+++ b/src/components/contact/ContactForm.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import { useActionState, useEffect, useRef } from 'react';
+import { useTranslations } from 'next-intl';
+import { Link } from '@/i18n/navigation';
+import { submitContact, type ContactActionState } from '@/lib/contact-actions';
+
+type Props = {
+  defaultName?: string;
+  defaultEmail?: string;
+  userId?: string;
+};
+
+export default function ContactForm({ defaultName = '', defaultEmail = '', userId }: Props) {
+  const t = useTranslations('contact');
+  const [state, action, isPending] = useActionState<ContactActionState, FormData>(
+    submitContact,
+    null,
+  );
+  const formRef = useRef<HTMLFormElement>(null);
+
+  useEffect(() => {
+    if (state && 'success' in state) {
+      formRef.current?.reset();
+    }
+  }, [state]);
+
+  if (state && 'success' in state) {
+    return (
+      <div className="text-center py-16 px-6">
+        <div
+          className="w-14 h-14 rounded-full flex items-center justify-center mx-auto mb-6"
+          style={{ background: 'var(--color-primary)' }}
+        >
+          <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
+        </div>
+        <h2 className="font-serif text-2xl mb-3" style={{ color: 'var(--color-ink)' }}>
+          {t('successTitle')}
+        </h2>
+        <p className="text-sm mb-8" style={{ color: '#666' }}>
+          {t('successMessage')}
+        </p>
+        <Link
+          href="/"
+          className="inline-block px-6 py-3 text-sm font-medium rounded-lg no-underline transition-colors"
+          style={{ background: 'var(--color-primary)', color: 'white' }}
+        >
+          {t('backToTop')}
+        </Link>
+      </div>
+    );
+  }
+
+  const categories = ['race_error', 'race_suggestion', 'site_bug', 'other'] as const;
+
+  return (
+    <form ref={formRef} action={action} className="space-y-6">
+      {userId && <input type="hidden" name="user_id" value={userId} />}
+
+      {state && 'error' in state && (
+        <div
+          className="px-4 py-3 rounded-lg text-sm"
+          style={{ background: '#fff0f0', color: '#c0392b', border: '1px solid #fac9c9' }}
+        >
+          {state.error}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+        <div>
+          <label
+            htmlFor="contact-name"
+            className="block text-sm font-medium mb-1.5"
+            style={{ color: 'var(--color-ink)' }}
+          >
+            {t('name')} <span style={{ color: 'var(--color-primary)' }}>*</span>
+          </label>
+          <input
+            id="contact-name"
+            type="text"
+            name="name"
+            defaultValue={defaultName}
+            placeholder={t('namePlaceholder')}
+            required
+            className="w-full px-4 py-2.5 rounded-lg text-sm outline-none transition-colors"
+            style={{
+              border: '1px solid var(--color-border)',
+              background: 'white',
+              color: 'var(--color-ink)',
+            }}
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="contact-email"
+            className="block text-sm font-medium mb-1.5"
+            style={{ color: 'var(--color-ink)' }}
+          >
+            {t('email')} <span style={{ color: 'var(--color-primary)' }}>*</span>
+          </label>
+          <input
+            id="contact-email"
+            type="email"
+            name="email"
+            defaultValue={defaultEmail}
+            placeholder={t('emailPlaceholder')}
+            required
+            className="w-full px-4 py-2.5 rounded-lg text-sm outline-none transition-colors"
+            style={{
+              border: '1px solid var(--color-border)',
+              background: 'white',
+              color: 'var(--color-ink)',
+            }}
+          />
+        </div>
+      </div>
+
+      <div>
+        <label
+          htmlFor="contact-category"
+          className="block text-sm font-medium mb-1.5"
+          style={{ color: 'var(--color-ink)' }}
+        >
+          {t('category')} <span style={{ color: 'var(--color-primary)' }}>*</span>
+        </label>
+        <select
+          id="contact-category"
+          name="category"
+          required
+          defaultValue=""
+          className="w-full px-4 py-2.5 rounded-lg text-sm outline-none transition-colors appearance-none"
+          style={{
+            border: '1px solid var(--color-border)',
+            background: 'white',
+            color: 'var(--color-ink)',
+          }}
+        >
+          <option value="" disabled>{t('categoryPlaceholder')}</option>
+          {categories.map((cat) => (
+            <option key={cat} value={cat}>{t(`categories.${cat}`)}</option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label
+          htmlFor="contact-message"
+          className="block text-sm font-medium mb-1.5"
+          style={{ color: 'var(--color-ink)' }}
+        >
+          {t('message')} <span style={{ color: 'var(--color-primary)' }}>*</span>
+        </label>
+        <textarea
+          id="contact-message"
+          name="message"
+          rows={6}
+          placeholder={t('messagePlaceholder')}
+          required
+          className="w-full px-4 py-2.5 rounded-lg text-sm outline-none transition-colors resize-y"
+          style={{
+            border: '1px solid var(--color-border)',
+            background: 'white',
+            color: 'var(--color-ink)',
+            minHeight: '120px',
+          }}
+        />
+      </div>
+
+      <div>
+        <button
+          type="submit"
+          disabled={isPending}
+          className="w-full sm:w-auto px-8 py-3 rounded-lg text-sm font-medium transition-opacity disabled:opacity-60"
+          style={{ background: 'var(--color-primary)', color: 'white' }}
+        >
+          {isPending ? t('submitting') : t('submit')}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/contact/ContactFormWrapper.tsx
+++ b/src/components/contact/ContactFormWrapper.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { useSession } from '@/lib/auth-client';
+import ContactForm from './ContactForm';
+
+export default function ContactFormWrapper() {
+  const { data: session } = useSession();
+  return (
+    <ContactForm
+      defaultName={session?.user.name ?? ''}
+      defaultEmail={session?.user.email ?? ''}
+      userId={session?.user.id}
+    />
+  );
+}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -43,6 +43,7 @@ export default function Footer() {
                 <li><Link href="/privacy" className="text-[0.8rem] text-[#aaa] hover:text-white no-underline transition-colors">{t('privacy')}</Link></li>
                 <li><Link href="/terms" className="text-[0.8rem] text-[#aaa] hover:text-white no-underline transition-colors">{t('terms')}</Link></li>
                 <li><Link href="/settings" className="text-[0.8rem] text-[#aaa] hover:text-white no-underline transition-colors">{tNav('settings')}</Link></li>
+                <li><Link href="/contact" className="text-[0.8rem] text-[#aaa] hover:text-white no-underline transition-colors">{tNav('contact')}</Link></li>
               </ul>
             </div>
           </div>

--- a/src/lib/contact-actions.ts
+++ b/src/lib/contact-actions.ts
@@ -1,0 +1,77 @@
+'use server';
+
+import { getCloudflareContext } from '@opennextjs/cloudflare';
+import { getDatabase } from '@/lib/db/client';
+import { contact_submissions } from '@/lib/db/schema';
+import { Resend } from 'resend';
+
+export type ContactActionState =
+  | { success: true }
+  | { error: string }
+  | null;
+
+const VALID_CATEGORIES = [
+  'race_error',
+  'race_suggestion',
+  'site_bug',
+  'other',
+] as const;
+
+export async function submitContact(
+  _prev: ContactActionState,
+  formData: FormData,
+): Promise<ContactActionState> {
+  const name = (formData.get('name') as string)?.trim();
+  const email = (formData.get('email') as string)?.trim();
+  const category = (formData.get('category') as string)?.trim();
+  const message = (formData.get('message') as string)?.trim();
+  const userId = (formData.get('user_id') as string) || null;
+
+  if (!name) return { error: 'お名前を入力してください' };
+  if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    return { error: '有効なメールアドレスを入力してください' };
+  }
+  if (!category || !VALID_CATEGORIES.includes(category as typeof VALID_CATEGORIES[number])) {
+    return { error: 'お問い合わせ種別を選択してください' };
+  }
+  if (!message || message.length < 10) {
+    return { error: 'お問い合わせ内容を10文字以上で入力してください' };
+  }
+  if (message.length > 5000) {
+    return { error: 'お問い合わせ内容は5000文字以内で入力してください' };
+  }
+
+  const db = getDatabase();
+  await db.insert(contact_submissions).values({
+    name,
+    email,
+    category,
+    message,
+    user_id: userId || null,
+    status: 'pending',
+    created_at: new Date().toISOString(),
+  });
+
+  // Resend通知（APIキー未設定の場合はスキップ）
+  const { env } = getCloudflareContext();
+  const resendApiKey = (env as Record<string, string>).RESEND_API_KEY;
+  const notifyEmail = (env as Record<string, string>).CONTACT_NOTIFY_EMAIL;
+
+  if (resendApiKey && notifyEmail) {
+    const resend = new Resend(resendApiKey);
+    const categoryLabels: Record<string, string> = {
+      race_error: '大会情報の誤り報告',
+      race_suggestion: '大会情報の追加・更新提案',
+      site_bug: 'サイトの不具合報告',
+      other: 'その他',
+    };
+    await resend.emails.send({
+      from: 'HASHIRU <noreply@hashiru.run>',
+      to: notifyEmail,
+      subject: `[HASHIRU] お問い合わせ: ${categoryLabels[category] ?? category}`,
+      text: `名前: ${name}\nメール: ${email}\n種別: ${categoryLabels[category] ?? category}\n\n${message}`,
+    });
+  }
+
+  return { success: true };
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -314,6 +314,24 @@ export const passkey = sqliteTable("passkey", {
 });
 
 // ==================
+// contact_submissions (お問い合わせ)
+// ==================
+
+export const contact_submissions = sqliteTable("contact_submissions", {
+  id:         integer("id").primaryKey({ autoIncrement: true }),
+  name:       text("name").notNull(),
+  email:      text("email").notNull(),
+  category:   text("category").notNull(),
+  message:    text("message").notNull(),
+  user_id:    text("user_id").references(() => user.id, { onDelete: "set null" }),
+  status:     text("status").notNull().default("pending"), // pending / in_progress / resolved
+  created_at: text("created_at").notNull(),
+}, (t) => [
+  index("contact_submissions_status_idx").on(t.status),
+  index("contact_submissions_created_at_idx").on(t.created_at),
+]);
+
+// ==================
 // user_races (ユーザー大会登録)
 // ==================
 

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -14,7 +14,8 @@
     "settings": "Settings",
     "mypage": "My Page",
     "login": "Login",
-    "logout": "Logout"
+    "logout": "Logout",
+    "contact": "Contact"
   },
   "auth": {
     "loginTitle": "Sign In",
@@ -239,6 +240,30 @@
     "optOutBody": "You can also disable Google Analytics data collection by installing the Google Analytics Opt-out Browser Add-on.",
     "contactTitle": "Contact",
     "contactBody": "For questions about this policy, please contact us via the official race listing pages."
+  },
+  "contact": {
+    "title": "Contact Us",
+    "subtitle": "Report a race error, suggest an update, or let us know about a bug.",
+    "name": "Name",
+    "namePlaceholder": "Your name",
+    "email": "Email",
+    "emailPlaceholder": "example@email.com",
+    "category": "Category",
+    "categoryPlaceholder": "Select a category",
+    "categories": {
+      "race_error": "Report a race error",
+      "race_suggestion": "Suggest race update / addition",
+      "site_bug": "Report a site bug",
+      "other": "Other"
+    },
+    "message": "Message",
+    "messagePlaceholder": "Please describe your enquiry (at least 10 characters)",
+    "submit": "Send",
+    "submitting": "Sending...",
+    "successTitle": "Message sent!",
+    "successMessage": "Thank you for contacting us. We'll review your message and get back to you if needed.",
+    "backToTop": "Back to top",
+    "loginNote": "Log in to pre-fill your name and email."
   },
   "settings": {
     "title": "Settings",

--- a/src/messages/ja.json
+++ b/src/messages/ja.json
@@ -14,7 +14,8 @@
     "settings": "設定",
     "mypage": "マイページ",
     "login": "ログイン",
-    "logout": "ログアウト"
+    "logout": "ログアウト",
+    "contact": "お問い合わせ"
   },
   "auth": {
     "loginTitle": "ログイン",
@@ -239,6 +240,30 @@
     "optOutBody": "ブラウザ拡張機能「Google Analytics オプトアウト アドオン」を使用することでも、GAによるデータ収集を無効にできます。",
     "contactTitle": "お問い合わせ",
     "contactBody": "本ポリシーに関するご質問は、公式レース掲載ページよりお問い合わせください。"
+  },
+  "contact": {
+    "title": "お問い合わせ",
+    "subtitle": "大会情報の誤りや不具合など、お気軽にご連絡ください。",
+    "name": "お名前",
+    "namePlaceholder": "山田 太郎",
+    "email": "メールアドレス",
+    "emailPlaceholder": "example@email.com",
+    "category": "お問い合わせ種別",
+    "categoryPlaceholder": "種別を選択してください",
+    "categories": {
+      "race_error": "大会情報の誤り報告",
+      "race_suggestion": "大会情報の追加・更新提案",
+      "site_bug": "サイトの不具合報告",
+      "other": "その他"
+    },
+    "message": "お問い合わせ内容",
+    "messagePlaceholder": "お問い合わせ内容を入力してください（10文字以上）",
+    "submit": "送信する",
+    "submitting": "送信中...",
+    "successTitle": "送信が完了しました",
+    "successMessage": "お問い合わせありがとうございます。内容を確認後、必要に応じてご連絡いたします。",
+    "backToTop": "トップに戻る",
+    "loginNote": "ログインすると名前・メールアドレスが自動で入力されます。"
   },
   "settings": {
     "title": "設定",


### PR DESCRIPTION
- contact_submissionsテーブルをD1に追加（Drizzleマイグレーション生成）
- Server Action (submitContact): バリデーション・D1保存・Resendメール通知
- /contact ページ・ContactFormコンポーネントを新規作成
- ログイン済みユーザーは名前・メールを自動入力
- フッターにお問い合わせリンクを追加
- Resend APIキー未設定時はメール通知をスキップして正常動作

https://claude.ai/code/session_01MeSiixT1wrzhANhurNwrnK