### PR TITLE
docs: READMEを現状に合わせて更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 | データベース | [Cloudflare D1](https://developers.cloudflare.com/d1/)（SQLite） |
 | ORM | [Drizzle ORM](https://orm.drizzle.team/) |
 | 地図 | [Leaflet](https://leafletjs.com/) + [react-leaflet](https://react-leaflet.js.org/) |
-| グラフ | [Recharts](https://recharts.org/)（高低差チャート・気象データ） |
+| グラフ | [Recharts](https://recharts.org/)（高低差チャート） |
 | ホスティング | [Cloudflare Pages](https://pages.cloudflare.com/) + [OpenNext](https://opennext.js.org/) |
 
 ## セットアップ
@@ -52,75 +52,71 @@ src/
 ├── app/
 │   ├── layout.tsx                  # ルートレイアウト（最小限）
 │   ├── page.tsx                    # / → /ja リダイレクト
+│   ├── api/                        # APIルート（認証・レース・ユーザー）
 │   └── [locale]/
 │       ├── layout.tsx              # ロケール共通レイアウト（フォント・Header・Footer）
-│       ├── page.tsx                # ホームページ（Travel Magazine スタイル）
+│       ├── page.tsx                # ホームページ
 │       ├── races/
 │       │   ├── page.tsx            # 大会一覧（フィルター + Magazine/Experience 切替）
 │       │   └── [id]/page.tsx       # 大会詳細
+│       ├── admin/                  # 管理画面（大会追加・削除）
 │       ├── calendar/page.tsx       # 大会カレンダー
-│       └── settings/page.tsx       # 設定
+│       ├── mypage/page.tsx         # マイページ
+│       ├── contact/page.tsx        # お問い合わせ
+│       ├── guide/page.tsx          # 利用ガイド
+│       ├── about/page.tsx          # サイト概要
+│       └── terms/ cookie-policy/ privacy/
 ├── components/
 │   ├── layout/                     # Header（JA/EN切替）, Footer
-│   ├── home/
-│   │   └── HomeRaceSection.tsx     # トップページ大会セクション（Magazine/Experience トグル）
 │   ├── races/
 │   │   ├── RaceCard.tsx            # Magazine スタイルカード
 │   │   ├── RaceCardExp.tsx         # Experience スタイルカード
-│   │   ├── RaceFilter.tsx          # 絞り込みサイドバー（月・距離・参加賞・都道府県）
+│   │   ├── RaceFilter.tsx          # 絞り込みサイドバー
 │   │   └── RaceList.tsx            # 一覧 + フィルター統合（Client Component）
 │   ├── course/
 │   │   ├── CourseMap.tsx           # Leaflet インタラクティブ地図
 │   │   ├── CourseMapLoader.tsx     # SSR無効ローダー
+│   │   ├── CourseProfileSection.tsx # 地図 + 高低差チャート統合セクション
 │   │   ├── ElevationChart.tsx      # Recharts 高低差チャート
 │   │   └── ElevationChartLoader.tsx
-│   └── __tests__/                  # コンポーネントテスト（Vitest + Testing Library）
-│       ├── RaceCard.test.tsx
-│       ├── RaceFilter.test.tsx
-│       └── RaceList.test.tsx
-├── i18n/
-│   ├── routing.ts                  # ロケールルーティング設定
-│   ├── navigation.ts               # ナビゲーションヘルパー
-│   └── request.ts                  # サーバーサイドリクエスト設定
+│   ├── contact/                    # お問い合わせフォーム
+│   ├── mypage/                     # マイページコンポーネント
+│   └── analytics/                  # Cookie同意バナー
+├── i18n/                           # next-intl 設定
 ├── lib/
 │   ├── types.ts                    # TypeScript 型定義（Race, RaceFilter 等）
 │   ├── data.ts                     # D1 データ取得関数
 │   ├── utils.ts                    # フィルター・フォーマット ユーティリティ
-│   ├── db/
-│   │   ├── schema.ts               # Drizzle ORM スキーマ定義
-│   │   └── client.ts               # D1 クライアント初期化
-│   └── __tests__/                  # ユーティリティ関数ユニットテスト（Vitest）
-│       ├── utils.filter.test.ts
-│       ├── utils.filter-state.test.ts
-│       ├── utils.format.test.ts
-│       ├── utils.status.test.ts
-│       └── fixtures.ts
+│   ├── auth.ts                     # 認証（Better Auth）
+│   └── db/
+│       ├── schema.ts               # Drizzle ORM スキーマ定義
+│       └── client.ts               # D1 クライアント初期化
 ├── messages/
 │   ├── ja.json                     # 日本語翻訳
 │   └── en.json                     # 英語翻訳
 └── data/
-    ├── races/                      # 大会 JSON ファイル（52大会 / 2026シーズン）
+    ├── races/                      # 大会 JSON ファイル（74大会）
     ├── prefectures.json            # 都道府県マスタ
     └── gift-categories.json        # 参加賞カテゴリマスタ
 migrations/
-├── 0000_bored_crusher_hogan.sql    # 初期スキーマ（全テーブル作成）
-├── 0001_nullable_entry_dates.sql   # entry_start/end_date を NULL 許容に変更
-├── 0002_race_series_results.sql    # シリーズ結果テーブル追加
-├── 0003_race_full_name_edition.sql # 正式名称・開催回次カラム追加
-├── 0004_races_series_id.sql        # シリーズID カラム追加
-├── 0005_race_entry_periods.sql     # 複数エントリー期間テーブル追加
+├── 0000〜0005_*.sql                # スキーママイグレーション
 ├── seed.sql                        # 都道府県・参加賞カテゴリ マスタデータ
-└── seed-races-all.sql              # 52大会の全データ
+├── seed-races-all.sql              # 全大会データ（generate-seed-races.js で生成）
+└── seed-series.sql                 # レースシリーズデータ
+public/
+├── gpx/                            # コースGPX / KMLファイル
+├── course-profiles/                # 生成済みコースプロフィールJSON
+└── images/races/                   # 大会アイキャッチ画像
+scripts/
+├── gpx-to-profile.js               # GPX/KML → コースプロフィールJSON 生成
+├── generate-seed-races.js          # races/*.json → seed-races-all.sql 生成
+├── normalize-race-json.js          # JSONフォーマット正規化
+└── cf-prepare.js                   # Cloudflare Pages デプロイ前準備
 tools/
 ├── admin-server.js                 # 管理ツールサーバー（port 4000）
-├── admin-server.test.js            # 管理ツールのユニット・統合テスト（node:test）
+├── admin-server.test.js            # 管理ツールテスト（node:test）
 └── admin/                          # 管理ツールUI（HTML/CSS/JS）
-    ├── index.html
-    ├── app.js
-    └── style.css
-.github/
-└── workflows/
-    └── test.yml                    # CI: push/PR 時にテスト + lint を自動実行
+.github/workflows/test.yml          # CI: push/PR 時にテスト + lint を自動実行
 ```
 
 ## デザインシステム
@@ -132,11 +128,8 @@ Travel Magazine スタイルのインターナショナル向けデザイン。P
 | トークン | 値 | 用途 |
 |---|---|---|
 | `--color-primary` | `#c0392b` | バーミリオンレッド、CTAボタン、アクセント |
-| `--color-primary-dark` | `#9a2d20` | ホバー状態 |
 | `--color-ink` | `#1a1714` | 見出し・濃いテキスト |
-| `--color-ink2` | `#3d3830` | 本文テキスト |
 | `--color-mid` | `#7a7060` | ラベル・補足情報 |
-| `--color-light` | `#b0a898` | プレースホルダー・薄いテキスト |
 | `--color-cream` | `#faf8f4` | 背景・カード |
 | `--color-border` | `#e4dfd8` | ボーダー・区切り線 |
 | `--font-serif` | Playfair Display | 見出し・タイトル |
@@ -153,134 +146,123 @@ Travel Magazine スタイルのインターナショナル向けデザイン。P
 
 ## データベース
 
-Cloudflare D1（SQLite）を使用。全 52 大会（2026 シーズン）のデータを投入済み。
+Cloudflare D1（SQLite）を使用。74大会のデータを投入済み。
 
 | テーブル | 内容 |
 |---|---|
 | `races` | 大会基本情報（名称・日付・都道府県・説明・エントリー情報等） |
-| `race_categories` | カテゴリ別距離・制限時間・スタート時刻・参加費（ウェーブスタート対応） |
-| `race_entry_periods` | 複数エントリー期間（先行・一般等）と期間別参加費 |
-| `aid_stations` | エイドステーション（距離・提供内容・注目エイドフラグ） |
-| `checkpoints` | 関門情報（距離・閉鎖時刻） |
-| `access_points` | 最寄り駅・アクセス方法（緯度経度付き） |
+| `race_categories` | カテゴリ別距離・制限時間・スタート時刻・参加費 |
+| `race_entry_periods` | 複数エントリー期間と期間別参加費 |
+| `aid_stations` | エイドステーション |
+| `checkpoints` | 関門情報 |
+| `access_points` | 最寄り駅・アクセス方法 |
 | `nearby_spots` | 周辺スポット（観光地・温泉・グルメ・宿泊） |
-| `weather_history` | 過去の気象データ（平均・最高・最低気温、湿度、降水量） |
+| `weather_history` | 過去の気象データ |
 | `participation_gifts` | 参加賞情報 |
-| `gift_categories` | 参加賞カテゴリマスタ（メダル・Tシャツ・完走証 等 9種） |
+| `gift_categories` | 参加賞カテゴリマスタ |
 | `prefectures` | 都道府県マスタ（47件） |
 
 ### マイグレーション
 
 ```bash
-# スキーマ変更後にマイグレーションファイルを生成
-npm run db:generate
+npm run db:generate          # スキーマ変更後にマイグレーションファイルを生成
+npm run db:migrate:local     # ローカルDBへ適用
+npm run db:migrate:remote    # リモートDBへ適用
+```
 
-# ローカルDBへ適用
-npm run db:migrate:local
+## コースプロフィール
 
-# リモートDBへ適用
-npm run db:migrate:remote
+GPX / KML ファイルからコースの地図・高低差チャートを生成する。
+
+### 手順
+
+1. GPXまたはKMLファイルを `public/gpx/` に配置（ファイル名はレースIDに合わせる例: `nagano-marathon-2026.gpx`）
+2. 大会JSONの `course_gpx_file` フィールドにファイル名を設定
+3. コースプロフィールJSONを生成:
+
+```bash
+npm run course:generate                      # 未生成のファイルのみ処理
+npm run course:generate nagano-marathon-2026 # 特定レースを強制再処理
+```
+
+生成された `public/course-profiles/{race-id}.json` は大会詳細ページで自動的に読み込まれる。
+
+- GPXファイルに標高データがない場合は国土地理院標高APIから自動取得
+- GPX / KML 両形式に対応
+
+## レースデータの更新
+
+```bash
+# races/*.json を編集後
+node scripts/generate-seed-races.js  # seed-races-all.sql を再生成
+npm run db:seed-races:local          # ローカルDBに反映
+npm run db:seed-races:remote         # リモートDBに反映
 ```
 
 ## 管理ツール
 
-`tools/admin-server.js` はスタンドアロンの管理ツールサーバーです。Next.js とは独立して動作し、大会JSONファイルの編集・画像管理・データ整備状況の確認ができます。
+`tools/admin-server.js` はスタンドアロンの管理ツールサーバー。Next.js とは独立して動作し、大会JSONファイルの編集・画像管理・データ整備状況の確認ができる。
 
 ```bash
 npm run admin
 # → http://localhost:4000
 ```
 
-### 機能
-
 | タブ | 機能 |
 |---|---|
-| 大会一覧 | JSONファイルの編集・保存・削除。未整備フィールドのバッジ表示（高優先:オレンジ / 中優先:グレー） |
-| 更新チェック | Bedrock（Claude）で公式サイトから情報を自動抽出し、登録済みデータとの差分を確認・適用 |
-| データチェック | 全大会のフィールド整備状況をテーブルで一覧表示。✗ をクリックで編集画面に直接遷移 |
-
-### 未整備フィールドの判定基準
-
-| 優先度 | フィールド | 判定条件 |
-|---|---|---|
-| 高 | エントリー期間 | `entry_periods` が空 かつ `entry_start_date` が null |
-| 高 | 参加費 | カテゴリ別・統一どちらも未設定 |
-| 高 | 公式URL | null または空文字 |
-| 中 | 定員 | 0 または null |
-| 中 | 制限時間 | いずれかのカテゴリが 0 または null |
-| 中 | 説明文 | `description_ja` が空文字 |
-
-### 管理ツールのテスト
+| 大会一覧 | JSONファイルの編集・保存・削除。未整備フィールドのバッジ表示 |
+| 更新チェック | Claude で公式サイトから情報を自動抽出し、登録済みデータとの差分を確認・適用 |
+| データチェック | 全大会のフィールド整備状況をテーブルで一覧表示 |
 
 ```bash
-npm run test:admin
+npm run test:admin  # 管理ツールのテストを実行
 ```
-
-`node:test`（Node.js 組み込み）による `getMissingFields()` ユニットテスト + HTTP統合テスト（計28件）。
 
 ## テスト
 
-### アプリケーションテスト（Vitest）
-
 ```bash
-npm test           # 全テストを実行
-npm run test:watch # ウォッチモード
-npm run test:coverage
+npm test               # 全テストを実行
+npm run test:watch     # ウォッチモード
+npm run test:coverage  # カバレッジ付き
 ```
 
-| テストファイル | 対象 | テスト数 |
-|---|---|---|
-| `utils.filter.test.ts` | `filterRaces()` / `sortRacesByDate()` | 19 |
-| `utils.filter-state.test.ts` | `defaultFilter` / `isDefaultFilter` / `isFilterEmpty` / `getMainCategory` | 14 |
-| `utils.format.test.ts` | 日付・距離・参加費フォーマット関数 | 複数 |
-| `utils.status.test.ts` | `getRaceStatus()` | 15 |
-| `RaceCard.test.tsx` | RaceCard コンポーネント | 複数 |
-| `RaceFilter.test.tsx` | RaceFilter コンポーネント | 複数 |
-| `RaceList.test.tsx` | RaceList コンポーネント | 複数 |
+CI（GitHub Actions）では `main` へのpush・PRで自動的にテスト + lint を実行（`.github/workflows/test.yml`）。
 
-### CI（GitHub Actions）
-
-`main` へのpush・PRで自動的にテスト + lint を実行（`.github/workflows/test.yml`）。
-
-## 主要機能（実装済み）
+## 主要機能
 
 | 機能 | 詳細 |
 |---|---|
-| 大会一覧 | 52大会を一覧表示。Magazine / Experience の2スタイルで閲覧可能 |
+| 大会一覧 | 74大会を一覧表示。Magazine / Experience の2スタイルで閲覧可能 |
 | 絞り込みフィルター | 開催月・距離カテゴリ・参加賞（OR複数選択）・都道府県・テキスト検索 |
-| 大会詳細 | コース情報・関門・エイドステーション・エントリー・アクセス・参加賞・周辺スポット・気象データを表示 |
-| 複数エントリー期間 | 先行・一般・追加募集など複数の申込期間と期間別参加費を表示 |
-| エントリー未発表表示 | エントリー情報が未発表の場合に「エントリー未発表」を明示表示 |
+| 大会詳細 | コース・関門・エイドステーション・エントリー・受付情報・アクセス・参加賞・周辺スポット・気象データ |
+| コースプロフィール | Leaflet インタラクティブ地図 + Recharts 高低差チャート（GPX/KML対応） |
+| 複数エントリー期間 | 先行・一般・追加募集など複数の申込期間と期間別参加費 |
+| 多言語対応 | 日本語 / 英語（Header の JA/EN ボタンで切替） |
 | 大会カレンダー | 月別の開催カレンダー |
-| 多言語対応 | 日本語 / 英語（Header の JA/EN ピルボタンで切替） |
+| マイページ | 参加予定・完走済み大会の管理 |
+| お問い合わせ | Resend 経由のメール送信フォーム |
 | レスポンシブ対応 | モバイル〜デスクトップ対応 |
 
 ## 今後の実装予定
 
 | 機能 | 概要 |
 |---|---|
-| コースプロフィール | GPX → 標高API → 静的JSON 生成パイプライン、Leaflet地図 + Recharts高低差チャート表示 |
-| 当日到着可否判定 | 乗換案内API（NAVITIME等）を用いた最寄り駅→会場の到達可否 |
-| ユーザー設定（localStorage） | 最寄り駅保存・お気に入り大会登録 |
+| 当日到着可否判定 | 乗換案内APIを用いた最寄り駅→会場の到達可否 |
 | SEO / OGP 強化 | Event Schema（構造化データ）・各ページOGP |
-| /about ページ | サイト概要・データ掲載方針 |
+| コースプロフィール拡充 | より多くの大会にGPX/KMLを整備 |
 
 ## デプロイ
 
 ```bash
-# 1. OpenNext Cloudflare ビルド
-npm run cf:build
-
-# 2. Cloudflare Pages へデプロイ
-npm run cf:deploy
+npm run cf:deploy  # ビルド + Cloudflare Pages へデプロイ
 ```
 
 ### 初回デプロイ時
 
 ```bash
-# リモートDBへマイグレーション + シードデータを適用
-npm run db:migrate:remote
-npm run db:seed:remote
+npm run db:migrate:remote    # リモートDBへマイグレーション適用
+npm run db:seed:remote       # マスタデータのシード
+npm run db:seed-races:remote # 大会データのシード
 ```
 
 ## ライセンス

--- a/scripts/gpx-to-profile.js
+++ b/scripts/gpx-to-profile.js
@@ -191,7 +191,7 @@ async function main() {
 
   let gpxFiles;
   if (targetId) {
-    // .gpx → .kml の順で探す
+    // race ID 指定時は強制再処理（.gpx → .kml の順で探す）
     const candidates = ['.gpx', '.kml'].map((ext) => path.join(GPX_DIR, `${targetId}${ext}`));
     const target = candidates.find((f) => fs.existsSync(f));
     if (!target) {
@@ -200,14 +200,25 @@ async function main() {
     }
     gpxFiles = [target];
   } else {
+    // 引数なし: 出力JSONが未生成のファイルのみ処理
     gpxFiles = fs
       .readdirSync(GPX_DIR)
       .filter((f) => f.endsWith('.gpx') || f.endsWith('.kml'))
+      .filter((f) => {
+        const ext = path.extname(f);
+        const id = path.basename(f, ext);
+        const outputPath = path.join(OUTPUT_DIR, `${id}.json`);
+        if (fs.existsSync(outputPath)) {
+          console.log(`スキップ: ${id} (出力済み)`);
+          return false;
+        }
+        return true;
+      })
       .map((f) => path.join(GPX_DIR, f));
   }
 
   if (gpxFiles.length === 0) {
-    console.log('GPX / KML ファイルが見つかりません。');
+    console.log(targetId ? 'GPX / KML ファイルが見つかりません。' : '処理対象の新規ファイルはありません。');
     return;
   }
 


### PR DESCRIPTION
## Summary

- ディレクトリ構成を現状のページ・コンポーネント構成に更新（admin, contact, mypage, analytics等を追加）
- コースプロフィール生成手順（GPX/KML → JSON）を独立セクションとして追加
- レースデータ更新フロー（JSON編集 → seed再生成 → DB反映）を追加
- 主要機能にコースプロフィール・受付情報・マイページ・お問い合わせを追加
- 「今後の実装予定」から実装済み項目（コースプロフィール等）を削除
- デプロイ手順を `npm run cf:deploy` 一発に簡略化、`db:seed-races:remote` を追加
- 大会数を 52 → 74 件に更新

## Test plan

- [ ] README の内容がリポジトリの現状と一致していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)