### PR TITLE
feat: サイトマップを追加（Issue #23）

### DIFF
--- a/docs/update-history.md
+++ b/docs/update-history.md
@@ -424,3 +424,10 @@
 - `src/components/layout/Footer.tsx`: フッターのInfoセクションにお問い合わせリンクを追加
 - `docs/schema.md`: contact_submissions テーブルの定義・マイグレーション履歴を追記
 - `package.json`: `resend` パッケージを追加（メール通知用）
+
+## 2026-05-01 サイトマップ追加（Issue #23）
+
+- `src/app/sitemap.ts`: `/sitemap.xml` を自動生成（Next.js MetadataRoute API）。静的9ページ × ja/en + 全大会 × ja/en を出力。`force-dynamic` でD1取得に対応
+- `src/app/[locale]/sitemap/page.tsx`: HTMLサイトマップページ新規作成（メインページ・サービス情報・全大会の3セクション）
+- `src/components/layout/Footer.tsx`: サービス情報セクションにサイトマップリンクを追加
+- `src/messages/ja.json` / `en.json`: `sitemap` 翻訳キー、フッター `sitemap` キーを追加

--- a/src/app/[locale]/sitemap/page.tsx
+++ b/src/app/[locale]/sitemap/page.tsx
@@ -1,0 +1,146 @@
+import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+import { Link } from '@/i18n/navigation';
+import { getRaces } from '@/lib/data';
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const isJa = locale !== 'en';
+  return {
+    title: isJa ? 'サイトマップ' : 'Sitemap',
+    description: isJa
+      ? 'HASHIRUの全ページ一覧です。'
+      : 'A complete list of all pages on HASHIRU.',
+    alternates: {
+      canonical: `https://hashiru.run/${locale}/sitemap`,
+      languages: {
+        ja: 'https://hashiru.run/ja/sitemap',
+        en: 'https://hashiru.run/en/sitemap',
+      },
+    },
+  };
+}
+
+export default async function SitemapPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale: rawLocale } = await params;
+  const locale = rawLocale as 'ja' | 'en';
+  const isJa = locale !== 'en';
+  const t = await getTranslations({ locale, namespace: 'sitemap' });
+
+  const races = await getRaces();
+
+  const mainPages = [
+    { href: '/',         label: isJa ? 'ホーム' : 'Home' },
+    { href: '/races',    label: isJa ? '大会一覧' : 'Race List' },
+    { href: '/calendar', label: isJa ? '大会カレンダー' : 'Calendar' },
+  ];
+
+  const infoPages = [
+    { href: '/guide',         label: isJa ? '初めての方へ' : 'Getting Started' },
+    { href: '/about',         label: isJa ? 'HASHIRUについて' : 'About HASHIRU' },
+    { href: '/contact',       label: isJa ? 'お問い合わせ' : 'Contact' },
+    { href: '/terms',         label: isJa ? '利用規約' : 'Terms of Service' },
+    { href: '/privacy',       label: isJa ? 'プライバシーポリシー' : 'Privacy Policy' },
+    { href: '/cookie-policy', label: isJa ? 'Cookieポリシー' : 'Cookie Policy' },
+  ];
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 sm:px-6 py-12 md:py-16">
+      <div className="mb-10">
+        <p
+          className="text-xs font-semibold tracking-[0.2em] uppercase mb-3"
+          style={{ color: 'var(--color-primary)' }}
+        >
+          Navigation
+        </p>
+        <h1
+          className="font-serif text-4xl font-bold mb-2"
+          style={{ color: 'var(--color-ink)' }}
+        >
+          {t('title')}
+        </h1>
+      </div>
+
+      <div className="space-y-10">
+        {/* メインページ */}
+        <section>
+          <h2
+            className="text-xs font-semibold tracking-[0.18em] uppercase mb-4"
+            style={{ color: 'var(--color-mid)' }}
+          >
+            {t('sectionMain')}
+          </h2>
+          <ul className="space-y-2 border-l-2 pl-4" style={{ borderColor: 'var(--color-border)' }}>
+            {mainPages.map(({ href, label }) => (
+              <li key={href}>
+                <Link
+                  href={href}
+                  className="text-sm hover:underline"
+                  style={{ color: 'var(--color-ink2)' }}
+                >
+                  {label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        {/* サービス情報 */}
+        <section>
+          <h2
+            className="text-xs font-semibold tracking-[0.18em] uppercase mb-4"
+            style={{ color: 'var(--color-mid)' }}
+          >
+            {t('sectionInfo')}
+          </h2>
+          <ul className="space-y-2 border-l-2 pl-4" style={{ borderColor: 'var(--color-border)' }}>
+            {infoPages.map(({ href, label }) => (
+              <li key={href}>
+                <Link
+                  href={href}
+                  className="text-sm hover:underline"
+                  style={{ color: 'var(--color-ink2)' }}
+                >
+                  {label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        {/* 大会一覧 */}
+        <section>
+          <h2
+            className="text-xs font-semibold tracking-[0.18em] uppercase mb-4"
+            style={{ color: 'var(--color-mid)' }}
+          >
+            {t('sectionRaces')} ({races.length})
+          </h2>
+          <ul className="space-y-2 border-l-2 pl-4 columns-1 sm:columns-2" style={{ borderColor: 'var(--color-border)' }}>
+            {races.map((race) => (
+              <li key={race.id} className="break-inside-avoid">
+                <Link
+                  href={`/races/${race.id}`}
+                  className="text-sm hover:underline"
+                  style={{ color: 'var(--color-ink2)' }}
+                >
+                  {isJa ? race.name_ja : race.name_en}
+                  <span className="ml-1.5 text-xs" style={{ color: 'var(--color-mid)' }}>
+                    {race.date}
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,48 @@
+import type { MetadataRoute } from 'next';
+import { getRaces } from '@/lib/data';
+
+export const dynamic = 'force-dynamic';
+
+const BASE_URL = 'https://hashiru.run';
+const LOCALES = ['ja', 'en'] as const;
+
+const STATIC_PAGES = [
+  { path: '',          priority: 1.0, changeFrequency: 'weekly'  as const },
+  { path: '/races',    priority: 0.9, changeFrequency: 'daily'   as const },
+  { path: '/calendar', priority: 0.8, changeFrequency: 'weekly'  as const },
+  { path: '/guide',    priority: 0.7, changeFrequency: 'monthly' as const },
+  { path: '/about',    priority: 0.6, changeFrequency: 'monthly' as const },
+  { path: '/terms',    priority: 0.5, changeFrequency: 'yearly'  as const },
+  { path: '/privacy',  priority: 0.5, changeFrequency: 'yearly'  as const },
+  { path: '/contact',  priority: 0.6, changeFrequency: 'monthly' as const },
+  { path: '/sitemap',  priority: 0.4, changeFrequency: 'weekly'  as const },
+];
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const races = await getRaces();
+
+  const staticEntries: MetadataRoute.Sitemap = STATIC_PAGES.flatMap(({ path, priority, changeFrequency }) =>
+    LOCALES.map(locale => ({
+      url: `${BASE_URL}/${locale}${path}`,
+      priority,
+      changeFrequency,
+      alternates: {
+        languages: Object.fromEntries(LOCALES.map(l => [l, `${BASE_URL}/${l}${path}`])),
+      },
+    }))
+  );
+
+  const raceEntries: MetadataRoute.Sitemap = races.flatMap(race =>
+    LOCALES.map(locale => ({
+      url: `${BASE_URL}/${locale}/races/${race.id}`,
+      lastModified: race.date ? new Date(race.date) : undefined,
+      changeFrequency: 'monthly' as const,
+      priority: 0.7,
+      alternates: {
+        languages: Object.fromEntries(LOCALES.map(l => [l, `${BASE_URL}/${l}/races/${race.id}`])),
+      },
+    }))
+  );
+
+  return [...staticEntries, ...raceEntries];
+}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -44,6 +44,7 @@ export default function Footer() {
                 <li><Link href="/terms" className="text-[0.8rem] text-[#aaa] hover:text-white no-underline transition-colors">{t('terms')}</Link></li>
                 <li><Link href="/settings" className="text-[0.8rem] text-[#aaa] hover:text-white no-underline transition-colors">{tNav('settings')}</Link></li>
                 <li><Link href="/contact" className="text-[0.8rem] text-[#aaa] hover:text-white no-underline transition-colors">{tNav('contact')}</Link></li>
+                <li><Link href="/sitemap" className="text-[0.8rem] text-[#aaa] hover:text-white no-underline transition-colors">{t('sitemap')}</Link></li>
               </ul>
             </div>
           </div>

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -79,7 +79,8 @@
       "guide": "Getting Started",
       "about": "About HASHIRU",
       "privacy": "Privacy Policy",
-      "terms": "Terms of Service"
+      "terms": "Terms of Service",
+      "sitemap": "Sitemap"
     },
     "card": {
       "distance": "Distance",
@@ -279,5 +280,11 @@
     "themeSystem": "Follow system",
     "save": "Save",
     "saved": "Saved!"
+  },
+  "sitemap": {
+    "title": "Sitemap",
+    "sectionMain": "Main Pages",
+    "sectionInfo": "Site Information",
+    "sectionRaces": "Races"
   }
 }

--- a/src/messages/ja.json
+++ b/src/messages/ja.json
@@ -79,7 +79,8 @@
       "guide": "初めての方へ",
       "about": "HASHIRUについて",
       "privacy": "プライバシーポリシー",
-      "terms": "利用規約"
+      "terms": "利用規約",
+      "sitemap": "サイトマップ"
     },
     "card": {
       "distance": "距離",
@@ -279,5 +280,11 @@
     "themeSystem": "システム設定に従う",
     "save": "保存する",
     "saved": "保存しました"
+  },
+  "sitemap": {
+    "title": "サイトマップ",
+    "sectionMain": "メインページ",
+    "sectionInfo": "サービス情報",
+    "sectionRaces": "大会一覧"
   }
 }


### PR DESCRIPTION
## Summary

Issue #23 の実装。

- **`/sitemap.xml`** — Next.js MetadataRoute APIで自動生成。静的ページ（9種）を ja/en 両ロケール分、全大会をD1から取得して動的エントリーとして含む
- **`/ja/sitemap` / `/en/sitemap`** — ユーザー向けHTMLサイトマップページ。メインページ・サービス情報・全大会の3セクション構成
- **フッター** — サービス情報セクションに「サイトマップ」リンクを追加

## 技術メモ

- `sitemap.ts` は D1（`getCloudflareContext`）を使用するため `export const dynamic = 'force-dynamic'` を設定。静的プリレンダリング時のエラーを回避
- `alternates.languages` で hreflang を自動出力（ja/en クロスリンク）

## Test plan

- [x] `npm run build` が成功すること（確認済み）
- [x] `/sitemap.xml` にアクセスして全ページのURLが含まれること
- [x] `/ja/sitemap`・`/en/sitemap` でHTMLサイトマップが表示されること
- [x] フッターの「サイトマップ」リンクが正しく動作すること

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)