### PR TITLE
feat: 詳細ページPhase3 ギャラリー・参加者の声（Issue #43）

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -321,6 +321,66 @@ ER図は `docs/er-diagram.drawio` で管理しています。[draw.io](https://a
 
 ---
 
+## race_gallery テーブル
+
+大会の見どころ画像ギャラリー。
+
+| カラム | 型 | NULL | デフォルト | 備考 |
+|---|---|---|---|---|
+| id | integer | NO | autoincrement | PK |
+| race_id | text | NO | — | FK → races.id（CASCADE） |
+| src | text | NO | — | 画像パス or URL |
+| caption_ja | text | YES | — | |
+| caption_en | text | YES | — | |
+| sort_order | integer | NO | `0` | |
+
+---
+
+## race_voices テーブル
+
+参加者の声（前回の様子セクション）。
+
+| カラム | 型 | NULL | デフォルト | 備考 |
+|---|---|---|---|---|
+| id | integer | NO | autoincrement | PK |
+| race_id | text | NO | — | FK → races.id（CASCADE） |
+| quote_ja | text | NO | — | 引用テキスト（日本語） |
+| author | text | YES | — | 発言者名（例: `"40代男性"`） |
+| sort_order | integer | NO | `0` | |
+
+---
+
+## race_time_buckets テーブル
+
+フィニッシャーのタイム分布（棒グラフ表示用）。
+
+| カラム | 型 | NULL | デフォルト | 備考 |
+|---|---|---|---|---|
+| id | integer | NO | autoincrement | PK |
+| race_id | text | NO | — | FK → races.id（CASCADE） |
+| bucket | text | NO | — | タイム帯ラベル（例: `"3:30–4:00"`） |
+| pct | real | NO | — | 割合 (0–100) |
+| sort_order | integer | NO | `0` | |
+
+---
+
+## race_course_highlights テーブル
+
+コース上の見どころポイント。
+
+| カラム | 型 | NULL | デフォルト | 備考 |
+|---|---|---|---|---|
+| id | integer | NO | autoincrement | PK |
+| race_id | text | NO | — | FK → races.id（CASCADE） |
+| km | real | NO | — | 地点（km） |
+| name_ja | text | NO | — | スポット名（日本語） |
+| name_en | text | YES | — | スポット名（英語） |
+| note_ja | text | YES | — | 説明（日本語） |
+| note_en | text | YES | — | 説明（英語） |
+| sort_order | integer | NO | `0` | |
+
+---
+
 ## マイグレーション履歴
 
 | ファイル | 内容 |
@@ -336,3 +396,4 @@ ER図は `docs/er-diagram.drawio` で管理しています。[draw.io](https://a
 | `migrations/0006_entry_info.sql` | races に entry_closed、race_categories に eligibility_ja/en、race_entry_links テーブルを追加（Issue #37） |
 | `migrations/0007_category_gpx.sql` | race_categories に course_gpx_file カラムを追加 |
 | `migrations/0008_phase2_motif_hero.sql` | races に motif/motif_color/motif_romaji/tagline_ja/tagline_en/hero_image_url/hero_caption_ja/hero_caption_en を追加、race_results に avg_time を追加（Issue #42 Design Phase 2） |
+| `migrations/0009_phase3_gallery_voices.sql` | race_gallery / race_voices / race_time_buckets / race_course_highlights テーブルを追加（Issue #43 Design Phase 3） |

--- a/docs/update-history.md
+++ b/docs/update-history.md
@@ -484,3 +484,20 @@
 - `tools/admin/index.html`: ビジュアルセクション（motif/tagline/hero_image 入力フォーム）を追加
 - `tools/admin/app.js`: `populateForm()` / `buildJson()` に Phase 2 フィールドの読み書きを追加
 - `docs/schema.md`: Phase 2 カラム定義とマイグレーション履歴を更新
+
+## 2026-05-04 詳細ページPhase3 ギャラリー・参加者の声対応（Issue #43）
+
+- `src/lib/db/schema.ts`: `race_gallery` / `race_voices` / `race_time_buckets` / `race_course_highlights` テーブルを追加、リレーション定義
+- `migrations/0009_phase3_gallery_voices.sql`: Phase 3 テーブル追加用マイグレーションを手動作成
+- `src/lib/types.ts`: `RaceGallery` / `RaceVoice` / `RaceTimeBucket` / `RaceCourseHighlight` インターフェースを追加、`Race` に配列フィールドを追加
+- `src/lib/data.ts`: `getRaceById()` に4テーブルのクエリ・マッピングを追加、`assembleRace()` に引数追加
+- `src/lib/__tests__/fixtures.ts`: `makeRace()` に4配列フィールドを追加、`makeGallery()` / `makeVoice()` / `makeTimeBucket()` / `makeCourseHighlight()` ファクトリを追加
+- `scripts/generate-seed-races.js`: 4テーブルの DELETE/INSERT 処理を追加
+- `tools/admin/index.html` / `tools/admin/app.js`: ギャラリー・参加者の声・タイム分布・コース見どころセクションを追加
+- `src/components/races/detail/DetailHeader.tsx`: ヒーロービジュアル（motif カラー背景・ヒーロー画像・タグライン）コンポーネント（TDD）
+- `src/components/races/detail/AnchorBar.tsx`: sticky セクションナビバーコンポーネント（TDD）
+- `src/components/races/detail/OverviewSection.tsx`: 概要・タグ表示コンポーネント（TDD）
+- `src/components/races/detail/EntrySection.tsx`: エントリー情報コンポーネント（TDD）
+- `src/components/races/detail/LastEditionSection.tsx`: 前回大会実績コンポーネント（TDD）
+- `src/components/races/detail/GallerySection.tsx`: ギャラリー・参加者の声コンポーネント（TDD）
+- `src/app/[locale]/races/[id]/page.tsx`: 新コンポーネントで詳細ページを再構成

--- a/migrations/0009_phase3_gallery_voices.sql
+++ b/migrations/0009_phase3_gallery_voices.sql
@@ -1,0 +1,41 @@
+-- Phase 3: race_gallery / race_voices / race_time_buckets / race_course_highlights テーブルを追加
+
+CREATE TABLE IF NOT EXISTS race_gallery (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  race_id    TEXT NOT NULL REFERENCES races(id) ON DELETE CASCADE,
+  src        TEXT NOT NULL,
+  caption_ja TEXT,
+  caption_en TEXT,
+  sort_order INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS race_gallery_race_id_idx ON race_gallery(race_id);
+
+CREATE TABLE IF NOT EXISTS race_voices (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  race_id    TEXT NOT NULL REFERENCES races(id) ON DELETE CASCADE,
+  quote_ja   TEXT NOT NULL,
+  author     TEXT,
+  sort_order INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS race_voices_race_id_idx ON race_voices(race_id);
+
+CREATE TABLE IF NOT EXISTS race_time_buckets (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  race_id    TEXT NOT NULL REFERENCES races(id) ON DELETE CASCADE,
+  bucket     TEXT NOT NULL,
+  pct        REAL NOT NULL,
+  sort_order INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS race_time_buckets_race_id_idx ON race_time_buckets(race_id);
+
+CREATE TABLE IF NOT EXISTS race_course_highlights (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  race_id    TEXT NOT NULL REFERENCES races(id) ON DELETE CASCADE,
+  km         REAL NOT NULL,
+  name_ja    TEXT NOT NULL,
+  name_en    TEXT,
+  note_ja    TEXT,
+  note_en    TEXT,
+  sort_order INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS race_course_highlights_race_id_idx ON race_course_highlights(race_id);

--- a/migrations/seed-races-all.sql
+++ b/migrations/seed-races-all.sql
@@ -1,5 +1,5 @@
 -- 自動生成: generate-seed-races.js
--- 生成日時: 2026-05-04T01:09:24.481Z
+-- 生成日時: 2026-05-04T12:41:53.063Z
 -- 対象ファイル数: 75 件（既存 2 件はskip）
 
 -- ==================
@@ -72,6 +72,10 @@ DELETE FROM participation_gifts WHERE race_id = 'abashiri-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'abashiri-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'abashiri-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'abashiri-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'abashiri-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'abashiri-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'abashiri-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'abashiri-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('abashiri-marathon-2026', 'full', 42.195, 390, '08:45', 2600, 12000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
@@ -149,6 +153,10 @@ DELETE FROM participation_gifts WHERE race_id = 'akita-nairiku-ultra-2026';
 DELETE FROM race_entry_links WHERE race_id = 'akita-nairiku-ultra-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'akita-nairiku-ultra-2026';
 DELETE FROM race_results WHERE race_id = 'akita-nairiku-ultra-2026';
+DELETE FROM race_gallery WHERE race_id = 'akita-nairiku-ultra-2026';
+DELETE FROM race_voices WHERE race_id = 'akita-nairiku-ultra-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'akita-nairiku-ultra-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'akita-nairiku-ultra-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('akita-nairiku-ultra-2026', 'ultra', 100, 780, '05:00', 650, 22000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -228,6 +236,10 @@ DELETE FROM participation_gifts WHERE race_id = 'aomori-sakura-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'aomori-sakura-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'aomori-sakura-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'aomori-sakura-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'aomori-sakura-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'aomori-sakura-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'aomori-sakura-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'aomori-sakura-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('aomori-sakura-marathon-2026', 'full', 42.195, 330, '08:50', 2400, 7000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -311,6 +323,10 @@ DELETE FROM participation_gifts WHERE race_id = 'asahikawa-half-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'asahikawa-half-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'asahikawa-half-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'asahikawa-half-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'asahikawa-half-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'asahikawa-half-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'asahikawa-half-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'asahikawa-half-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('asahikawa-half-marathon-2026', 'half', 21.0975, 180, '08:30', 2500, 6500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -388,6 +404,10 @@ DELETE FROM participation_gifts WHERE race_id = 'beppu-oita-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'beppu-oita-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'beppu-oita-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'beppu-oita-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'beppu-oita-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'beppu-oita-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'beppu-oita-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'beppu-oita-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('beppu-oita-marathon-2026', 'full', 42.195, 0, '12:00', 4000, 15000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -469,6 +489,10 @@ DELETE FROM participation_gifts WHERE race_id = 'biwako-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'biwako-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'biwako-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'biwako-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'biwako-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'biwako-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'biwako-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'biwako-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('biwako-marathon-2026', 'full', 42.195, 360, '08:20', 7000, 15000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -548,6 +572,10 @@ DELETE FROM participation_gifts WHERE race_id = 'chiba-aqualine-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'chiba-aqualine-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'chiba-aqualine-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'chiba-aqualine-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'chiba-aqualine-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'chiba-aqualine-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'chiba-aqualine-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'chiba-aqualine-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('chiba-aqualine-marathon-2026', 'full', 42.195, 375, '09:45', 12000, 16500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -629,6 +657,10 @@ DELETE FROM participation_gifts WHERE race_id = 'ehime-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'ehime-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'ehime-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'ehime-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'ehime-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'ehime-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'ehime-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'ehime-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('ehime-marathon-2026', 'full', 42.195, 360, '10:00', 10000, 12900, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -716,6 +748,10 @@ DELETE FROM participation_gifts WHERE race_id = 'fuji-mountain-race-2026';
 DELETE FROM race_entry_links WHERE race_id = 'fuji-mountain-race-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'fuji-mountain-race-2026';
 DELETE FROM race_results WHERE race_id = 'fuji-mountain-race-2026';
+DELETE FROM race_gallery WHERE race_id = 'fuji-mountain-race-2026';
+DELETE FROM race_voices WHERE race_id = 'fuji-mountain-race-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'fuji-mountain-race-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'fuji-mountain-race-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('fuji-mountain-race-2026', 'other', 21, 260, '07:00', 1770, 18000, NULL, '山頂コース', NULL, NULL, NULL, '第76回大会、第77回大会、第78回大会のいずれかにおいて五合目関門（五合目ゴール）通過時間が2時間20分以内の実績のある者。又は、第2回富士山クライムランにおいて五合目ゴール時間が2時間以内の実績がある者とする。 過去(第76回、第77回、第78回)の大会の記録についてはこちらからご確認ください。 第2回富士山クライムランの記録についてはこちらからご確認ください。', 'Participants must have completed the 5th Station checkpoint (5th Station finish) in 2 hours and 20 minutes or less in either the 76th, 77th, or 78th edition of the race. Alternatively, participants must have completed the 5th Station finish in 2 hours or less in the 2nd Mount Fuji Climb Run. Please click here to view records from past editions (76th, 77th, and 78th). Please click here to view records from the 2nd Mt. Fuji Climb Run.  Translated with DeepL.com (free version)', 'fuji-mountain-race-2026.gpx', '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -795,6 +831,10 @@ DELETE FROM participation_gifts WHERE race_id = 'fujisan-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'fujisan-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'fujisan-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'fujisan-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'fujisan-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'fujisan-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'fujisan-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'fujisan-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('fujisan-marathon-2026', 'full', 42.195, 360, '09:00', 0, 12900, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -872,6 +912,10 @@ DELETE FROM participation_gifts WHERE race_id = 'fukuchiyama-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'fukuchiyama-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'fukuchiyama-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'fukuchiyama-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'fukuchiyama-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'fukuchiyama-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'fukuchiyama-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'fukuchiyama-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('fukuchiyama-marathon-2026', 'full', 42.195, 360, '', 5400, 11000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -959,6 +1003,10 @@ DELETE FROM participation_gifts WHERE race_id = 'fukui-sakura-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'fukui-sakura-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'fukui-sakura-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'fukui-sakura-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'fukui-sakura-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'fukui-sakura-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'fukui-sakura-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'fukui-sakura-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('fukui-sakura-marathon-2026', 'full', 42.195, 420, '08:30', 13200, 14000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -1044,6 +1092,10 @@ DELETE FROM participation_gifts WHERE race_id = 'fukuoka-international-marathon-
 DELETE FROM race_entry_links WHERE race_id = 'fukuoka-international-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'fukuoka-international-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'fukuoka-international-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'fukuoka-international-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'fukuoka-international-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'fukuoka-international-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'fukuoka-international-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('fukuoka-international-marathon-2026', 'full', 42.195, 155, '12:10', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -1121,6 +1173,10 @@ DELETE FROM participation_gifts WHERE race_id = 'fukuoka-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'fukuoka-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'fukuoka-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'fukuoka-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'fukuoka-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'fukuoka-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'fukuoka-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'fukuoka-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('fukuoka-marathon-2026', 'full', 42.195, 420, '08:20', 13000, 16000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -1214,6 +1270,10 @@ DELETE FROM participation_gifts WHERE race_id = 'gunma-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'gunma-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'gunma-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'gunma-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'gunma-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'gunma-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'gunma-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'gunma-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('gunma-marathon-2026', 'full', 42.195, 360, '08:55', 5500, 13500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -1299,6 +1359,10 @@ DELETE FROM participation_gifts WHERE race_id = 'higashine-sakuranbo-marathon-20
 DELETE FROM race_entry_links WHERE race_id = 'higashine-sakuranbo-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'higashine-sakuranbo-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'higashine-sakuranbo-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'higashine-sakuranbo-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'higashine-sakuranbo-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'higashine-sakuranbo-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'higashine-sakuranbo-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('higashine-sakuranbo-marathon-2026', 'half', 21.0975, 170, '08:40', 5500, 6000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -1380,6 +1444,10 @@ DELETE FROM participation_gifts WHERE race_id = 'higashinipon-half-marathon-2026
 DELETE FROM race_entry_links WHERE race_id = 'higashinipon-half-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'higashinipon-half-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'higashinipon-half-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'higashinipon-half-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'higashinipon-half-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'higashinipon-half-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'higashinipon-half-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('higashinipon-half-marathon-2026', 'half', 21.0975, 180, '09:00', 4000, 5500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -1457,6 +1525,10 @@ DELETE FROM participation_gifts WHERE race_id = 'himeji-castle-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'himeji-castle-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'himeji-castle-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'himeji-castle-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'himeji-castle-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'himeji-castle-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'himeji-castle-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'himeji-castle-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('himeji-castle-marathon-2026', 'full', 42.195, 360, '', 9000, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -1540,6 +1612,10 @@ DELETE FROM participation_gifts WHERE race_id = 'hitachi-seaside-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'hitachi-seaside-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'hitachi-seaside-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'hitachi-seaside-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'hitachi-seaside-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'hitachi-seaside-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'hitachi-seaside-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'hitachi-seaside-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('hitachi-seaside-marathon-2026', 'full', 42.195, 360, '10:00', 6000, 10000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
@@ -1621,6 +1697,10 @@ DELETE FROM participation_gifts WHERE race_id = 'hofu-yomiuri-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'hofu-yomiuri-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'hofu-yomiuri-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'hofu-yomiuri-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'hofu-yomiuri-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'hofu-yomiuri-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'hofu-yomiuri-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'hofu-yomiuri-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('hofu-yomiuri-marathon-2026', 'full', 42.195, 240, '12:03', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -1698,6 +1778,10 @@ DELETE FROM participation_gifts WHERE race_id = 'hokkaido-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'hokkaido-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'hokkaido-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'hokkaido-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'hokkaido-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'hokkaido-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'hokkaido-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'hokkaido-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('hokkaido-marathon-2026', 'full', 42.195, 360, '08:30', 20000, 16500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -1781,6 +1865,10 @@ DELETE FROM participation_gifts WHERE race_id = 'ibusuki-nanohana-2026';
 DELETE FROM race_entry_links WHERE race_id = 'ibusuki-nanohana-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'ibusuki-nanohana-2026';
 DELETE FROM race_results WHERE race_id = 'ibusuki-nanohana-2026';
+DELETE FROM race_gallery WHERE race_id = 'ibusuki-nanohana-2026';
+DELETE FROM race_voices WHERE race_id = 'ibusuki-nanohana-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'ibusuki-nanohana-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'ibusuki-nanohana-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('ibusuki-nanohana-2026', 'full', 42.195, 480, '09:00', 10000, 10000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO aid_stations (race_id, distance_km, offerings_ja, offerings_en, is_featured) VALUES
@@ -1870,6 +1958,10 @@ DELETE FROM participation_gifts WHERE race_id = 'ichinoseki-half-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'ichinoseki-half-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'ichinoseki-half-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'ichinoseki-half-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'ichinoseki-half-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'ichinoseki-half-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'ichinoseki-half-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'ichinoseki-half-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('ichinoseki-half-marathon-2026', 'half', 21.0975, 170, '09:00', 2000, 6000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -1947,6 +2039,10 @@ DELETE FROM participation_gifts WHERE race_id = 'iki-ultra-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'iki-ultra-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'iki-ultra-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'iki-ultra-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'iki-ultra-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'iki-ultra-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'iki-ultra-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'iki-ultra-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('iki-ultra-marathon-2026', 'ultra', 100, 840, '05:00', 1000, 20000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -2026,6 +2122,10 @@ DELETE FROM participation_gifts WHERE race_id = 'itabashi-city-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'itabashi-city-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'itabashi-city-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'itabashi-city-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'itabashi-city-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'itabashi-city-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'itabashi-city-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'itabashi-city-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('itabashi-city-marathon-2026', 'full', 42.195, 420, '09:00', 10000, 11550, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -2107,6 +2207,10 @@ DELETE FROM participation_gifts WHERE race_id = 'iwaki-sunshine-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'iwaki-sunshine-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'iwaki-sunshine-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'iwaki-sunshine-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'iwaki-sunshine-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'iwaki-sunshine-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'iwaki-sunshine-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'iwaki-sunshine-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('iwaki-sunshine-marathon-2026', 'full', 42.195, 360, '', 5000, 9000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -2222,6 +2326,10 @@ DELETE FROM participation_gifts WHERE race_id = 'iwate-morioka-city-marathon-202
 DELETE FROM race_entry_links WHERE race_id = 'iwate-morioka-city-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'iwate-morioka-city-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'iwate-morioka-city-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'iwate-morioka-city-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'iwate-morioka-city-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'iwate-morioka-city-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'iwate-morioka-city-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('iwate-morioka-city-marathon-2026', 'full', 42.195, 360, '09:00', 6000, 12000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
@@ -2299,6 +2407,10 @@ DELETE FROM participation_gifts WHERE race_id = 'iwate-oshu-kirameki-marathon-20
 DELETE FROM race_entry_links WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('iwate-oshu-kirameki-marathon-2026', 'full', 42.195, 360, '08:30', 3000, 10000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -2380,6 +2492,10 @@ DELETE FROM participation_gifts WHERE race_id = 'kagawa-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'kagawa-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'kagawa-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'kagawa-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'kagawa-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'kagawa-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'kagawa-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'kagawa-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kagawa-marathon-2026', 'full', 42.195, 360, '10:00', 10000, 14000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -2459,6 +2575,10 @@ DELETE FROM participation_gifts WHERE race_id = 'kagoshima-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'kagoshima-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'kagoshima-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'kagoshima-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'kagoshima-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'kagoshima-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'kagoshima-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'kagoshima-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kagoshima-marathon-2026', 'full', 42.195, 420, '08:30', 10000, 14000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -2540,6 +2660,10 @@ DELETE FROM participation_gifts WHERE race_id = 'kaikyo-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'kaikyo-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'kaikyo-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'kaikyo-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'kaikyo-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'kaikyo-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'kaikyo-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'kaikyo-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kaikyo-marathon-2026', 'full', 42.195, 360, '', 10000, 12000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -2623,6 +2747,10 @@ DELETE FROM participation_gifts WHERE race_id = 'kanazawa-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'kanazawa-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'kanazawa-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'kanazawa-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'kanazawa-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'kanazawa-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'kanazawa-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'kanazawa-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kanazawa-marathon-2026', 'full', 42.195, 420, '08:30', 15000, 14000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -2706,6 +2834,10 @@ DELETE FROM participation_gifts WHERE race_id = 'kasumigaura-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'kasumigaura-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'kasumigaura-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'kasumigaura-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'kasumigaura-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'kasumigaura-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'kasumigaura-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'kasumigaura-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kasumigaura-marathon-2026', 'full', 42.195, 360, '09:45', 14000, 12000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -2789,6 +2921,10 @@ DELETE FROM participation_gifts WHERE race_id = 'katsuta-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'katsuta-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'katsuta-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'katsuta-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'katsuta-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'katsuta-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'katsuta-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'katsuta-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('katsuta-marathon-2026', 'full', 42.195, 360, '10:30', 0, 8000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -2872,6 +3008,10 @@ DELETE FROM participation_gifts WHERE race_id = 'kitakyushu-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'kitakyushu-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'kitakyushu-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'kitakyushu-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'kitakyushu-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'kitakyushu-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'kitakyushu-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'kitakyushu-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kitakyushu-marathon-2026', 'full', 42.195, 360, '09:00', 10800, 14500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -2953,6 +3093,10 @@ DELETE FROM participation_gifts WHERE race_id = 'kix-senshu-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'kix-senshu-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'kix-senshu-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'kix-senshu-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'kix-senshu-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'kix-senshu-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'kix-senshu-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'kix-senshu-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kix-senshu-marathon-2026', 'full', 42.195, 420, '10:30', 700, 5000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -3050,6 +3194,10 @@ DELETE FROM participation_gifts WHERE race_id = 'kobe-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'kobe-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'kobe-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'kobe-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'kobe-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'kobe-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'kobe-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'kobe-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kobe-marathon-2026', 'full', 42.195, 420, '09:00', 20000, 18000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -3133,6 +3281,10 @@ DELETE FROM participation_gifts WHERE race_id = 'kochi-ryoma-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'kochi-ryoma-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'kochi-ryoma-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'kochi-ryoma-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'kochi-ryoma-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'kochi-ryoma-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'kochi-ryoma-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'kochi-ryoma-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kochi-ryoma-marathon-2026', 'full', 42.195, 420, '09:00', 10000, 13000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -3214,6 +3366,10 @@ DELETE FROM participation_gifts WHERE race_id = 'kumamoto-castle-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'kumamoto-castle-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'kumamoto-castle-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'kumamoto-castle-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'kumamoto-castle-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'kumamoto-castle-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'kumamoto-castle-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'kumamoto-castle-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kumamoto-castle-marathon-2026', 'full', 42.195, 420, '09:00', 13000, 13750, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -3295,6 +3451,10 @@ DELETE FROM participation_gifts WHERE race_id = 'kyoto-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'kyoto-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'kyoto-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'kyoto-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'kyoto-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'kyoto-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'kyoto-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'kyoto-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kyoto-marathon-2026', 'full', 42.195, 360, '08:55', 16000, 18500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -3378,6 +3538,10 @@ DELETE FROM participation_gifts WHERE race_id = 'mie-matsusaka-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'mie-matsusaka-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'mie-matsusaka-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'mie-matsusaka-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'mie-matsusaka-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'mie-matsusaka-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'mie-matsusaka-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'mie-matsusaka-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('mie-matsusaka-marathon-2026', 'full', 42.195, 0, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -3455,6 +3619,10 @@ DELETE FROM participation_gifts WHERE race_id = 'mito-komon-manyu-marathon-2026'
 DELETE FROM race_entry_links WHERE race_id = 'mito-komon-manyu-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'mito-komon-manyu-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'mito-komon-manyu-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'mito-komon-manyu-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'mito-komon-manyu-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'mito-komon-manyu-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'mito-komon-manyu-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('mito-komon-manyu-marathon-2026', 'full', 42.195, 360, '', 10000, 10000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -3554,6 +3722,10 @@ DELETE FROM participation_gifts WHERE race_id = 'mtfuji-climb-run-2026';
 DELETE FROM race_entry_links WHERE race_id = 'mtfuji-climb-run-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'mtfuji-climb-run-2026';
 DELETE FROM race_results WHERE race_id = 'mtfuji-climb-run-2026';
+DELETE FROM race_gallery WHERE race_id = 'mtfuji-climb-run-2026';
+DELETE FROM race_voices WHERE race_id = 'mtfuji-climb-run-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'mtfuji-climb-run-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'mtfuji-climb-run-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('mtfuji-climb-run-2026', 'other', 12, 180, '09:00', 2000, 15000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
@@ -3631,6 +3803,10 @@ DELETE FROM participation_gifts WHERE race_id = 'nagoya-womens-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'nagoya-womens-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'nagoya-womens-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'nagoya-womens-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'nagoya-womens-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'nagoya-womens-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'nagoya-womens-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'nagoya-womens-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('nagoya-womens-marathon-2026', 'full', 42.195, 420, '09:10', 20000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -3710,6 +3886,10 @@ DELETE FROM participation_gifts WHERE race_id = 'naha-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'naha-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'naha-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'naha-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'naha-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'naha-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'naha-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'naha-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('naha-marathon-2026', 'full', 42.195, 375, '09:00', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -3789,6 +3969,10 @@ DELETE FROM participation_gifts WHERE race_id = 'nara-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'nara-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'nara-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'nara-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'nara-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'nara-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'nara-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'nara-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('nara-marathon-2026', 'full', 42.195, 360, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -3868,6 +4052,10 @@ DELETE FROM participation_gifts WHERE race_id = 'niigata-city-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'niigata-city-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'niigata-city-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'niigata-city-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'niigata-city-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'niigata-city-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'niigata-city-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'niigata-city-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('niigata-city-marathon-2026', 'full', 42.195, 420, '08:30', 9000, 12500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
@@ -3947,6 +4135,10 @@ DELETE FROM participation_gifts WHERE race_id = 'nishio-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'nishio-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'nishio-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'nishio-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'nishio-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'nishio-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'nishio-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'nishio-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('nishio-marathon-2026', 'full', 42.195, 390, '09:00', 6000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -4025,6 +4217,10 @@ DELETE FROM participation_gifts WHERE race_id = 'okayama-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'okayama-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'okayama-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'okayama-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'okayama-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'okayama-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'okayama-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'okayama-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('okayama-marathon-2026', 'full', 42.195, 360, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -4104,6 +4300,10 @@ DELETE FROM participation_gifts WHERE race_id = 'okushinano100-2026';
 DELETE FROM race_entry_links WHERE race_id = 'okushinano100-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'okushinano100-2026';
 DELETE FROM race_results WHERE race_id = 'okushinano100-2026';
+DELETE FROM race_gallery WHERE race_id = 'okushinano100-2026';
+DELETE FROM race_voices WHERE race_id = 'okushinano100-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'okushinano100-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'okushinano100-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('okushinano100-2026', 'ultra', 100, 1260, '05:00', 700, 31000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -4185,6 +4385,10 @@ DELETE FROM participation_gifts WHERE race_id = 'osaka-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'osaka-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'osaka-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'osaka-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'osaka-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'osaka-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'osaka-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'osaka-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('osaka-marathon-2026', 'full', 42.195, 420, '09:15', 31970, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -4274,6 +4478,10 @@ DELETE FROM participation_gifts WHERE race_id = 'osaka-yodo-river-citizens-marat
 DELETE FROM race_entry_links WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('osaka-yodo-river-citizens-marathon-2026', 'full', 42.195, 480, '09:00', 4000, 9800, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -4359,6 +4567,10 @@ DELETE FROM participation_gifts WHERE race_id = 'osj-ontake100-2026';
 DELETE FROM race_entry_links WHERE race_id = 'osj-ontake100-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'osj-ontake100-2026';
 DELETE FROM race_results WHERE race_id = 'osj-ontake100-2026';
+DELETE FROM race_gallery WHERE race_id = 'osj-ontake100-2026';
+DELETE FROM race_voices WHERE race_id = 'osj-ontake100-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'osj-ontake100-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'osj-ontake100-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('osj-ontake100-2026', 'ultra', 163, 1440, '20:00', 200, 21000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -4436,6 +4648,10 @@ DELETE FROM participation_gifts WHERE race_id = 'sado-toki-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'sado-toki-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'sado-toki-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'sado-toki-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'sado-toki-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'sado-toki-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'sado-toki-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'sado-toki-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('sado-toki-marathon-2026', 'full', 42.195, 0, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -4517,6 +4733,10 @@ DELETE FROM participation_gifts WHERE race_id = 'saga-sakura-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'saga-sakura-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'saga-sakura-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'saga-sakura-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'saga-sakura-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'saga-sakura-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'saga-sakura-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'saga-sakura-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('saga-sakura-marathon-2026', 'full', 42.195, 0, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -4594,6 +4814,10 @@ DELETE FROM participation_gifts WHERE race_id = 'saitama-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'saitama-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'saitama-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'saitama-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'saitama-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'saitama-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'saitama-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'saitama-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('saitama-marathon-2026', 'full', 42.195, 360, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -4760,6 +4984,10 @@ DELETE FROM participation_gifts WHERE race_id = 'shiga-kogen100-2026';
 DELETE FROM race_entry_links WHERE race_id = 'shiga-kogen100-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'shiga-kogen100-2026';
 DELETE FROM race_results WHERE race_id = 'shiga-kogen100-2026';
+DELETE FROM race_gallery WHERE race_id = 'shiga-kogen100-2026';
+DELETE FROM race_voices WHERE race_id = 'shiga-kogen100-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'shiga-kogen100-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'shiga-kogen100-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('shiga-kogen100-2026', 'ultra', 100, 1560, '04:30', 700, 28000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -4847,6 +5075,10 @@ DELETE FROM participation_gifts WHERE race_id = 'shimada-oigawa-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'shimada-oigawa-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'shimada-oigawa-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'shimada-oigawa-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'shimada-oigawa-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'shimada-oigawa-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'shimada-oigawa-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'shimada-oigawa-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('shimada-oigawa-marathon-2026', 'full', 42.195, 420, '09:00', 6000, 10000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -4927,6 +5159,10 @@ DELETE FROM participation_gifts WHERE race_id = 'shinetsu5mountains-trail-100-20
 DELETE FROM race_entry_links WHERE race_id = 'shinetsu5mountains-trail-100-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'shinetsu5mountains-trail-100-2026';
 DELETE FROM race_results WHERE race_id = 'shinetsu5mountains-trail-100-2026';
+DELETE FROM race_gallery WHERE race_id = 'shinetsu5mountains-trail-100-2026';
+DELETE FROM race_voices WHERE race_id = 'shinetsu5mountains-trail-100-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'shinetsu5mountains-trail-100-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'shinetsu5mountains-trail-100-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('shinetsu5mountains-trail-100-2026', 'ultra', 163, 1980, '18:30', 600, 47000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -5014,6 +5250,10 @@ DELETE FROM participation_gifts WHERE race_id = 'shizuoka-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'shizuoka-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'shizuoka-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'shizuoka-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'shizuoka-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'shizuoka-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'shizuoka-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'shizuoka-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('shizuoka-marathon-2026', 'full', 42.195, 0, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -5091,6 +5331,10 @@ DELETE FROM participation_gifts WHERE race_id = 'shonan-international-marathon-2
 DELETE FROM race_entry_links WHERE race_id = 'shonan-international-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'shonan-international-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'shonan-international-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'shonan-international-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'shonan-international-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'shonan-international-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'shonan-international-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('shonan-international-marathon-2026', 'full', 42.195, 345, '', 19500, 16000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -5175,6 +5419,10 @@ DELETE FROM participation_gifts WHERE race_id = 'soja-kibiji-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'soja-kibiji-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'soja-kibiji-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'soja-kibiji-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'soja-kibiji-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'soja-kibiji-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'soja-kibiji-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'soja-kibiji-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('soja-kibiji-marathon-2026', 'full', 42.195, 360, '09:20', 2000, 9100, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -5254,6 +5502,10 @@ DELETE FROM participation_gifts WHERE race_id = 'tamba-sasayama-abc-marathon-202
 DELETE FROM race_entry_links WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('tamba-sasayama-abc-marathon-2026', 'full', 42.195, 330, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -5331,6 +5583,10 @@ DELETE FROM participation_gifts WHERE race_id = 'tateyama-wakashio-2026';
 DELETE FROM race_entry_links WHERE race_id = 'tateyama-wakashio-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'tateyama-wakashio-2026';
 DELETE FROM race_results WHERE race_id = 'tateyama-wakashio-2026';
+DELETE FROM race_gallery WHERE race_id = 'tateyama-wakashio-2026';
+DELETE FROM race_voices WHERE race_id = 'tateyama-wakashio-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'tateyama-wakashio-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'tateyama-wakashio-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('tateyama-wakashio-2026', 'full', 42.195, 360, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -5411,6 +5667,10 @@ DELETE FROM participation_gifts WHERE race_id = 'tazawako-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'tazawako-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'tazawako-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'tazawako-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'tazawako-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'tazawako-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'tazawako-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'tazawako-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('tazawako-marathon-2026', 'full', 42.195, 360, '08:30', 1600, 10000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -5490,6 +5750,10 @@ DELETE FROM participation_gifts WHERE race_id = 'tokushima-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'tokushima-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'tokushima-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'tokushima-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'tokushima-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'tokushima-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'tokushima-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'tokushima-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('tokushima-marathon-2026', 'full', 42.195, 0, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -5567,6 +5831,10 @@ DELETE FROM participation_gifts WHERE race_id = 'tokyo-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'tokyo-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'tokyo-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'tokyo-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'tokyo-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'tokyo-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'tokyo-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'tokyo-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('tokyo-marathon-2026', 'full', 42.195, 420, '09:10', 38500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, sort_order) VALUES
@@ -5654,6 +5922,10 @@ DELETE FROM participation_gifts WHERE race_id = 'tokyo-marathon-2027';
 DELETE FROM race_entry_links WHERE race_id = 'tokyo-marathon-2027';
 DELETE FROM race_entry_periods WHERE race_id = 'tokyo-marathon-2027';
 DELETE FROM race_results WHERE race_id = 'tokyo-marathon-2027';
+DELETE FROM race_gallery WHERE race_id = 'tokyo-marathon-2027';
+DELETE FROM race_voices WHERE race_id = 'tokyo-marathon-2027';
+DELETE FROM race_time_buckets WHERE race_id = 'tokyo-marathon-2027';
+DELETE FROM race_course_highlights WHERE race_id = 'tokyo-marathon-2027';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('tokyo-marathon-2027', 'full', 42.195, 0, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, sort_order) VALUES
@@ -5741,6 +6013,10 @@ DELETE FROM participation_gifts WHERE race_id = 'tomisato-suikaroad-2026';
 DELETE FROM race_entry_links WHERE race_id = 'tomisato-suikaroad-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'tomisato-suikaroad-2026';
 DELETE FROM race_results WHERE race_id = 'tomisato-suikaroad-2026';
+DELETE FROM race_gallery WHERE race_id = 'tomisato-suikaroad-2026';
+DELETE FROM race_voices WHERE race_id = 'tomisato-suikaroad-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'tomisato-suikaroad-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'tomisato-suikaroad-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('tomisato-suikaroad-2026', '10k', 10, 70, '09:15', 1500, 6500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -5820,6 +6096,10 @@ DELETE FROM participation_gifts WHERE race_id = 'tottori-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'tottori-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'tottori-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'tottori-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'tottori-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'tottori-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'tottori-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'tottori-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('tottori-marathon-2026', 'full', 42.195, 0, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -5906,6 +6186,10 @@ DELETE FROM participation_gifts WHERE race_id = 'toyako-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'toyako-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'toyako-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'toyako-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'toyako-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'toyako-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'toyako-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'toyako-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('toyako-marathon-2026', 'full', 42.195, 0, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -5987,6 +6271,10 @@ DELETE FROM participation_gifts WHERE race_id = 'toyama-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'toyama-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'toyama-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'toyama-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'toyama-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'toyama-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'toyama-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'toyama-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('toyama-marathon-2026', 'full', 42.195, 420, '09:30', 13000, 14000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -6068,6 +6356,10 @@ DELETE FROM participation_gifts WHERE race_id = 'tsukuba-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'tsukuba-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'tsukuba-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'tsukuba-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'tsukuba-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'tsukuba-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'tsukuba-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'tsukuba-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('tsukuba-marathon-2026', 'full', 42.195, 0, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -6145,6 +6437,10 @@ DELETE FROM participation_gifts WHERE race_id = 'wakkanai-peace-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'wakkanai-peace-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'wakkanai-peace-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'wakkanai-peace-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'wakkanai-peace-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'wakkanai-peace-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'wakkanai-peace-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'wakkanai-peace-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('wakkanai-peace-marathon-2026', 'full', 42.195, 390, '', 1000, 10000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -6226,6 +6522,10 @@ DELETE FROM participation_gifts WHERE race_id = 'yokohama-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'yokohama-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'yokohama-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'yokohama-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'yokohama-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'yokohama-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'yokohama-marathon-2026';
+DELETE FROM race_course_highlights WHERE race_id = 'yokohama-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('yokohama-marathon-2026', 'full', 42.195, 390, '08:30', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES

--- a/scripts/generate-seed-races.js
+++ b/scripts/generate-seed-races.js
@@ -99,6 +99,10 @@ function generateRaceSQL(r) {
   lines.push(`DELETE FROM race_entry_links WHERE race_id = ${esc(r.id)};`);
   lines.push(`DELETE FROM race_entry_periods WHERE race_id = ${esc(r.id)};`);
   lines.push(`DELETE FROM race_results WHERE race_id = ${esc(r.id)};`);
+  lines.push(`DELETE FROM race_gallery WHERE race_id = ${esc(r.id)};`);
+  lines.push(`DELETE FROM race_voices WHERE race_id = ${esc(r.id)};`);
+  lines.push(`DELETE FROM race_time_buckets WHERE race_id = ${esc(r.id)};`);
+  lines.push(`DELETE FROM race_course_highlights WHERE race_id = ${esc(r.id)};`);
 
   // race_categories
   if (r.categories && r.categories.length > 0) {
@@ -169,6 +173,38 @@ function generateRaceSQL(r) {
     r.entry_periods.forEach((ep, idx) => {
       lines.push(`INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   (${esc(r.id)}, ${esc(ep.category_id ?? null)}, ${esc(ep.label_ja || '一般エントリー')}, ${esc(ep.label_en || 'General Entry')}, ${esc(ep.start_date)}, ${esc(ep.end_date)}, ${esc(ep.entry_fee ?? null)}, ${idx});`);
+    });
+  }
+
+  // race_gallery
+  if (r.gallery && r.gallery.length > 0) {
+    r.gallery.forEach((g, idx) => {
+      lines.push(`INSERT OR REPLACE INTO race_gallery (race_id, src, caption_ja, caption_en, sort_order) VALUES
+  (${esc(r.id)}, ${esc(g.src)}, ${esc(g.caption_ja ?? null)}, ${esc(g.caption_en ?? null)}, ${idx});`);
+    });
+  }
+
+  // race_voices
+  if (r.voices && r.voices.length > 0) {
+    r.voices.forEach((v, idx) => {
+      lines.push(`INSERT OR REPLACE INTO race_voices (race_id, quote_ja, author, sort_order) VALUES
+  (${esc(r.id)}, ${esc(v.quote_ja)}, ${esc(v.author ?? null)}, ${idx});`);
+    });
+  }
+
+  // race_time_buckets
+  if (r.time_buckets && r.time_buckets.length > 0) {
+    r.time_buckets.forEach((tb, idx) => {
+      lines.push(`INSERT OR REPLACE INTO race_time_buckets (race_id, bucket, pct, sort_order) VALUES
+  (${esc(r.id)}, ${esc(tb.bucket)}, ${esc(tb.pct)}, ${idx});`);
+    });
+  }
+
+  // race_course_highlights
+  if (r.course_highlights && r.course_highlights.length > 0) {
+    r.course_highlights.forEach((ch, idx) => {
+      lines.push(`INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  (${esc(r.id)}, ${esc(ch.km)}, ${esc(ch.name_ja)}, ${esc(ch.name_en ?? null)}, ${esc(ch.note_ja ?? null)}, ${esc(ch.note_en ?? null)}, ${idx});`);
     });
   }
 

--- a/src/app/[locale]/races/[id]/page.tsx
+++ b/src/app/[locale]/races/[id]/page.tsx
@@ -10,6 +10,12 @@ import type { Locale, NearbySpotType } from '@/lib/types';
 import CourseProfileSection from '@/components/course/CourseProfileSection';
 import RaceBreadcrumb from '@/components/races/RaceBreadcrumb';
 import RaceRegistrationButtons from '@/components/races/RaceRegistrationButtons';
+import DetailHeader from '@/components/races/detail/DetailHeader';
+import AnchorBar from '@/components/races/detail/AnchorBar';
+import OverviewSection from '@/components/races/detail/OverviewSection';
+import EntrySection from '@/components/races/detail/EntrySection';
+import LastEditionSection from '@/components/races/detail/LastEditionSection';
+import GallerySection from '@/components/races/detail/GallerySection';
 
 export async function generateMetadata({
   params,
@@ -127,6 +133,15 @@ export default async function RaceDetailPage({
     today <= race.entry_end_date;
   const isNotYetOpen = !race.entry_closed && race.entry_start_date !== null && today < race.entry_start_date;
 
+  // AnchorBar に表示するセクション
+  const anchorItems = [
+    ...(raceDesc || race.tags.length > 0 ? [{ id: 'overview', label: locale === 'ja' ? '概要' : 'Overview' }] : []),
+    { id: 'course', label: locale === 'ja' ? 'コース' : 'Course' },
+    { id: 'entry', label: locale === 'ja' ? 'エントリー' : 'Registration' },
+    ...(race.result ? [{ id: 'last-edition', label: locale === 'ja' ? '前回大会' : 'Last Edition' }] : []),
+    ...(race.gallery.length > 0 || race.voices.length > 0 ? [{ id: 'gallery', label: locale === 'ja' ? 'ギャラリー' : 'Gallery' }] : []),
+  ];
+
   const jsonLd = {
     '@context': 'https://schema.org',
     '@type': 'SportsEvent',
@@ -153,23 +168,29 @@ export default async function RaceDetailPage({
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
-      {/* ── Hero ── */}
-      <div style={{ background: 'var(--color-ink)' }} className="text-white">
-        <div className="max-w-4xl mx-auto px-4 sm:px-6 pt-6 pb-10">
-          {/* Breadcrumb */}
-          <RaceBreadcrumb
-            raceName={raceName}
-            from={from}
-            labels={{
-              home: t('breadcrumb.home'),
-              races: t('breadcrumb.races'),
-              calendar: t('breadcrumb.calendar'),
-            }}
-          />
 
+      {/* ── ブレッドクラム ── */}
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 pt-4">
+        <RaceBreadcrumb
+          raceName={raceName}
+          from={from}
+          labels={{
+            home: t('breadcrumb.home'),
+            races: t('breadcrumb.races'),
+            calendar: t('breadcrumb.calendar'),
+          }}
+        />
+      </div>
+
+      {/* ── Hero ── */}
+      <DetailHeader race={race} locale={locale} raceName={raceName} />
+
+      {/* ── メタ情報ストリップ ── */}
+      <div style={{ background: 'var(--color-ink)' }} className="text-white">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 py-4">
           {/* Tags */}
           {race.tags.length > 0 && (
-            <div className="flex flex-wrap gap-2 mb-4">
+            <div className="flex flex-wrap gap-2 mb-3">
               {race.tags.map((tag) => (
                 <span
                   key={tag}
@@ -182,19 +203,8 @@ export default async function RaceDetailPage({
             </div>
           )}
 
-          {/* Race name */}
-          <h1 className="font-serif text-3xl md:text-4xl font-bold leading-tight mb-2">
-            {raceName}
-          </h1>
-          {/* シリーズ名（正式名称と異なる場合のみ表示） */}
-          {raceName !== raceSeriesName && (
-            <p className="text-sm mb-4" style={{ color: 'var(--color-light)' }}>
-              {raceSeriesName}
-            </p>
-          )}
-
           {/* Meta row */}
-          <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm mb-5" style={{ color: 'var(--color-light)' }}>
+          <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm mb-4" style={{ color: 'var(--color-light)' }}>
             <span>📅 {formatDate(race.date, locale)}</span>
             <span>📍 {getRaceCity(race, locale)}</span>
             {mainCategory && <span>🏃 {mainCategory.distance_km}km</span>}
@@ -247,7 +257,7 @@ export default async function RaceDetailPage({
             )}
           </div>
 
-          {/* 登録ボタン（ログイン済みのみ表示） */}
+          {/* 登録ボタン */}
           {!isPast && (
             <RaceRegistrationButtons
               raceId={race.id}
@@ -274,6 +284,9 @@ export default async function RaceDetailPage({
         </div>
       </div>
 
+      {/* ── AnchorBar ── */}
+      <AnchorBar items={anchorItems} />
+
       {/* ── Content ── */}
       <div
         className="max-w-4xl mx-auto px-4 sm:px-6 py-10 space-y-12"
@@ -281,18 +294,16 @@ export default async function RaceDetailPage({
       >
 
         {/* Overview */}
-        {raceDesc && (
+        {(raceDesc || race.tags.length > 0) && (
           <section>
             <SectionLabel>{locale === 'ja' ? '概要' : 'Overview'}</SectionLabel>
             <SectionTitle>{t('overview')}</SectionTitle>
-            <p className="text-base leading-relaxed whitespace-pre-line" style={{ color: 'var(--color-ink2)' }}>
-              {raceDesc}
-            </p>
+            <OverviewSection race={race} locale={locale} />
           </section>
         )}
 
         {/* Categories & Course */}
-        <section>
+        <section id="course">
           <SectionLabel>{locale === 'ja' ? 'コース' : 'Course'}</SectionLabel>
           <SectionTitle>{t('course')}</SectionTitle>
 
@@ -488,183 +499,7 @@ export default async function RaceDetailPage({
           <SectionLabel>{locale === 'ja' ? 'エントリー' : 'Registration'}</SectionLabel>
           <SectionTitle>{t('applicationPeriod')}</SectionTitle>
           <Card>
-            {/* 受付終了メッセージ */}
-            {!isPast && race.entry_closed && (
-              <p
-                className="text-sm mb-4 px-3 py-2.5 rounded-[3px] leading-relaxed"
-                style={{ background: '#fff8f0', border: '1px solid #f0d9c0', color: '#7a4f1a' }}
-              >
-                {locale === 'ja'
-                  ? '定員に達したため受付を終了しました。最新情報は公式サイトをご確認ください。'
-                  : 'Registration has closed as the event has reached capacity. Please check the official site for the latest information.'}
-              </p>
-            )}
-            {/* entry_periods がある場合は一覧表示、ない場合は旧フィールドにフォールバック */}
-            {race.entry_periods && race.entry_periods.length > 0 ? (
-              <div className="mb-4">
-                {race.entry_periods.length === 1 ? (
-                  // 1件のみの場合はシンプル表示
-                  <div className="flex flex-wrap gap-6">
-                    <div>
-                      <p className="text-xs mb-1" style={{ color: 'var(--color-mid)' }}>
-                        {locale === 'ja' ? '受付期間' : 'Period'}
-                      </p>
-                      <p className="font-medium">
-                        {formatDate(race.entry_periods[0].start_date, locale)}
-                        {' — '}
-                        {formatDate(race.entry_periods[0].end_date, locale)}
-                      </p>
-                    </div>
-                    {race.entry_periods[0].entry_fee && (
-                      <div>
-                        <p className="text-xs mb-1" style={{ color: 'var(--color-mid)' }}>
-                          {t('fee')}
-                        </p>
-                        <p className="font-medium">{formatCurrency(race.entry_periods[0].entry_fee)}</p>
-                      </div>
-                    )}
-                    {!race.entry_periods[0].entry_fee && !race.entry_fee_by_category && race.entry_fee && (
-                      <div>
-                        <p className="text-xs mb-1" style={{ color: 'var(--color-mid)' }}>
-                          {t('fee')}
-                        </p>
-                        <p className="font-medium">{formatCurrency(race.entry_fee)}</p>
-                      </div>
-                    )}
-                  </div>
-                ) : (
-                  // 複数エントリー期間の場合はテーブル表示
-                  <div className="overflow-x-auto">
-                    <table className="w-full text-sm">
-                      <thead>
-                        <tr style={{ borderBottom: '2px solid var(--color-border)' }}>
-                          <th className="text-left pb-2.5 font-semibold" style={{ color: 'var(--color-mid)' }}>
-                            {locale === 'ja' ? '種別' : 'Type'}
-                          </th>
-                          <th className="text-left pb-2.5 font-semibold" style={{ color: 'var(--color-mid)' }}>
-                            {locale === 'ja' ? '受付期間' : 'Period'}
-                          </th>
-                          <th className="text-right pb-2.5 font-semibold" style={{ color: 'var(--color-mid)' }}>
-                            {t('fee')}
-                          </th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {race.entry_periods.map((ep) => (
-                          <tr key={ep.id} style={{ borderBottom: '1px solid var(--color-border)' }} className="last:border-0">
-                            <td className="py-2.5 font-medium">
-                              {locale === 'ja' ? ep.label_ja : ep.label_en}
-                            </td>
-                            <td className="py-2.5">
-                              {formatDate(ep.start_date, locale)} — {formatDate(ep.end_date, locale)}
-                            </td>
-                            <td className="py-2.5 text-right">
-                              {ep.entry_fee
-                                ? formatCurrency(ep.entry_fee)
-                                : (!race.entry_fee_by_category && race.entry_fee)
-                                  ? formatCurrency(race.entry_fee)
-                                  : '—'}
-                            </td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
-                )}
-              </div>
-            ) : (
-              // フォールバック: 旧フィールド
-              <div className="flex flex-wrap gap-6 mb-4">
-                <div>
-                  <p className="text-xs mb-1" style={{ color: 'var(--color-mid)' }}>
-                    {locale === 'ja' ? '受付期間' : 'Period'}
-                  </p>
-                  <p className="font-medium">
-                    {race.entry_start_date
-                      ? formatDate(race.entry_start_date, locale)
-                      : (!isPast ? <span style={{ color: 'var(--color-light)' }}>{t('unpublished')}</span> : '—')}
-                    {' — '}
-                    {race.entry_end_date
-                      ? formatDate(race.entry_end_date, locale)
-                      : (!isPast ? <span style={{ color: 'var(--color-light)' }}>{t('unpublished')}</span> : '—')}
-                  </p>
-                </div>
-                {!race.entry_fee_by_category && race.entry_fee && (
-                  <div>
-                    <p className="text-xs mb-1" style={{ color: 'var(--color-mid)' }}>
-                      {t('fee')}
-                    </p>
-                    <p className="font-medium">{formatCurrency(race.entry_fee)}</p>
-                  </div>
-                )}
-              </div>
-            )}
-            {(() => {
-              const receptionTypeLabel: Record<string, { ja: string; en: string }> = {
-                pre_day:  { ja: '前日受付', en: 'Pre-event pickup' },
-                race_day: { ja: '当日受付', en: 'Race day pickup' },
-                same_day: { ja: '当日受付', en: 'Race day pickup' },
-                both:     { ja: '前日・当日受付', en: 'Pre-event & race day' },
-                pre_mail: { ja: '事前郵送', en: 'By mail' },
-                mail:     { ja: '事前郵送', en: 'By mail' },
-              };
-              const typeLabel = race.reception_type ? receptionTypeLabel[race.reception_type] : null;
-              const note = locale === 'ja' ? race.reception_note_ja : race.reception_note_en;
-              if (!typeLabel && !note) return null;
-              return (
-                <div className="mt-3 mb-4">
-                  <p className="text-xs mb-1" style={{ color: 'var(--color-mid)' }}>
-                    {locale === 'ja' ? '受付' : 'Reception'}
-                  </p>
-                  {typeLabel && (
-                    <p className="font-medium text-sm mb-1">
-                      {locale === 'ja' ? typeLabel.ja : typeLabel.en}
-                    </p>
-                  )}
-                  {note && (
-                    <p className="text-sm whitespace-pre-line" style={{ color: 'var(--color-mid)' }}>
-                      {note}
-                    </p>
-                  )}
-                </div>
-              );
-            })()}
-            {race.entry_capacity > 0 && (
-              <div className="mt-3 mb-4">
-                <p className="text-xs mb-1" style={{ color: 'var(--color-mid)' }}>
-                  {t('capacity')}
-                </p>
-                <p className="font-medium">{race.entry_capacity.toLocaleString()}{locale === 'ja' ? '人' : ' runners'}</p>
-              </div>
-            )}
-            {/* エントリーリンク */}
-            {race.entry_links.length > 0 && (
-              <div className="mt-4 flex flex-wrap gap-2">
-                {race.entry_links.map((link) => (
-                  <a
-                    key={link.id}
-                    href={link.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-block px-5 py-2 text-sm font-semibold rounded-[3px] transition-colors no-underline"
-                    style={{ background: 'var(--color-primary)', color: 'white' }}
-                  >
-                    {link.site_name} ↗
-                  </a>
-                ))}
-              </div>
-            )}
-            {race.official_url && (
-              <a
-                href={race.official_url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-block mt-4 px-5 py-2 text-sm font-semibold rounded-[3px] transition-colors no-underline"
-                style={{ background: 'var(--color-cream)', color: 'var(--color-ink)', border: '1px solid var(--color-border)' }}
-              >
-                {t('website')} ↗
-              </a>
-            )}
+            <EntrySection race={race} locale={locale} today={today} />
           </Card>
         </section>
 
@@ -776,97 +611,21 @@ export default async function RaceDetailPage({
           </section>
         )}
 
-        {/* Race Result */}
+        {/* Last Edition Result */}
         {race.result && (
           <section>
             <SectionLabel>{locale === 'ja' ? '開催実績' : 'Results'}</SectionLabel>
-            <SectionTitle>{locale === 'ja' ? 'レース実績' : 'Race Results'}</SectionTitle>
-            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-3">
-              {race.result.participants_count !== null && (
-                <Card className="text-center">
-                  <p className="text-2xl font-bold" style={{ color: 'var(--color-ink)' }}>
-                    {race.result.participants_count.toLocaleString()}
-                  </p>
-                  <p className="text-xs mt-0.5" style={{ color: 'var(--color-mid)' }}>
-                    {locale === 'ja' ? '参加者数' : 'Participants'}
-                  </p>
-                </Card>
-              )}
-              {race.result.finishers_count !== null && (
-                <Card className="text-center">
-                  <p className="text-2xl font-bold" style={{ color: 'var(--color-ink)' }}>
-                    {race.result.finishers_count.toLocaleString()}
-                  </p>
-                  <p className="text-xs mt-0.5" style={{ color: 'var(--color-mid)' }}>
-                    {locale === 'ja' ? '完走者数' : 'Finishers'}
-                  </p>
-                </Card>
-              )}
-              {race.result.finisher_rate_pct !== null && (
-                <Card className="text-center">
-                  <p className="text-2xl font-bold" style={{ color: 'var(--color-ink)' }}>
-                    {race.result.finisher_rate_pct.toFixed(1)}%
-                  </p>
-                  <p className="text-xs mt-0.5" style={{ color: 'var(--color-mid)' }}>
-                    {locale === 'ja' ? '完走率' : 'Finish Rate'}
-                  </p>
-                </Card>
-              )}
-              {race.result.temperature_c !== null && (
-                <Card className="text-center">
-                  <p className="text-2xl font-bold" style={{ color: 'var(--color-ink)' }}>
-                    {race.result.temperature_c}°C
-                  </p>
-                  <p className="text-xs mt-0.5" style={{ color: 'var(--color-mid)' }}>
-                    {locale === 'ja' ? '当日気温' : 'Temperature'}
-                  </p>
-                </Card>
-              )}
-            </div>
-            {/* Weather details */}
-            {race.result.weather_condition_ja && (
-              <Card>
-                <div className="flex flex-wrap gap-5 text-sm">
-                  <div>
-                    <p className="text-xs mb-0.5" style={{ color: 'var(--color-mid)' }}>
-                      {locale === 'ja' ? '天気' : 'Weather'}
-                    </p>
-                    <p className="font-medium">
-                      {locale === 'ja' ? race.result.weather_condition_ja : race.result.weather_condition_en}
-                    </p>
-                  </div>
-                  {race.result.max_temp_c !== null && (
-                    <div>
-                      <p className="text-xs mb-0.5" style={{ color: 'var(--color-mid)' }}>{locale === 'ja' ? '最高気温' : 'Max'}</p>
-                      <p className="font-medium" style={{ color: '#c0392b' }}>{race.result.max_temp_c}°C</p>
-                    </div>
-                  )}
-                  {race.result.min_temp_c !== null && (
-                    <div>
-                      <p className="text-xs mb-0.5" style={{ color: 'var(--color-mid)' }}>{locale === 'ja' ? '最低気温' : 'Min'}</p>
-                      <p className="font-medium" style={{ color: '#2980b9' }}>{race.result.min_temp_c}°C</p>
-                    </div>
-                  )}
-                  {race.result.wind_speed_ms !== null && (
-                    <div>
-                      <p className="text-xs mb-0.5" style={{ color: 'var(--color-mid)' }}>{locale === 'ja' ? '風速' : 'Wind'}</p>
-                      <p className="font-medium">{race.result.wind_speed_ms} m/s</p>
-                    </div>
-                  )}
-                  {race.result.humidity_pct !== null && (
-                    <div>
-                      <p className="text-xs mb-0.5" style={{ color: 'var(--color-mid)' }}>{locale === 'ja' ? '湿度' : 'Humidity'}</p>
-                      <p className="font-medium">{race.result.humidity_pct}%</p>
-                    </div>
-                  )}
-                </div>
-                {race.result.notes_ja && (
-                  <p className="text-sm mt-3 pt-3 leading-relaxed" style={{ borderTop: '1px solid var(--color-border)', color: 'var(--color-ink2)' }}>
-                    {locale === 'ja' ? race.result.notes_ja : race.result.notes_en}
-                  </p>
-                )}
-              </Card>
-            )}
+            <SectionTitle>{locale === 'ja' ? '前回大会' : 'Last Edition'}</SectionTitle>
+            <LastEditionSection race={race} locale={locale} />
+          </section>
+        )}
+
+        {/* Gallery & Voices */}
+        {(race.gallery.length > 0 || race.voices.length > 0) && (
+          <section>
+            <SectionLabel>{locale === 'ja' ? 'ギャラリー' : 'Gallery'}</SectionLabel>
+            <SectionTitle>{locale === 'ja' ? '写真・参加者の声' : 'Photos & Voices'}</SectionTitle>
+            <GallerySection race={race} locale={locale} />
           </section>
         )}
 
@@ -919,7 +678,6 @@ export default async function RaceDetailPage({
                             </div>
                           </div>
                           <div className="flex items-center gap-3 shrink-0">
-                            {/* Result stats if available */}
                             {r.result?.participants_count !== null && r.result?.participants_count !== undefined && (
                               <div className="text-right hidden sm:block">
                                 <p className="text-sm font-semibold" style={{ color: 'var(--color-ink)' }}>

--- a/src/components/races/detail/AnchorBar.tsx
+++ b/src/components/races/detail/AnchorBar.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+interface AnchorBarItem {
+  id: string;
+  label: string;
+}
+
+interface AnchorBarProps {
+  items: AnchorBarItem[];
+  activeId?: string;
+}
+
+export default function AnchorBar({ items, activeId }: AnchorBarProps) {
+  if (items.length === 0) return null;
+
+  return (
+    <nav
+      className="sticky top-0 z-20 overflow-x-auto"
+      style={{ background: 'white', borderBottom: '1px solid var(--color-border)' }}
+    >
+      <div className="flex max-w-4xl mx-auto px-4 sm:px-6">
+        {items.map((item) => {
+          const isActive = item.id === activeId;
+          return (
+            <a
+              key={item.id}
+              href={`#${item.id}`}
+              data-active={isActive ? 'true' : undefined}
+              className="shrink-0 px-4 py-3 text-sm font-medium transition-colors no-underline"
+              style={{
+                color: isActive ? 'var(--color-primary)' : 'var(--color-mid)',
+                borderBottom: isActive ? '2px solid var(--color-primary)' : '2px solid transparent',
+              }}
+            >
+              {item.label}
+            </a>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/src/components/races/detail/DetailHeader.tsx
+++ b/src/components/races/detail/DetailHeader.tsx
@@ -1,0 +1,80 @@
+import type { Race, Locale } from '@/lib/types';
+
+interface DetailHeaderProps {
+  race: Race;
+  locale: Locale;
+  raceName: string;
+}
+
+export default function DetailHeader({ race, locale, raceName }: DetailHeaderProps) {
+  const tagline = locale === 'en' ? race.tagline_en : race.tagline_ja;
+  const bgColor = race.motif_color ?? 'var(--color-primary)';
+
+  return (
+    <div
+      className="relative overflow-hidden"
+      style={{ minHeight: 280, background: bgColor }}
+    >
+      {/* Diagonal stripe overlay */}
+      <div
+        className="absolute inset-0"
+        style={{
+          backgroundImage: 'repeating-linear-gradient(-45deg, transparent 0, transparent 10px, rgba(255,255,255,0.03) 10px, rgba(255,255,255,0.03) 20px)',
+        }}
+      />
+
+      {/* Hero image */}
+      {race.hero_image_url && (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={race.hero_image_url}
+          alt={race.hero_caption_ja ?? ''}
+          className="absolute inset-0 w-full h-full object-cover opacity-40"
+        />
+      )}
+
+      {/* Bottom gradient */}
+      <div
+        className="absolute inset-0"
+        style={{ background: 'linear-gradient(to top, rgba(0,0,0,0.6) 0%, transparent 60%)' }}
+      />
+
+      {/* Content */}
+      <div className="relative max-w-4xl mx-auto px-4 sm:px-6 pt-10 pb-10 flex flex-col gap-3">
+        {/* Motif + edition row */}
+        <div className="flex items-center gap-3">
+          {race.motif && (
+            <span
+              className="font-mono text-white/50 tracking-[0.2em] text-xs uppercase"
+            >
+              {race.motif}
+            </span>
+          )}
+          {race.edition && (
+            <span className="text-white/60 text-sm font-mono">
+              第{race.edition}回
+            </span>
+          )}
+        </div>
+
+        {/* Race name */}
+        <h1
+          className="text-white font-serif leading-tight"
+          style={{ fontSize: 'clamp(2rem, 5vw, 3.5rem)', fontFamily: 'var(--font-noto-serif-jp)' }}
+        >
+          {raceName}
+        </h1>
+
+        {/* Tagline */}
+        {tagline && (
+          <p
+            data-testid="tagline"
+            className="text-white/75 text-base font-light tracking-wide"
+          >
+            {tagline}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/races/detail/EntrySection.tsx
+++ b/src/components/races/detail/EntrySection.tsx
@@ -1,0 +1,157 @@
+import type { Race, Locale } from '@/lib/types';
+import { formatDate, formatCurrency } from '@/lib/utils';
+
+interface EntrySectionProps {
+  race: Race;
+  locale: Locale;
+  today: string;
+}
+
+export default function EntrySection({ race, locale, today }: EntrySectionProps) {
+  return (
+    <section id="entry">
+      {/* 受付終了メッセージ */}
+      {race.entry_closed && (
+        <p
+          data-testid="entry-closed-msg"
+          className="text-sm mb-4 px-3 py-2.5 rounded-[3px] leading-relaxed"
+          style={{ background: '#fff8f0', border: '1px solid #f0d9c0', color: '#7a4f1a' }}
+        >
+          {locale === 'ja'
+            ? '定員に達したため受付を終了しました。最新情報は公式サイトをご確認ください。'
+            : 'Registration has closed as the event has reached capacity. Please check the official site for the latest information.'}
+        </p>
+      )}
+
+      {/* エントリー期間 */}
+      {race.entry_periods.length > 0 ? (
+        <div className="mb-4">
+          {race.entry_periods.length === 1 ? (
+            <div className="flex flex-wrap gap-6">
+              <div>
+                <p className="text-xs mb-1" style={{ color: 'var(--color-mid)' }}>
+                  {locale === 'ja' ? '受付期間' : 'Period'}
+                </p>
+                <p className="font-medium">
+                  {formatDate(race.entry_periods[0].start_date, locale)}
+                  {' — '}
+                  {formatDate(race.entry_periods[0].end_date, locale)}
+                </p>
+              </div>
+              {race.entry_periods[0].entry_fee && (
+                <div>
+                  <p className="text-xs mb-1" style={{ color: 'var(--color-mid)' }}>
+                    {locale === 'ja' ? '参加費' : 'Fee'}
+                  </p>
+                  <p className="font-medium">{formatCurrency(race.entry_periods[0].entry_fee)}</p>
+                </div>
+              )}
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr style={{ borderBottom: '2px solid var(--color-border)' }}>
+                    <th className="text-left pb-2.5 font-semibold" style={{ color: 'var(--color-mid)' }}>
+                      {locale === 'ja' ? '種別' : 'Type'}
+                    </th>
+                    <th className="text-left pb-2.5 font-semibold" style={{ color: 'var(--color-mid)' }}>
+                      {locale === 'ja' ? '受付期間' : 'Period'}
+                    </th>
+                    <th className="text-right pb-2.5 font-semibold" style={{ color: 'var(--color-mid)' }}>
+                      {locale === 'ja' ? '参加費' : 'Fee'}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {race.entry_periods.map((ep) => (
+                    <tr key={ep.id} style={{ borderBottom: '1px solid var(--color-border)' }} className="last:border-0">
+                      <td className="py-2.5 font-medium">
+                        {locale === 'ja' ? ep.label_ja : ep.label_en}
+                      </td>
+                      <td className="py-2.5">
+                        {formatDate(ep.start_date, locale)} — {formatDate(ep.end_date, locale)}
+                      </td>
+                      <td className="py-2.5 text-right">
+                        {ep.entry_fee
+                          ? formatCurrency(ep.entry_fee)
+                          : (!race.entry_fee_by_category && race.entry_fee)
+                            ? formatCurrency(race.entry_fee)
+                            : '—'}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="flex flex-wrap gap-6 mb-4">
+          <div>
+            <p className="text-xs mb-1" style={{ color: 'var(--color-mid)' }}>
+              {locale === 'ja' ? '受付期間' : 'Period'}
+            </p>
+            <p className="font-medium">
+              {race.entry_start_date
+                ? `${formatDate(race.entry_start_date, locale)} — ${race.entry_end_date ? formatDate(race.entry_end_date, locale) : '—'}`
+                : '—'}
+            </p>
+          </div>
+          {!race.entry_fee_by_category && race.entry_fee && (
+            <div>
+              <p className="text-xs mb-1" style={{ color: 'var(--color-mid)' }}>
+                {locale === 'ja' ? '参加費' : 'Fee'}
+              </p>
+              <p className="font-medium">{formatCurrency(race.entry_fee)}</p>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* 定員 */}
+      {race.entry_capacity > 0 && (
+        <div className="mb-4">
+          <p className="text-xs mb-1" style={{ color: 'var(--color-mid)' }}>
+            {locale === 'ja' ? '定員' : 'Capacity'}
+          </p>
+          <p className="font-medium">
+            {race.entry_capacity.toLocaleString()}
+            {locale === 'ja' ? '人' : ' runners'}
+          </p>
+        </div>
+      )}
+
+      {/* エントリーリンク */}
+      {race.entry_links.length > 0 && (
+        <div className="mt-4 flex flex-wrap gap-2">
+          {race.entry_links.map((link) => (
+            <a
+              key={link.id}
+              href={link.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-block px-5 py-2 text-sm font-semibold rounded-[3px] transition-colors no-underline"
+              style={{ background: 'var(--color-primary)', color: 'white' }}
+            >
+              {link.site_name} ↗
+            </a>
+          ))}
+        </div>
+      )}
+
+      {/* 公式サイト */}
+      {race.official_url && (
+        <a
+          href={race.official_url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-block mt-4 px-5 py-2 text-sm font-semibold rounded-[3px] transition-colors no-underline"
+          style={{ background: 'var(--color-cream)', color: 'var(--color-ink)', border: '1px solid var(--color-border)' }}
+        >
+          {locale === 'ja' ? '公式サイト' : 'Official Site'} ↗
+        </a>
+      )}
+    </section>
+  );
+}

--- a/src/components/races/detail/EntrySection.tsx
+++ b/src/components/races/detail/EntrySection.tsx
@@ -8,6 +8,8 @@ interface EntrySectionProps {
 }
 
 export default function EntrySection({ race, locale, today }: EntrySectionProps) {
+  const isPast = race.date < today;
+
   return (
     <section id="entry">
       {/* 受付終了メッセージ */}
@@ -95,7 +97,9 @@ export default function EntrySection({ race, locale, today }: EntrySectionProps)
             <p className="font-medium">
               {race.entry_start_date
                 ? `${formatDate(race.entry_start_date, locale)} — ${race.entry_end_date ? formatDate(race.entry_end_date, locale) : '—'}`
-                : '—'}
+                : (!isPast
+                  ? (locale === 'ja' ? '未発表' : 'TBA')
+                  : '—')}
             </p>
           </div>
           {!race.entry_fee_by_category && race.entry_fee && (

--- a/src/components/races/detail/GallerySection.tsx
+++ b/src/components/races/detail/GallerySection.tsx
@@ -1,0 +1,70 @@
+import type { Race, Locale } from '@/lib/types';
+
+interface GallerySectionProps {
+  race: Race;
+  locale: Locale;
+}
+
+export default function GallerySection({ race, locale }: GallerySectionProps) {
+  const hasGallery = race.gallery.length > 0;
+  const hasVoices = race.voices.length > 0;
+
+  if (!hasGallery && !hasVoices) return null;
+
+  const isJa = locale === 'ja';
+
+  return (
+    <section id="gallery">
+      {/* フォトギャラリー */}
+      {hasGallery && (
+        <div className="mb-8">
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+            {race.gallery.map((item) => (
+              <div key={item.id} className="overflow-hidden rounded-[4px]">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={item.src}
+                  alt={item.caption_ja ?? ''}
+                  className="w-full aspect-[4/3] object-cover"
+                />
+                {(item.caption_ja || item.caption_en) && (
+                  <p
+                    className="text-xs px-2 py-1.5 leading-snug"
+                    style={{ color: 'var(--color-mid)', background: 'white', border: '1px solid var(--color-border)', borderTop: 'none' }}
+                  >
+                    {isJa ? (item.caption_ja ?? item.caption_en) : (item.caption_en ?? item.caption_ja)}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* 参加者の声 */}
+      {hasVoices && (
+        <div className="space-y-3">
+          {race.voices.map((voice, i) => (
+            <div
+              key={i}
+              className="rounded-[4px] p-4"
+              style={{ background: 'var(--color-cream)', border: '1px solid var(--color-border)' }}
+            >
+              <p
+                className="text-sm leading-relaxed mb-2"
+                style={{ color: 'var(--color-ink2)' }}
+              >
+                &ldquo;{voice.quote_ja}&rdquo;
+              </p>
+              {voice.author && (
+                <p className="text-xs font-medium" style={{ color: 'var(--color-mid)' }}>
+                  — {voice.author}
+                </p>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/races/detail/LastEditionSection.tsx
+++ b/src/components/races/detail/LastEditionSection.tsx
@@ -1,0 +1,130 @@
+import type { Race, Locale } from '@/lib/types';
+
+interface LastEditionSectionProps {
+  race: Race;
+  locale: Locale;
+}
+
+export default function LastEditionSection({ race, locale }: LastEditionSectionProps) {
+  const result = race.result;
+  if (!result) return null;
+
+  const isJa = locale === 'ja';
+
+  return (
+    <section id="last-edition">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-3">
+        {result.participants_count !== null && (
+          <div
+            className="rounded-[4px] p-5 text-center"
+            style={{ background: 'white', border: '1px solid var(--color-border)' }}
+          >
+            <p className="text-2xl font-bold" style={{ color: 'var(--color-ink)' }}>
+              {result.participants_count.toLocaleString()}
+            </p>
+            <p className="text-xs mt-0.5" style={{ color: 'var(--color-mid)' }}>
+              {isJa ? '参加者数' : 'Participants'}
+            </p>
+          </div>
+        )}
+        {result.finishers_count !== null && (
+          <div
+            className="rounded-[4px] p-5 text-center"
+            style={{ background: 'white', border: '1px solid var(--color-border)' }}
+          >
+            <p className="text-2xl font-bold" style={{ color: 'var(--color-ink)' }}>
+              {result.finishers_count.toLocaleString()}
+            </p>
+            <p className="text-xs mt-0.5" style={{ color: 'var(--color-mid)' }}>
+              {isJa ? '完走者数' : 'Finishers'}
+            </p>
+          </div>
+        )}
+        {result.finisher_rate_pct !== null && (
+          <div
+            className="rounded-[4px] p-5 text-center"
+            style={{ background: 'white', border: '1px solid var(--color-border)' }}
+          >
+            <p className="text-2xl font-bold" style={{ color: 'var(--color-ink)' }}>
+              {result.finisher_rate_pct.toFixed(1)}%
+            </p>
+            <p className="text-xs mt-0.5" style={{ color: 'var(--color-mid)' }}>
+              {isJa ? '完走率' : 'Finish Rate'}
+            </p>
+          </div>
+        )}
+        {result.temperature_c !== null && (
+          <div
+            className="rounded-[4px] p-5 text-center"
+            style={{ background: 'white', border: '1px solid var(--color-border)' }}
+          >
+            <p className="text-2xl font-bold" style={{ color: 'var(--color-ink)' }}>
+              {result.temperature_c}°C
+            </p>
+            <p className="text-xs mt-0.5" style={{ color: 'var(--color-mid)' }}>
+              {isJa ? '当日気温' : 'Temperature'}
+            </p>
+          </div>
+        )}
+      </div>
+
+      {result.weather_condition_ja && (
+        <div
+          className="rounded-[4px] p-5"
+          style={{ background: 'white', border: '1px solid var(--color-border)' }}
+        >
+          <div className="flex flex-wrap gap-5 text-sm">
+            <div>
+              <p className="text-xs mb-0.5" style={{ color: 'var(--color-mid)' }}>
+                {isJa ? '天気' : 'Weather'}
+              </p>
+              <p className="font-medium">
+                {isJa ? result.weather_condition_ja : result.weather_condition_en}
+              </p>
+            </div>
+            {result.max_temp_c !== null && (
+              <div>
+                <p className="text-xs mb-0.5" style={{ color: 'var(--color-mid)' }}>
+                  {isJa ? '最高気温' : 'Max'}
+                </p>
+                <p className="font-medium" style={{ color: '#c0392b' }}>{result.max_temp_c}°C</p>
+              </div>
+            )}
+            {result.min_temp_c !== null && (
+              <div>
+                <p className="text-xs mb-0.5" style={{ color: 'var(--color-mid)' }}>
+                  {isJa ? '最低気温' : 'Min'}
+                </p>
+                <p className="font-medium" style={{ color: '#2980b9' }}>{result.min_temp_c}°C</p>
+              </div>
+            )}
+            {result.wind_speed_ms !== null && (
+              <div>
+                <p className="text-xs mb-0.5" style={{ color: 'var(--color-mid)' }}>
+                  {isJa ? '風速' : 'Wind'}
+                </p>
+                <p className="font-medium">{result.wind_speed_ms} m/s</p>
+              </div>
+            )}
+            {result.humidity_pct !== null && (
+              <div>
+                <p className="text-xs mb-0.5" style={{ color: 'var(--color-mid)' }}>
+                  {isJa ? '湿度' : 'Humidity'}
+                </p>
+                <p className="font-medium">{result.humidity_pct}%</p>
+              </div>
+            )}
+          </div>
+          {result.notes_ja && (
+            <p
+              className="text-sm mt-3 pt-3 leading-relaxed"
+              style={{ borderTop: '1px solid var(--color-border)', color: 'var(--color-ink2)' }}
+            >
+              {isJa ? result.notes_ja : result.notes_en}
+            </p>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/races/detail/OverviewSection.tsx
+++ b/src/components/races/detail/OverviewSection.tsx
@@ -1,0 +1,43 @@
+import type { Race, Locale } from '@/lib/types';
+
+interface OverviewSectionProps {
+  race: Race;
+  locale: Locale;
+}
+
+export default function OverviewSection({ race, locale }: OverviewSectionProps) {
+  const description =
+    locale === 'en' ? (race.description_en || race.description_ja) : race.description_ja;
+
+  if (!description && race.tags.length === 0) return null;
+
+  return (
+    <section id="overview">
+      {race.tags.length > 0 && (
+        <div className="flex flex-wrap gap-2 mb-4">
+          {race.tags.map((tag) => (
+            <span
+              key={tag}
+              className="text-xs font-semibold px-2.5 py-1 rounded-[3px]"
+              style={{
+                background: 'var(--color-cream)',
+                color: 'var(--color-ink2)',
+                border: '1px solid var(--color-border)',
+              }}
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
+      {description && (
+        <p
+          className="text-base leading-relaxed whitespace-pre-line"
+          style={{ color: 'var(--color-ink2)' }}
+        >
+          {description}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/src/components/races/detail/__tests__/AnchorBar.test.tsx
+++ b/src/components/races/detail/__tests__/AnchorBar.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import AnchorBar from '../AnchorBar';
+
+const items = [
+  { id: 'overview', label: '概要' },
+  { id: 'course', label: 'コース' },
+  { id: 'entry', label: 'エントリー' },
+];
+
+describe('AnchorBar', () => {
+  it('アイテムがアンカーリンクとして描画される', () => {
+    render(<AnchorBar items={items} />);
+    expect(screen.getByText('概要')).toBeInTheDocument();
+    expect(screen.getByText('コース')).toBeInTheDocument();
+    expect(screen.getByText('エントリー')).toBeInTheDocument();
+  });
+
+  it('各リンクの href が #id 形式になっている', () => {
+    const { container } = render(<AnchorBar items={items} />);
+    const links = container.querySelectorAll('a');
+    expect(links[0].getAttribute('href')).toBe('#overview');
+    expect(links[1].getAttribute('href')).toBe('#course');
+    expect(links[2].getAttribute('href')).toBe('#entry');
+  });
+
+  it('アイテムが空のとき何も描画しない', () => {
+    const { container } = render(<AnchorBar items={[]} />);
+    expect(container.querySelector('nav')).toBeNull();
+  });
+
+  it('nav 要素が sticky で描画される', () => {
+    const { container } = render(<AnchorBar items={items} />);
+    const nav = container.querySelector('nav');
+    expect(nav).not.toBeNull();
+    expect(nav?.className).toMatch(/sticky/);
+  });
+
+  it('activeId に一致するリンクが active スタイルを持つ', () => {
+    const { container } = render(<AnchorBar items={items} activeId="course" />);
+    const links = container.querySelectorAll('a');
+    expect(links[1].getAttribute('data-active')).toBe('true');
+    expect(links[0].getAttribute('data-active')).not.toBe('true');
+  });
+});

--- a/src/components/races/detail/__tests__/DetailHeader.test.tsx
+++ b/src/components/races/detail/__tests__/DetailHeader.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import DetailHeader from '../DetailHeader';
+import { makeRace } from '../../../../lib/__tests__/fixtures';
+
+describe('DetailHeader - 基本レンダリング', () => {
+  it('大会名が表示される', () => {
+    const race = makeRace({ name_ja: '長野マラソン2026', date: '2026-04-19' });
+    render(<DetailHeader race={race} locale="ja" raceName="長野マラソン2026" />);
+    expect(screen.getByText('長野マラソン2026')).toBeInTheDocument();
+  });
+
+  it('en ロケールで英語大会名が表示される', () => {
+    const race = makeRace({ name_en: 'Nagano Marathon 2026', date: '2026-04-19' });
+    render(<DetailHeader race={race} locale="en" raceName="Nagano Marathon 2026" />);
+    expect(screen.getByText('Nagano Marathon 2026')).toBeInTheDocument();
+  });
+
+  it('tagline_ja が表示される', () => {
+    const race = makeRace({ tagline_ja: '桜咲く古都を駆け抜けろ。', date: '2026-04-19' });
+    render(<DetailHeader race={race} locale="ja" raceName="長野マラソン2026" />);
+    expect(screen.getByText('桜咲く古都を駆け抜けろ。')).toBeInTheDocument();
+  });
+
+  it('tagline_en が en ロケールで表示される', () => {
+    const race = makeRace({ tagline_en: 'Chase the Cherry Blossoms.', date: '2026-04-19' });
+    render(<DetailHeader race={race} locale="en" raceName="Nagano Marathon 2026" />);
+    expect(screen.getByText('Chase the Cherry Blossoms.')).toBeInTheDocument();
+  });
+
+  it('tagline が null のとき何も表示されない', () => {
+    const race = makeRace({ tagline_ja: null, tagline_en: null, date: '2026-04-19' });
+    const { container } = render(<DetailHeader race={race} locale="ja" raceName="テスト大会" />);
+    expect(container.querySelector('[data-testid="tagline"]')).toBeNull();
+  });
+
+  it('edition が表示される', () => {
+    const race = makeRace({ edition: 51, date: '2026-04-19' });
+    render(<DetailHeader race={race} locale="ja" raceName="テスト大会" />);
+    expect(screen.getByText(/第51回/)).toBeInTheDocument();
+  });
+
+  it('edition が null のとき回次が表示されない', () => {
+    const race = makeRace({ edition: null, date: '2026-04-19' });
+    render(<DetailHeader race={race} locale="ja" raceName="テスト大会" />);
+    expect(screen.queryByText(/第.*回/)).toBeNull();
+  });
+
+  it('motif が表示される', () => {
+    const race = makeRace({ motif: 'SAKURA', date: '2026-04-19' });
+    render(<DetailHeader race={race} locale="ja" raceName="テスト大会" />);
+    expect(screen.getByText('SAKURA')).toBeInTheDocument();
+  });
+
+  it('hero_image_url がある場合 img タグが描画される', () => {
+    const race = makeRace({ hero_image_url: '/images/hero.jpg', date: '2026-04-19' });
+    const { container } = render(<DetailHeader race={race} locale="ja" raceName="テスト大会" />);
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('src')).toBe('/images/hero.jpg');
+  });
+
+  it('hero_image_url が null のとき img タグが描画されない', () => {
+    const race = makeRace({ hero_image_url: null, date: '2026-04-19' });
+    const { container } = render(<DetailHeader race={race} locale="ja" raceName="テスト大会" />);
+    expect(container.querySelector('img')).toBeNull();
+  });
+});

--- a/src/components/races/detail/__tests__/EntrySection.test.tsx
+++ b/src/components/races/detail/__tests__/EntrySection.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import EntrySection from '../EntrySection';
+import { makeRace } from '../../../../lib/__tests__/fixtures';
+
+describe('EntrySection', () => {
+  it('セクションに id="entry" が付く', () => {
+    const race = makeRace({ date: '2026-04-19' });
+    const { container } = render(<EntrySection race={race} locale="ja" today="2026-01-01" />);
+    expect(container.querySelector('#entry')).not.toBeNull();
+  });
+
+  it('entry_closed=true のとき受付終了メッセージが表示される', () => {
+    const race = makeRace({ entry_closed: true, date: '2026-04-19' });
+    render(<EntrySection race={race} locale="ja" today="2026-01-01" />);
+    expect(screen.getByTestId('entry-closed-msg')).toBeInTheDocument();
+  });
+
+  it('entry_closed=false のとき受付終了メッセージが表示されない', () => {
+    const race = makeRace({ entry_closed: false, date: '2026-04-19' });
+    const { container } = render(<EntrySection race={race} locale="ja" today="2026-01-01" />);
+    expect(container.querySelector('[data-testid="entry-closed-msg"]')).toBeNull();
+  });
+
+  it('entry_periods が1件のとき期間が表示される', () => {
+    const race = makeRace({
+      date: '2026-04-19',
+      entry_periods: [{
+        id: 1, race_id: 'test', category_id: null,
+        label_ja: '一般エントリー', label_en: 'General',
+        start_date: '2025-09-01', end_date: '2025-11-30',
+        entry_fee: null, sort_order: 0,
+      }],
+    });
+    render(<EntrySection race={race} locale="ja" today="2025-08-01" />);
+    expect(screen.getByText(/2025/)).toBeInTheDocument();
+  });
+
+  it('entry_links が表示される', () => {
+    const race = makeRace({
+      date: '2026-04-19',
+      entry_links: [{
+        id: 1, race_id: 'test',
+        site_name: 'RunNet', url: 'https://runnet.jp/test', sort_order: 0,
+      }],
+    });
+    render(<EntrySection race={race} locale="ja" today="2026-01-01" />);
+    const link = screen.getByText('RunNet ↗');
+    expect(link).toBeInTheDocument();
+    expect(link.closest('a')?.getAttribute('href')).toBe('https://runnet.jp/test');
+  });
+
+  it('entry_capacity > 0 のとき定員が表示される', () => {
+    const race = makeRace({ entry_capacity: 3000, date: '2026-04-19' });
+    render(<EntrySection race={race} locale="ja" today="2026-01-01" />);
+    expect(screen.getByText(/3,000/)).toBeInTheDocument();
+  });
+
+  it('entry_capacity = 0 のとき定員が表示されない', () => {
+    const race = makeRace({ entry_capacity: 0, date: '2026-04-19' });
+    render(<EntrySection race={race} locale="ja" today="2026-01-01" />);
+    expect(screen.queryByText(/人$/)).toBeNull();
+  });
+});

--- a/src/components/races/detail/__tests__/GallerySection.test.tsx
+++ b/src/components/races/detail/__tests__/GallerySection.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import GallerySection from '../GallerySection';
+import { makeRace, makeGallery, makeVoice } from '../../../../lib/__tests__/fixtures';
+
+describe('GallerySection', () => {
+  it('gallery も voices も空のとき何も描画しない', () => {
+    const race = makeRace({ gallery: [], voices: [], date: '2026-04-19' });
+    const { container } = render(<GallerySection race={race} locale="ja" />);
+    expect(container.querySelector('section')).toBeNull();
+  });
+
+  it('セクションに id="gallery" が付く', () => {
+    const race = makeRace({ gallery: [makeGallery()], date: '2026-04-19' });
+    const { container } = render(<GallerySection race={race} locale="ja" />);
+    expect(container.querySelector('#gallery')).not.toBeNull();
+  });
+
+  it('gallery の画像が描画される', () => {
+    const item = makeGallery({ src: '/images/races/test-1.jpg', caption_ja: '大会写真' });
+    const race = makeRace({ gallery: [item], date: '2026-04-19' });
+    const { container } = render(<GallerySection race={race} locale="ja" />);
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('src')).toBe('/images/races/test-1.jpg');
+  });
+
+  it('ja ロケールで caption_ja が表示される', () => {
+    const item = makeGallery({ caption_ja: '桜のゴールゲート', caption_en: 'Cherry blossom gate' });
+    const race = makeRace({ gallery: [item], date: '2026-04-19' });
+    render(<GallerySection race={race} locale="ja" />);
+    expect(screen.getByText('桜のゴールゲート')).toBeInTheDocument();
+  });
+
+  it('en ロケールで caption_en が表示される', () => {
+    const item = makeGallery({ caption_ja: '桜のゴールゲート', caption_en: 'Cherry blossom gate' });
+    const race = makeRace({ gallery: [item], date: '2026-04-19' });
+    render(<GallerySection race={race} locale="en" />);
+    expect(screen.getByText('Cherry blossom gate')).toBeInTheDocument();
+  });
+
+  it('voices の quote_ja が表示される', () => {
+    const voice = makeVoice({ quote_ja: '最高のコースでした！', author: '田中太郎' });
+    const race = makeRace({ voices: [voice], date: '2026-04-19' });
+    render(<GallerySection race={race} locale="ja" />);
+    expect(screen.getByText(/最高のコースでした！/)).toBeInTheDocument();
+    expect(screen.getByText(/田中太郎/)).toBeInTheDocument();
+  });
+
+  it('voices の author が null のとき匿名表示', () => {
+    const voice = makeVoice({ quote_ja: '楽しかった', author: null });
+    const race = makeRace({ voices: [voice], date: '2026-04-19' });
+    render(<GallerySection race={race} locale="ja" />);
+    expect(screen.getByText(/楽しかった/)).toBeInTheDocument();
+  });
+});

--- a/src/components/races/detail/__tests__/LastEditionSection.test.tsx
+++ b/src/components/races/detail/__tests__/LastEditionSection.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import LastEditionSection from '../LastEditionSection';
+import { makeRace } from '../../../../lib/__tests__/fixtures';
+import type { RaceResult } from '@/lib/types';
+
+const fullResult: RaceResult = {
+  participants_count: 12000,
+  finishers_count: 11500,
+  finisher_rate_pct: 95.8,
+  weather_condition_ja: '晴れ',
+  weather_condition_en: 'Clear',
+  temperature_c: 14,
+  max_temp_c: 18,
+  min_temp_c: 8,
+  wind_speed_ms: 3.2,
+  humidity_pct: 55,
+  notes_ja: null,
+  notes_en: null,
+  avg_time: null,
+};
+
+describe('LastEditionSection', () => {
+  it('result が null のとき何も描画しない', () => {
+    const race = makeRace({ result: null, date: '2026-04-19' });
+    const { container } = render(<LastEditionSection race={race} locale="ja" />);
+    expect(container.querySelector('section')).toBeNull();
+  });
+
+  it('セクションに id="last-edition" が付く', () => {
+    const race = makeRace({ result: fullResult, date: '2026-04-19' });
+    const { container } = render(<LastEditionSection race={race} locale="ja" />);
+    expect(container.querySelector('#last-edition')).not.toBeNull();
+  });
+
+  it('参加者数が表示される', () => {
+    const race = makeRace({ result: fullResult, date: '2026-04-19' });
+    render(<LastEditionSection race={race} locale="ja" />);
+    expect(screen.getByText('12,000')).toBeInTheDocument();
+  });
+
+  it('完走率が表示される', () => {
+    const race = makeRace({ result: fullResult, date: '2026-04-19' });
+    render(<LastEditionSection race={race} locale="ja" />);
+    expect(screen.getByText('95.8%')).toBeInTheDocument();
+  });
+
+  it('当日気温が表示される', () => {
+    const race = makeRace({ result: fullResult, date: '2026-04-19' });
+    render(<LastEditionSection race={race} locale="ja" />);
+    expect(screen.getByText(/14°C/)).toBeInTheDocument();
+  });
+
+  it('en ロケールで weather_condition_en が表示される', () => {
+    const race = makeRace({ result: fullResult, date: '2026-04-19' });
+    render(<LastEditionSection race={race} locale="en" />);
+    expect(screen.getByText('Clear')).toBeInTheDocument();
+  });
+
+  it('participants_count が null のとき参加者数カードが描画されない', () => {
+    const result: RaceResult = { ...fullResult, participants_count: null };
+    const race = makeRace({ result, date: '2026-04-19' });
+    render(<LastEditionSection race={race} locale="ja" />);
+    expect(screen.queryByText(/参加者数/)).toBeNull();
+  });
+});

--- a/src/components/races/detail/__tests__/OverviewSection.test.tsx
+++ b/src/components/races/detail/__tests__/OverviewSection.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import OverviewSection from '../OverviewSection';
+import { makeRace } from '../../../../lib/__tests__/fixtures';
+
+describe('OverviewSection', () => {
+  it('ja ロケールで description_ja が表示される', () => {
+    const race = makeRace({ description_ja: '桜並木を走る春の大会。', date: '2026-04-19' });
+    render(<OverviewSection race={race} locale="ja" />);
+    expect(screen.getByText('桜並木を走る春の大会。')).toBeInTheDocument();
+  });
+
+  it('en ロケールで description_en が表示される', () => {
+    const race = makeRace({ description_en: 'A spring race along cherry blossoms.', date: '2026-04-19' });
+    render(<OverviewSection race={race} locale="en" />);
+    expect(screen.getByText('A spring race along cherry blossoms.')).toBeInTheDocument();
+  });
+
+  it('description_en が null のとき description_ja にフォールバック', () => {
+    const race = makeRace({ description_ja: '日本語説明', description_en: null, date: '2026-04-19' });
+    render(<OverviewSection race={race} locale="en" />);
+    expect(screen.getByText('日本語説明')).toBeInTheDocument();
+  });
+
+  it('description_ja が空文字のとき何も描画しない', () => {
+    const race = makeRace({ description_ja: '', description_en: '', date: '2026-04-19' });
+    const { container } = render(<OverviewSection race={race} locale="ja" />);
+    expect(container.querySelector('section')).toBeNull();
+  });
+
+  it('セクションに id="overview" が付く', () => {
+    const race = makeRace({ description_ja: 'テスト', date: '2026-04-19' });
+    const { container } = render(<OverviewSection race={race} locale="ja" />);
+    expect(container.querySelector('#overview')).not.toBeNull();
+  });
+
+  it('tags が表示される', () => {
+    const race = makeRace({ tags: ['ファミリー', '公認コース'], date: '2026-04-19' });
+    render(<OverviewSection race={race} locale="ja" />);
+    expect(screen.getByText('ファミリー')).toBeInTheDocument();
+    expect(screen.getByText('公認コース')).toBeInTheDocument();
+  });
+});

--- a/src/lib/__tests__/fixtures.ts
+++ b/src/lib/__tests__/fixtures.ts
@@ -1,4 +1,4 @@
-import type { Race, RaceCategory, EntryPeriod, EntryLink } from '../types';
+import type { Race, RaceCategory, EntryPeriod, EntryLink, RaceGallery, RaceVoice, RaceTimeBucket, RaceCourseHighlight } from '../types';
 
 /** テスト用の最小限 Race オブジェクトを生成するファクトリ */
 export function makeRace(overrides: Partial<Race> = {}): Race {
@@ -48,6 +48,10 @@ export function makeRace(overrides: Partial<Race> = {}): Race {
     entry_periods: [],
     entry_links: [],
     result: null,
+    gallery: [],
+    voices: [],
+    time_buckets: [],
+    course_highlights: [],
     motif: null,
     motif_color: null,
     motif_romaji: null,
@@ -104,6 +108,54 @@ export function makeEntryPeriod(overrides: Partial<EntryPeriod> = {}): EntryPeri
     start_date: '2026-04-01',
     end_date: '2026-06-30',
     entry_fee: null,
+    sort_order: 0,
+    ...overrides,
+  };
+}
+
+export function makeGallery(overrides: Partial<RaceGallery> = {}): RaceGallery {
+  return {
+    id: 1,
+    race_id: 'test-race-2026',
+    src: '/images/races/test-race-2026-1.jpg',
+    caption_ja: 'テストキャプション',
+    caption_en: 'Test caption',
+    sort_order: 0,
+    ...overrides,
+  };
+}
+
+export function makeVoice(overrides: Partial<RaceVoice> = {}): RaceVoice {
+  return {
+    id: 1,
+    race_id: 'test-race-2026',
+    quote_ja: 'とても楽しいレースでした。',
+    author: '40代男性',
+    sort_order: 0,
+    ...overrides,
+  };
+}
+
+export function makeTimeBucket(overrides: Partial<RaceTimeBucket> = {}): RaceTimeBucket {
+  return {
+    id: 1,
+    race_id: 'test-race-2026',
+    bucket: '4:00–4:30',
+    pct: 25.0,
+    sort_order: 0,
+    ...overrides,
+  };
+}
+
+export function makeCourseHighlight(overrides: Partial<RaceCourseHighlight> = {}): RaceCourseHighlight {
+  return {
+    id: 1,
+    race_id: 'test-race-2026',
+    km: 21.0,
+    name_ja: '折り返し地点',
+    name_en: 'Turnaround Point',
+    note_ja: '眺望が素晴らしい',
+    note_en: 'Great views',
     sort_order: 0,
     ...overrides,
   };

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -6,6 +6,7 @@ import type {
   AidStation, Checkpoint, AccessPoint, NearbySpot, WeatherHistory,
   ParticipationGift, GiftCategoryId, CourseSurface, ReceptionType, NearbySpotType,
   RaceSeries, RaceResult, EntryPeriod, EntryLink,
+  RaceGallery, RaceVoice, RaceTimeBucket, RaceCourseHighlight,
 } from "./types";
 
 // ==================
@@ -160,6 +161,55 @@ function rowToResult(row: ResultRow): RaceResult {
   };
 }
 
+type GalleryRow = typeof schema.race_gallery.$inferSelect;
+type VoiceRow = typeof schema.race_voices.$inferSelect;
+type TimeBucketRow = typeof schema.race_time_buckets.$inferSelect;
+type CourseHighlightRow = typeof schema.race_course_highlights.$inferSelect;
+
+function rowToGallery(row: GalleryRow): RaceGallery {
+  return {
+    id: row.id,
+    race_id: row.race_id,
+    src: row.src,
+    caption_ja: row.caption_ja ?? null,
+    caption_en: row.caption_en ?? null,
+    sort_order: row.sort_order,
+  };
+}
+
+function rowToVoice(row: VoiceRow): RaceVoice {
+  return {
+    id: row.id,
+    race_id: row.race_id,
+    quote_ja: row.quote_ja,
+    author: row.author ?? null,
+    sort_order: row.sort_order,
+  };
+}
+
+function rowToTimeBucket(row: TimeBucketRow): RaceTimeBucket {
+  return {
+    id: row.id,
+    race_id: row.race_id,
+    bucket: row.bucket,
+    pct: row.pct,
+    sort_order: row.sort_order,
+  };
+}
+
+function rowToCourseHighlight(row: CourseHighlightRow): RaceCourseHighlight {
+  return {
+    id: row.id,
+    race_id: row.race_id,
+    km: row.km,
+    name_ja: row.name_ja,
+    name_en: row.name_en ?? null,
+    note_ja: row.note_ja ?? null,
+    note_en: row.note_en ?? null,
+    sort_order: row.sort_order,
+  };
+}
+
 function assembleRace(
   row: RaceRow,
   categories: CategoryRow[],
@@ -172,6 +222,10 @@ function assembleRace(
   resultRows: ResultRow[] = [],
   entryPeriodRows: EntryPeriodRow[] = [],
   entryLinkRows: EntryLinkRow[] = [],
+  galleryRows: GalleryRow[] = [],
+  voiceRows: VoiceRow[] = [],
+  timeBucketRows: TimeBucketRow[] = [],
+  courseHighlightRows: CourseHighlightRow[] = [],
 ): Race {
   const course_info: CourseInfo = {
     max_elevation_m: row.course_max_elevation_m,
@@ -221,6 +275,10 @@ function assembleRace(
     entry_periods: entryPeriodRows.map(rowToEntryPeriod),
     entry_links: entryLinkRows.map(rowToEntryLink),
     result: resultRows.length > 0 ? rowToResult(resultRows[0]) : null,
+    gallery:           galleryRows.map(rowToGallery),
+    voices:            voiceRows.map(rowToVoice),
+    time_buckets:      timeBucketRows.map(rowToTimeBucket),
+    course_highlights: courseHighlightRows.map(rowToCourseHighlight),
     motif:           row.motif ?? null,
     motif_color:     row.motif_color ?? null,
     motif_romaji:    row.motif_romaji ?? null,
@@ -263,7 +321,7 @@ export async function getRaces(): Promise<Race[]> {
 export async function getRaceById(id: string): Promise<Race | null> {
   const db = getDatabase();
 
-  const [raceRows, categoryRows, aidRows, checkRows, accessRows, spotRows, weatherRows, giftRows, resultRows, entryPeriodRows, entryLinkRows] =
+  const [raceRows, categoryRows, aidRows, checkRows, accessRows, spotRows, weatherRows, giftRows, resultRows, entryPeriodRows, entryLinkRows, galleryRows, voiceRows, timeBucketRows, courseHighlightRows] =
     await db.batch([
       db.select().from(schema.races).where(eq(schema.races.id, id)),
       db.select().from(schema.race_categories).where(eq(schema.race_categories.race_id, id)).orderBy(asc(schema.race_categories.sort_order)),
@@ -276,12 +334,16 @@ export async function getRaceById(id: string): Promise<Race | null> {
       db.select().from(schema.race_results).where(eq(schema.race_results.race_id, id)),
       db.select().from(schema.race_entry_periods).where(eq(schema.race_entry_periods.race_id, id)).orderBy(asc(schema.race_entry_periods.sort_order)),
       db.select().from(schema.race_entry_links).where(eq(schema.race_entry_links.race_id, id)).orderBy(asc(schema.race_entry_links.sort_order)),
+      db.select().from(schema.race_gallery).where(eq(schema.race_gallery.race_id, id)).orderBy(asc(schema.race_gallery.sort_order)),
+      db.select().from(schema.race_voices).where(eq(schema.race_voices.race_id, id)).orderBy(asc(schema.race_voices.sort_order)),
+      db.select().from(schema.race_time_buckets).where(eq(schema.race_time_buckets.race_id, id)).orderBy(asc(schema.race_time_buckets.sort_order)),
+      db.select().from(schema.race_course_highlights).where(eq(schema.race_course_highlights.race_id, id)).orderBy(asc(schema.race_course_highlights.sort_order)),
     ]);
 
   const row = raceRows[0];
   if (!row) return null;
 
-  return assembleRace(row, categoryRows, aidRows, checkRows, accessRows, spotRows, weatherRows, giftRows, resultRows, entryPeriodRows, entryLinkRows);
+  return assembleRace(row, categoryRows, aidRows, checkRows, accessRows, spotRows, weatherRows, giftRows, resultRows, entryPeriodRows, entryLinkRows, galleryRows, voiceRows, timeBucketRows, courseHighlightRows);
 }
 
 export async function getRacesByPrefecture(prefecture: string): Promise<Race[]> {

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -360,6 +360,66 @@ export const contact_submissions = sqliteTable("contact_submissions", {
 ]);
 
 // ==================
+// race_gallery (大会画像ギャラリー)
+// ==================
+
+export const race_gallery = sqliteTable("race_gallery", {
+  id:         integer("id").primaryKey({ autoIncrement: true }),
+  race_id:    text("race_id").notNull().references(() => races.id, { onDelete: "cascade" }),
+  src:        text("src").notNull(),
+  caption_ja: text("caption_ja"),
+  caption_en: text("caption_en"),
+  sort_order: integer("sort_order").notNull().default(0),
+}, (t) => [
+  index("race_gallery_race_id_idx").on(t.race_id),
+]);
+
+// ==================
+// race_voices (参加者の声)
+// ==================
+
+export const race_voices = sqliteTable("race_voices", {
+  id:         integer("id").primaryKey({ autoIncrement: true }),
+  race_id:    text("race_id").notNull().references(() => races.id, { onDelete: "cascade" }),
+  quote_ja:   text("quote_ja").notNull(),
+  author:     text("author"),
+  sort_order: integer("sort_order").notNull().default(0),
+}, (t) => [
+  index("race_voices_race_id_idx").on(t.race_id),
+]);
+
+// ==================
+// race_time_buckets (タイム分布)
+// ==================
+
+export const race_time_buckets = sqliteTable("race_time_buckets", {
+  id:         integer("id").primaryKey({ autoIncrement: true }),
+  race_id:    text("race_id").notNull().references(() => races.id, { onDelete: "cascade" }),
+  bucket:     text("bucket").notNull(),  // e.g. "3:30–4:00"
+  pct:        real("pct").notNull(),     // 割合 (0–100)
+  sort_order: integer("sort_order").notNull().default(0),
+}, (t) => [
+  index("race_time_buckets_race_id_idx").on(t.race_id),
+]);
+
+// ==================
+// race_course_highlights (コース見どころ)
+// ==================
+
+export const race_course_highlights = sqliteTable("race_course_highlights", {
+  id:         integer("id").primaryKey({ autoIncrement: true }),
+  race_id:    text("race_id").notNull().references(() => races.id, { onDelete: "cascade" }),
+  km:         real("km").notNull(),
+  name_ja:    text("name_ja").notNull(),
+  name_en:    text("name_en"),
+  note_ja:    text("note_ja"),
+  note_en:    text("note_en"),
+  sort_order: integer("sort_order").notNull().default(0),
+}, (t) => [
+  index("race_course_highlights_race_id_idx").on(t.race_id),
+]);
+
+// ==================
 // user_races (ユーザー大会登録)
 // ==================
 
@@ -395,6 +455,26 @@ export const racesRelations = relations(races, ({ many, one }) => ({
   entry_periods:       many(race_entry_periods),
   entry_links:         many(race_entry_links),
   result:              one(race_results, { fields: [races.id], references: [race_results.race_id] }),
+  gallery:             many(race_gallery),
+  voices:              many(race_voices),
+  time_buckets:        many(race_time_buckets),
+  course_highlights:   many(race_course_highlights),
+}));
+
+export const raceGalleryRelations = relations(race_gallery, ({ one }) => ({
+  race: one(races, { fields: [race_gallery.race_id], references: [races.id] }),
+}));
+
+export const raceVoicesRelations = relations(race_voices, ({ one }) => ({
+  race: one(races, { fields: [race_voices.race_id], references: [races.id] }),
+}));
+
+export const raceTimeBucketsRelations = relations(race_time_buckets, ({ one }) => ({
+  race: one(races, { fields: [race_time_buckets.race_id], references: [races.id] }),
+}));
+
+export const raceCourseHighlightsRelations = relations(race_course_highlights, ({ one }) => ({
+  race: one(races, { fields: [race_course_highlights.race_id], references: [races.id] }),
 }));
 
 export const raceEntryLinksRelations = relations(race_entry_links, ({ one }) => ({

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -49,6 +49,10 @@ export interface Race {
   entry_periods: EntryPeriod[];
   entry_links: EntryLink[];
   result: RaceResult | null;      // 開催実績（未開催の場合は null）
+  gallery: RaceGallery[];
+  voices: RaceVoice[];
+  time_buckets: RaceTimeBucket[];
+  course_highlights: RaceCourseHighlight[];
   // Phase 2: ビジュアル拡張フィールド
   motif: string | null;
   motif_color: string | null;
@@ -247,6 +251,58 @@ export interface RaceSeries {
   name_en: string;        // "Nagano Marathon"
   first_held_year: number | null;
   website_url: string | null;
+}
+
+// ==================
+// RaceGallery
+// ==================
+
+export interface RaceGallery {
+  id: number;
+  race_id: string;
+  src: string;
+  caption_ja: string | null;
+  caption_en: string | null;
+  sort_order: number;
+}
+
+// ==================
+// RaceVoice
+// ==================
+
+export interface RaceVoice {
+  id: number;
+  race_id: string;
+  quote_ja: string;
+  author: string | null;
+  sort_order: number;
+}
+
+// ==================
+// RaceTimeBucket
+// ==================
+
+export interface RaceTimeBucket {
+  id: number;
+  race_id: string;
+  bucket: string;
+  pct: number;
+  sort_order: number;
+}
+
+// ==================
+// RaceCourseHighlight
+// ==================
+
+export interface RaceCourseHighlight {
+  id: number;
+  race_id: string;
+  km: number;
+  name_ja: string;
+  name_en: string | null;
+  note_ja: string | null;
+  note_en: string | null;
+  sort_order: number;
 }
 
 // ==================

--- a/tools/admin/app.js
+++ b/tools/admin/app.js
@@ -211,9 +211,123 @@ function populateForm(r) {
   setVal('f-hero_caption_ja', r.hero_caption_ja ?? '');
   setVal('f-hero_caption_en', r.hero_caption_en ?? '');
 
+  // Phase 3: ギャラリー / 声 / タイム分布 / コース見どころ
+  renderGallery(r.gallery ?? []);
+  renderVoices(r.voices ?? []);
+  renderTimeBuckets(r.time_buckets ?? []);
+  renderCourseHighlights(r.course_highlights ?? []);
+
   // 画像
   loadImagePreview(r.id);
 }
+
+// ── ギャラリー ────────────────────────────────────────────────────
+function renderGallery(items) {
+  const c = document.getElementById('gallery-container');
+  c.innerHTML = '';
+  items.forEach(g => addGalleryRow(g));
+}
+function addGalleryRow(g = {}) {
+  const c = document.getElementById('gallery-container');
+  const row = document.createElement('div');
+  row.className = 'dynamic-row';
+  row.innerHTML = `
+    <input type="text" class="g-src" placeholder="画像パス / URL" value="${(g.src ?? '').replace(/"/g, '&quot;')}" />
+    <input type="text" class="g-caption-ja" placeholder="キャプション（日本語）" value="${(g.caption_ja ?? '').replace(/"/g, '&quot;')}" />
+    <input type="text" class="g-caption-en" placeholder="Caption (English)" value="${(g.caption_en ?? '').replace(/"/g, '&quot;')}" />
+    <button type="button" class="btn-remove" title="削除">×</button>`;
+  row.querySelector('.btn-remove').addEventListener('click', () => row.remove());
+  c.appendChild(row);
+}
+function collectGallery() {
+  return [...document.querySelectorAll('#gallery-container .dynamic-row')].map(row => ({
+    src: row.querySelector('.g-src').value.trim(),
+    caption_ja: row.querySelector('.g-caption-ja').value.trim() || null,
+    caption_en: row.querySelector('.g-caption-en').value.trim() || null,
+  })).filter(g => g.src);
+}
+document.getElementById('btn-add-gallery').addEventListener('click', () => addGalleryRow());
+
+// ── 参加者の声 ───────────────────────────────────────────────────
+function renderVoices(items) {
+  const c = document.getElementById('voices-container');
+  c.innerHTML = '';
+  items.forEach(v => addVoiceRow(v));
+}
+function addVoiceRow(v = {}) {
+  const c = document.getElementById('voices-container');
+  const row = document.createElement('div');
+  row.className = 'dynamic-row';
+  row.innerHTML = `
+    <textarea class="v-quote-ja" placeholder="コメント（日本語）" rows="2">${v.quote_ja ?? ''}</textarea>
+    <input type="text" class="v-author" placeholder="発言者（例: 40代男性）" value="${(v.author ?? '').replace(/"/g, '&quot;')}" />
+    <button type="button" class="btn-remove" title="削除">×</button>`;
+  row.querySelector('.btn-remove').addEventListener('click', () => row.remove());
+  c.appendChild(row);
+}
+function collectVoices() {
+  return [...document.querySelectorAll('#voices-container .dynamic-row')].map(row => ({
+    quote_ja: row.querySelector('.v-quote-ja').value.trim(),
+    author: row.querySelector('.v-author').value.trim() || null,
+  })).filter(v => v.quote_ja);
+}
+document.getElementById('btn-add-voice').addEventListener('click', () => addVoiceRow());
+
+// ── タイム分布 ───────────────────────────────────────────────────
+function renderTimeBuckets(items) {
+  const c = document.getElementById('time-buckets-container');
+  c.innerHTML = '';
+  items.forEach(tb => addTimeBucketRow(tb));
+}
+function addTimeBucketRow(tb = {}) {
+  const c = document.getElementById('time-buckets-container');
+  const row = document.createElement('div');
+  row.className = 'dynamic-row';
+  row.innerHTML = `
+    <input type="text" class="tb-bucket" placeholder='例: "3:30–4:00"' value="${(tb.bucket ?? '').replace(/"/g, '&quot;')}" />
+    <input type="number" class="tb-pct" placeholder="割合(%)" step="0.1" min="0" max="100" value="${tb.pct ?? ''}" />
+    <button type="button" class="btn-remove" title="削除">×</button>`;
+  row.querySelector('.btn-remove').addEventListener('click', () => row.remove());
+  c.appendChild(row);
+}
+function collectTimeBuckets() {
+  return [...document.querySelectorAll('#time-buckets-container .dynamic-row')].map(row => ({
+    bucket: row.querySelector('.tb-bucket').value.trim(),
+    pct: parseFloat(row.querySelector('.tb-pct').value) || 0,
+  })).filter(tb => tb.bucket);
+}
+document.getElementById('btn-add-time-bucket').addEventListener('click', () => addTimeBucketRow());
+
+// ── コース見どころ ───────────────────────────────────────────────
+function renderCourseHighlights(items) {
+  const c = document.getElementById('course-highlights-container');
+  c.innerHTML = '';
+  items.forEach(ch => addCourseHighlightRow(ch));
+}
+function addCourseHighlightRow(ch = {}) {
+  const c = document.getElementById('course-highlights-container');
+  const row = document.createElement('div');
+  row.className = 'dynamic-row';
+  row.innerHTML = `
+    <input type="number" class="ch-km" placeholder="地点(km)" step="0.1" min="0" value="${ch.km ?? ''}" />
+    <input type="text" class="ch-name-ja" placeholder="スポット名（日本語）" value="${(ch.name_ja ?? '').replace(/"/g, '&quot;')}" />
+    <input type="text" class="ch-name-en" placeholder="Spot name (English)" value="${(ch.name_en ?? '').replace(/"/g, '&quot;')}" />
+    <input type="text" class="ch-note-ja" placeholder="説明（日本語）" value="${(ch.note_ja ?? '').replace(/"/g, '&quot;')}" />
+    <input type="text" class="ch-note-en" placeholder="Note (English)" value="${(ch.note_en ?? '').replace(/"/g, '&quot;')}" />
+    <button type="button" class="btn-remove" title="削除">×</button>`;
+  row.querySelector('.btn-remove').addEventListener('click', () => row.remove());
+  c.appendChild(row);
+}
+function collectCourseHighlights() {
+  return [...document.querySelectorAll('#course-highlights-container .dynamic-row')].map(row => ({
+    km: parseFloat(row.querySelector('.ch-km').value) || 0,
+    name_ja: row.querySelector('.ch-name-ja').value.trim(),
+    name_en: row.querySelector('.ch-name-en').value.trim() || null,
+    note_ja: row.querySelector('.ch-note-ja').value.trim() || null,
+    note_en: row.querySelector('.ch-note-en').value.trim() || null,
+  })).filter(ch => ch.name_ja);
+}
+document.getElementById('btn-add-course-highlight').addEventListener('click', () => addCourseHighlightRow());
 
 function setVal(id, val) {
   const el = document.getElementById(id);
@@ -817,6 +931,11 @@ function buildRaceData() {
     hero_image_url: getVal('f-hero_image_url') || null,
     hero_caption_ja: getVal('f-hero_caption_ja') || null,
     hero_caption_en: getVal('f-hero_caption_en') || null,
+    // Phase 3
+    gallery: collectGallery(),
+    voices: collectVoices(),
+    time_buckets: collectTimeBuckets(),
+    course_highlights: collectCourseHighlights(),
   };
 }
 

--- a/tools/admin/index.html
+++ b/tools/admin/index.html
@@ -285,6 +285,34 @@
             </div>
           </section>
 
+          <!-- ギャラリー (Phase 3) -->
+          <section class="form-section">
+            <h2 class="section-title">ギャラリー</h2>
+            <div id="gallery-container"></div>
+            <button type="button" class="btn btn-secondary" id="btn-add-gallery">+ 画像を追加</button>
+          </section>
+
+          <!-- 参加者の声 (Phase 3) -->
+          <section class="form-section">
+            <h2 class="section-title">参加者の声</h2>
+            <div id="voices-container"></div>
+            <button type="button" class="btn btn-secondary" id="btn-add-voice">+ 声を追加</button>
+          </section>
+
+          <!-- タイム分布 (Phase 3) -->
+          <section class="form-section">
+            <h2 class="section-title">タイム分布</h2>
+            <div id="time-buckets-container"></div>
+            <button type="button" class="btn btn-secondary" id="btn-add-time-bucket">+ バケットを追加</button>
+          </section>
+
+          <!-- コース見どころ (Phase 3) -->
+          <section class="form-section">
+            <h2 class="section-title">コース見どころ</h2>
+            <div id="course-highlights-container"></div>
+            <button type="button" class="btn btn-secondary" id="btn-add-course-highlight">+ 見どころを追加</button>
+          </section>
+
         </div><!-- /form-body -->
       </div><!-- /editor -->
 


### PR DESCRIPTION
## 概要

Issue #43 Phase 3 の実装。詳細ページに新テーブル（gallery/voices/time_buckets/course_highlights）対応と、コンポーネント分割によるリデザインを行った。

## 変更内容

### スキーマ・データ層
- `race_gallery` / `race_voices` / `race_time_buckets` / `race_course_highlights` テーブルを追加
- `src/lib/types.ts`: 4型インターフェース追加、`Race` に配列フィールド追加
- `src/lib/data.ts`: `getRaceById()` に4テーブルのクエリ追加
- `scripts/generate-seed-races.js` / `tools/admin/`: 4テーブル対応

### 新コンポーネント（TDD）
- `DetailHeader`: ヒーロービジュアル（motif カラー背景・ヒーロー画像・タグライン）
- `AnchorBar`: sticky セクションナビ
- `OverviewSection`: 概要・タグ表示
- `EntrySection`: エントリー情報・受付終了表示
- `LastEditionSection`: 前回大会実績
- `GallerySection`: ギャラリー・参加者の声

### ページ再構成
- `src/app/[locale]/races/[id]/page.tsx`: 上記コンポーネントで詳細ページを再構成

## テスト
- 新規 42 テスト追加（全 227 テスト通過）

https://claude.ai/code/session_01MeSiixT1wrzhANhurNwrnK