### PR TITLE
feat: カレンダーページPhase4 強化（Issue #44）

### DIFF
--- a/docs/update-history.md
+++ b/docs/update-history.md
@@ -501,3 +501,12 @@
 - `src/components/races/detail/LastEditionSection.tsx`: 前回大会実績コンポーネント（TDD）
 - `src/components/races/detail/GallerySection.tsx`: ギャラリー・参加者の声コンポーネント（TDD）
 - `src/app/[locale]/races/[id]/page.tsx`: 新コンポーネントで詳細ページを再構成
+
+## 2026-05-05 カレンダーページPhase4 強化（Issue #44）
+
+- `src/components/calendar/ControlBar.tsx`: STATUS/REGION フィルター UI（TDD）
+- `src/components/calendar/HoverCard.tsx`: ホバー時ミニカード（TDD）
+- `src/components/calendar/MonthGrid.tsx`: 月送りグリッド Client Component（TDD）
+- `src/components/calendar/YearTimeline.tsx`: SVG ベース年間タイムライン（TDD）
+- `src/components/calendar/CalendarView.tsx`: ビュー切替・フィルター統合ラッパー（TDD）
+- `src/app/[locale]/calendar/page.tsx`: CalendarView で再構成、デザイントークン統一

--- a/src/app/[locale]/calendar/page.tsx
+++ b/src/app/[locale]/calendar/page.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
-import { getRaces } from '@/lib/data';
+import { getRaces, getPrefectures } from '@/lib/data';
 import { getTodayJST } from '@/lib/utils';
 import { Link } from '@/i18n/navigation';
-import type { Race, EntryPeriod } from '@/lib/types';
+import type { Locale } from '@/lib/types';
+import CalendarView from '@/components/calendar/CalendarView';
 
 export async function generateMetadata({
   params,
@@ -15,22 +16,6 @@ export async function generateMetadata({
   return { title: t('title') };
 }
 
-function getDaysInMonth(year: number, month: number): number {
-  return new Date(year, month + 1, 0).getDate();
-}
-
-function getFirstDayOfMonth(year: number, month: number): number {
-  return new Date(year, month, 1).getDay();
-}
-
-type EntryBand = {
-  race: Race;
-  period: EntryPeriod;
-  isStart: boolean;    // actual period start_date
-  isEnd: boolean;      // actual period end_date
-  isRowStart: boolean; // Sunday continuation (not actual start)
-};
-
 export default async function CalendarPage({
   params,
   searchParams,
@@ -38,264 +23,85 @@ export default async function CalendarPage({
   params: Promise<{ locale: string }>;
   searchParams: Promise<{ year?: string; month?: string }>;
 }) {
-  const { locale } = await params;
+  const { locale: rawLocale } = await params;
+  const locale = rawLocale as Locale;
   const sp = await searchParams;
-  const todayJST = getTodayJST(); // 例: '2026-04-14'
+  const todayJST = getTodayJST();
   const [todayYear, todayMonth0] = todayJST.split('-').map(Number);
   const year = parseInt(sp.year ?? String(todayYear));
   const month = parseInt(sp.month ?? String(todayMonth0 - 1)); // 0-indexed
 
   const t = await getTranslations({ locale, namespace: 'calendar' });
   const tNav = await getTranslations({ locale, namespace: 'nav' });
-  const races = await getRaces();
+  const isJa = locale === 'ja';
 
-  // Race day events
-  const raceDaysByDate = new Map<string, Race[]>();
-  races.forEach((race) => {
-    const key = race.date.split('T')[0];
-    if (!raceDaysByDate.has(key)) raceDaysByDate.set(key, []);
-    raceDaysByDate.get(key)!.push(race);
-  });
+  const [races, prefectures] = await Promise.all([getRaces(), getPrefectures()]);
 
-  // Entry period bands: expand each entry period into per-day entries
-  const entryBandsByDate = new Map<string, EntryBand[]>();
-  const monthStart = new Date(year, month, 1);
-  const monthEnd = new Date(year, month + 1, 0);
-
-  // ── Lane assignment ─────────────────────────────────────────────────────────
-  // 各エントリー期間に固定レーン番号を割り当て、複数日にまたがる帯が
-  // 毎日同じ行に表示されるようにする（Googleカレンダー方式）
-  interface PeriodEntry {
-    race: Race;
-    period: EntryPeriod;
-    effectiveStart: string;
-    effectiveEnd: string;
-    key: string;
-  }
-  const allPeriods: PeriodEntry[] = [];
-
-  races.forEach((race) => {
-    const periods = race.entry_periods ?? [];
-    // Fallback to old fields if no entry_periods
-    const effectivePeriods = periods.length > 0
-      ? periods
-      : (race.entry_start_date && race.entry_end_date
-          ? [{ id: 0, race_id: race.id, category_id: null, label_ja: '一般エントリー', label_en: 'General Entry', start_date: race.entry_start_date.split('T')[0], end_date: race.entry_end_date.split('T')[0], entry_fee: null, sort_order: 0 }]
-          : []);
-
-    effectivePeriods.forEach((period) => {
-      const periodStart = new Date(period.start_date + 'T00:00:00');
-      const periodEnd = new Date(period.end_date + 'T00:00:00');
-
-      // Skip if no overlap with current month
-      if (periodStart > monthEnd || periodEnd < monthStart) return;
-
-      const effectiveStart = periodStart < monthStart ? monthStart : periodStart;
-      const effectiveEnd = periodEnd > monthEnd ? monthEnd : periodEnd;
-      const effStartStr = `${year}-${String(effectiveStart.getMonth() + 1).padStart(2, '0')}-${String(effectiveStart.getDate()).padStart(2, '0')}`;
-      const effEndStr = `${year}-${String(effectiveEnd.getMonth() + 1).padStart(2, '0')}-${String(effectiveEnd.getDate()).padStart(2, '0')}`;
-
-      allPeriods.push({
-        race,
-        period,
-        effectiveStart: effStartStr,
-        effectiveEnd: effEndStr,
-        key: `${race.id}__${period.id ?? period.start_date}`,
-      });
-
-      let cur = new Date(effectiveStart.getTime());
-      while (cur <= effectiveEnd) {
-        const d = cur.getDate();
-        const dateStr = `${year}-${String(month + 1).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
-        const dow = cur.getDay();
-        if (!entryBandsByDate.has(dateStr)) entryBandsByDate.set(dateStr, []);
-        entryBandsByDate.get(dateStr)!.push({
-          race,
-          period,
-          isStart: dateStr === period.start_date,
-          isEnd: dateStr === period.end_date,
-          isRowStart: (dow === 0 || d === 1) && dateStr !== period.start_date,
-        });
-        cur = new Date(cur.getTime() + 86400000);
-      }
-    });
-  });
-
-  // 開始日順にソートしてから貪欲法でレーン割り当て
-  allPeriods.sort((a, b) =>
-    a.effectiveStart !== b.effectiveStart
-      ? a.effectiveStart.localeCompare(b.effectiveStart)
-      : a.race.name_ja.localeCompare(b.race.name_ja),
+  // prefecture コード → 地方名のマップ
+  const prefToRegion = Object.fromEntries(
+    prefectures.map((p) => [p.code, isJa ? p.region : p.regionEn])
   );
-  const laneMap = new Map<string, number>();
-  const laneLastEnd: string[] = [];
-  for (const pe of allPeriods) {
-    let lane = laneLastEnd.findIndex((end) => end < pe.effectiveStart);
-    if (lane === -1) lane = laneLastEnd.length;
-    laneLastEnd[lane] = pe.effectiveEnd;
-    laneMap.set(pe.key, lane);
-  }
-  const totalLanes = laneLastEnd.length;
 
-  const daysInMonth = getDaysInMonth(year, month);
-  const firstDay = getFirstDayOfMonth(year, month);
+  // 地方名一覧（重複排除・順序保持）
+  const regions = [...new Set(prefectures.map((p) => isJa ? p.region : p.regionEn))];
 
   const prevMonth = month === 0 ? { year: year - 1, month: 11 } : { year, month: month - 1 };
   const nextMonth = month === 11 ? { year: year + 1, month: 0 } : { year, month: month + 1 };
 
   const monthNames = t.raw('months') as string[];
-  const weekdayNames = t.raw('weekdays') as string[];
-  const monthLabel = `${year}年${monthNames[month]}`;
-
-  const raceName = (race: Race) =>
-    locale === 'en' ? (race.name_en ?? race.name_ja) : race.name_ja;
+  const monthLabel = isJa ? `${year}年${monthNames[month]}` : `${monthNames[month]} ${year}`;
 
   return (
-    <div className="max-w-4xl mx-auto px-4 py-8">
+    <div className="max-w-5xl mx-auto px-4 py-8" style={{ color: 'var(--color-ink)' }}>
       {/* Breadcrumb */}
-      <nav className="flex items-center gap-1.5 text-xs mb-4 text-gray-400" aria-label="breadcrumb">
-        <Link href="/" className="hover:text-gray-700 transition-colors">{tNav('home')}</Link>
+      <nav className="flex items-center gap-1.5 text-xs mb-4" style={{ color: 'var(--color-mid)' }} aria-label="breadcrumb">
+        <Link href="/" className="hover:underline">{tNav('home')}</Link>
         <span aria-hidden="true">›</span>
-        <span className="text-gray-700">{tNav('calendar')}</span>
+        <span style={{ color: 'var(--color-ink)' }}>{tNav('calendar')}</span>
       </nav>
 
-      <h1 className="text-3xl font-bold text-gray-900 mb-8">{t('title')}</h1>
+      <h1 className="font-serif text-3xl font-bold mb-6" style={{ color: 'var(--color-ink)' }}>
+        {t('title')}
+      </h1>
 
       {/* Month navigation */}
-      <div className="flex items-center justify-between mb-6">
+      <div className="flex items-center justify-between mb-4">
         <Link
           href={`?year=${prevMonth.year}&month=${prevMonth.month}`}
-          className="px-4 py-2 text-sm font-medium text-gray-600 hover:text-primary border border-gray-200 rounded-lg hover:border-primary transition-colors"
+          className="px-4 py-1.5 text-sm font-medium rounded-[3px] transition-colors no-underline"
+          style={{ background: 'var(--color-cream)', color: 'var(--color-ink)', border: '1px solid var(--color-border)' }}
         >
           ← {t('prev')}
         </Link>
-        <h2 className="text-xl font-bold text-gray-900">{monthLabel}</h2>
+        <h2 className="text-lg font-bold">{monthLabel}</h2>
         <Link
           href={`?year=${nextMonth.year}&month=${nextMonth.month}`}
-          className="px-4 py-2 text-sm font-medium text-gray-600 hover:text-primary border border-gray-200 rounded-lg hover:border-primary transition-colors"
+          className="px-4 py-1.5 text-sm font-medium rounded-[3px] transition-colors no-underline"
+          style={{ background: 'var(--color-cream)', color: 'var(--color-ink)', border: '1px solid var(--color-border)' }}
         >
           {t('next')} →
         </Link>
       </div>
 
-      {/* Calendar grid */}
-      <div className="border border-gray-200 rounded-xl overflow-hidden">
-        {/* Weekday headers */}
-        <div className="grid grid-cols-7 bg-gray-50 border-b border-gray-200">
-          {weekdayNames.map((day, i) => (
-            <div
-              key={day}
-              className={`p-3 text-center text-sm font-semibold ${
-                i === 0 ? 'text-accent' : i === 6 ? 'text-primary' : 'text-gray-600'
-              }`}
-            >
-              {day}
-            </div>
-          ))}
-        </div>
-
-        {/* Calendar days — cells have no horizontal padding; bands handle their own margins */}
-        <div className="grid grid-cols-7">
-          {/* Empty cells before first day */}
-          {Array.from({ length: firstDay }).map((_, i) => (
-            <div key={`empty-${i}`} className="min-h-28 border-b border-r border-gray-100 bg-gray-50" />
-          ))}
-
-          {/* Day cells */}
-          {Array.from({ length: daysInMonth }).map((_, i) => {
-            const day = i + 1;
-            const dateStr = `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
-            const dayRaces = raceDaysByDate.get(dateStr) ?? [];
-            const entryBands = entryBandsByDate.get(dateStr) ?? [];
-            const isToday = dateStr === todayJST;
-            const dayOfWeek = (firstDay + i) % 7;
-
-
-            return (
-              <div
-                key={day}
-                className={`min-h-28 border-b border-r border-gray-100 ${isToday ? 'bg-blue-50' : 'hover:bg-gray-50'}`}
-              >
-                {/* Date number */}
-                <div className="px-2 pt-2 pb-1">
-                  <span
-                    className={`inline-flex items-center justify-center w-7 h-7 rounded-full text-sm font-medium ${
-                      isToday
-                        ? 'bg-primary text-white'
-                        : dayOfWeek === 0
-                        ? 'text-accent'
-                        : dayOfWeek === 6
-                        ? 'text-primary'
-                        : 'text-gray-700'
-                    }`}
-                  >
-                    {day}
-                  </span>
-                </div>
-
-                {/* Entry period bands — レーン番号順に描画し位置を固定 */}
-                <div className="space-y-px">
-                  {Array.from({ length: totalLanes }, (_, lane) => {
-                    const band = entryBands.find(
-                      (b) => laneMap.get(`${b.race.id}__${b.period.id ?? b.period.start_date}`) === lane,
-                    );
-                    // 該当レーンに帯がない日はプレースホルダーで高さを確保
-                    if (!band) return <div key={lane} className="h-5" />;
-
-                    const name = raceName(band.race);
-                    const periodLabel = locale === 'en' ? band.period.label_en : band.period.label_ja;
-                    let label = '';
-                    if (band.isStart) label = `${t('entryStart')} ${name}${periodLabel !== '一般エントリー' && periodLabel !== 'General Entry' ? ` (${periodLabel})` : ''}`;
-                    else if (band.isEnd) label = `${t('entryEnd')} ${name}`;
-                    else if (band.isRowStart) label = name;
-
-                    // ラベルがある開始セルはテキストをセル外へ食み出させる（overflow-visible + whitespace-nowrap）
-                    const hasLabel = label !== '';
-                    let cx =
-                      `flex items-center h-5 text-xs text-green-900 bg-green-100 transition-colors hover:bg-green-200 ${hasLabel ? 'overflow-visible relative z-10' : 'overflow-hidden'} `;
-                    if (band.isStart && band.isEnd) {
-                      cx += 'mx-2 rounded-full px-2';
-                    } else if (band.isStart) {
-                      cx += 'ml-2 rounded-l-full pl-2 pr-1';
-                    } else if (band.isEnd) {
-                      cx += 'mr-2 rounded-r-full pl-1 pr-2';
-                    }
-
-                    return (
-                      <Link key={lane} href={`/races/${band.race.id}?from=calendar`} className={cx}>
-                        {label && <span className="whitespace-nowrap">{label}</span>}
-                      </Link>
-                    );
-                  })}
-                </div>
-
-                {/* Race day badges */}
-                <div className="px-2 mt-1 space-y-1">
-                  {dayRaces.map((race) => (
-                    <Link
-                      key={race.id}
-                      href={`/races/${race.id}?from=calendar`}
-                      className="block text-xs bg-primary text-white rounded px-1.5 py-0.5 truncate hover:bg-primary/80 transition-colors"
-                    >
-                      {raceName(race)}
-                    </Link>
-                  ))}
-                </div>
-              </div>
-            );
-          })}
-        </div>
-      </div>
+      <CalendarView
+        races={races}
+        year={year}
+        month={month}
+        locale={locale}
+        today={todayJST}
+        regions={regions}
+        prefToRegion={prefToRegion}
+      />
 
       {/* Legend */}
-      <div className="mt-4 flex flex-wrap items-center gap-4 text-xs text-gray-600">
+      <div className="mt-4 flex flex-wrap items-center gap-4 text-xs" style={{ color: 'var(--color-mid)' }}>
         <span className="font-medium">{t('legend')}:</span>
         <span className="flex items-center gap-1.5">
-          <span className="inline-block w-3 h-3 rounded-sm bg-primary" />
+          <span className="inline-block w-3 h-3 rounded-sm" style={{ background: 'var(--color-primary)' }} />
           {t('raceDay')}
         </span>
         <span className="flex items-center gap-1.5">
-          <span className="inline-block w-8 h-3 bg-green-100 rounded-full" />
+          <span className="inline-block w-8 h-3 rounded-full" style={{ background: '#d1fae5' }} />
           {t('entryPeriod')}
         </span>
       </div>

--- a/src/components/calendar/CalendarView.tsx
+++ b/src/components/calendar/CalendarView.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { useState } from 'react';
+import type { Race, Locale } from '@/lib/types';
+import ControlBar, { type StatusFilter } from './ControlBar';
+import MonthGrid from './MonthGrid';
+import YearTimeline from './YearTimeline';
+import HoverCard from './HoverCard';
+import { getTodayJST } from '@/lib/utils';
+
+type ViewMode = 'month' | 'timeline';
+
+interface CalendarViewProps {
+  races: Race[];
+  year: number;
+  month: number; // 0-indexed
+  locale: Locale;
+  today: string;
+  regions: string[];
+  prefToRegion: Record<string, string>;
+}
+
+function getRaceStatus(race: Race, today: string): 'open' | 'soon' | 'closed' | 'past' {
+  if (race.date < today) return 'past';
+  if (race.entry_closed) return 'closed';
+
+  const activePeriod = race.entry_periods.find(
+    (p) => today >= p.start_date && today <= p.end_date,
+  ) ?? (race.entry_start_date && race.entry_end_date &&
+    today >= race.entry_start_date && today <= race.entry_end_date
+      ? { start_date: race.entry_start_date, end_date: race.entry_end_date }
+      : null);
+
+  if (activePeriod) return 'open';
+
+  const futurePeriod = race.entry_periods.find((p) => p.start_date > today)
+    ?? (race.entry_start_date && race.entry_start_date > today ? {} : null);
+  if (futurePeriod) return 'soon';
+
+  return 'closed';
+}
+
+export default function CalendarView({
+  races,
+  year,
+  month,
+  locale,
+  today,
+  regions,
+  prefToRegion,
+}: CalendarViewProps) {
+  const [view, setView] = useState<ViewMode>('month');
+  const [status, setStatus] = useState<StatusFilter>('all');
+  const [region, setRegion] = useState<string>('all');
+  const [hoverRace, setHoverRace] = useState<Race | null>(null);
+  const [hoverPos, setHoverPos] = useState({ x: 0, y: 0 });
+
+  const isJa = locale === 'ja';
+
+  // フィルタリング
+  const filteredRaces = races.filter((race) => {
+    if (region !== 'all') {
+      const raceRegion = prefToRegion[race.prefecture];
+      if (raceRegion !== region) return false;
+    }
+    if (status !== 'all') {
+      const rStatus = getRaceStatus(race, today);
+      if (status === 'open' && rStatus !== 'open') return false;
+      if (status === 'soon' && rStatus !== 'soon') return false;
+      if (status === 'closed' && rStatus !== 'closed' && rStatus !== 'past') return false;
+    }
+    return true;
+  });
+
+  const handleHover = (race: Race | null, pos: { x: number; y: number }) => {
+    setHoverRace(race);
+    setHoverPos(pos);
+  };
+
+  return (
+    <div>
+      {/* View toggle */}
+      <div className="flex items-center gap-2 mb-4">
+        <button
+          onClick={() => setView('month')}
+          className="px-3 py-1 text-xs font-semibold rounded-[3px] transition-colors"
+          style={{
+            background: view === 'month' ? 'var(--color-ink)' : 'var(--color-cream)',
+            color: view === 'month' ? 'white' : 'var(--color-ink)',
+            border: `1px solid ${view === 'month' ? 'var(--color-ink)' : 'var(--color-border)'}`,
+          }}
+        >
+          {isJa ? '月' : 'Month'}
+        </button>
+        <button
+          onClick={() => setView('timeline')}
+          className="px-3 py-1 text-xs font-semibold rounded-[3px] transition-colors"
+          style={{
+            background: view === 'timeline' ? 'var(--color-ink)' : 'var(--color-cream)',
+            color: view === 'timeline' ? 'white' : 'var(--color-ink)',
+            border: `1px solid ${view === 'timeline' ? 'var(--color-ink)' : 'var(--color-border)'}`,
+          }}
+        >
+          {isJa ? '年間' : 'Year'}
+        </button>
+      </div>
+
+      <ControlBar
+        status={status}
+        region={region}
+        onStatusChange={setStatus}
+        onRegionChange={setRegion}
+        regions={regions}
+        locale={locale}
+      />
+
+      {view === 'month' ? (
+        <MonthGrid
+          races={filteredRaces}
+          year={year}
+          month={month}
+          locale={locale}
+          today={today}
+          onHover={handleHover}
+        />
+      ) : (
+        <YearTimeline
+          races={filteredRaces}
+          year={year}
+          locale={locale}
+          today={today}
+        />
+      )}
+
+      <HoverCard race={hoverRace} locale={locale} position={hoverPos} />
+    </div>
+  );
+}

--- a/src/components/calendar/CalendarView.tsx
+++ b/src/components/calendar/CalendarView.tsx
@@ -6,8 +6,6 @@ import ControlBar, { type StatusFilter } from './ControlBar';
 import MonthGrid from './MonthGrid';
 import YearTimeline from './YearTimeline';
 import HoverCard from './HoverCard';
-import { getTodayJST } from '@/lib/utils';
-
 type ViewMode = 'month' | 'timeline';
 
 interface CalendarViewProps {

--- a/src/components/calendar/ControlBar.tsx
+++ b/src/components/calendar/ControlBar.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+export type StatusFilter = 'all' | 'open' | 'soon' | 'closed';
+
+interface ControlBarProps {
+  status: StatusFilter;
+  region: string;
+  onStatusChange: (status: StatusFilter) => void;
+  onRegionChange: (region: string) => void;
+  regions: string[];
+  locale: string;
+}
+
+const STATUS_OPTIONS: { value: StatusFilter; ja: string; en: string }[] = [
+  { value: 'all', ja: 'すべて', en: 'All' },
+  { value: 'open', ja: '受付中', en: 'Open' },
+  { value: 'soon', ja: 'まもなく', en: 'Coming Soon' },
+  { value: 'closed', ja: '終了', en: 'Closed' },
+];
+
+export default function ControlBar({
+  status,
+  region,
+  onStatusChange,
+  onRegionChange,
+  regions,
+  locale,
+}: ControlBarProps) {
+  const isJa = locale === 'ja';
+
+  return (
+    <div className="flex flex-col gap-3 mb-4">
+      {/* Status filter */}
+      <div className="flex flex-wrap gap-1.5">
+        {STATUS_OPTIONS.map((opt) => {
+          const isActive = status === opt.value;
+          return (
+            <button
+              key={opt.value}
+              data-active={isActive ? 'true' : undefined}
+              onClick={() => onStatusChange(opt.value)}
+              className="px-3 py-1 text-xs font-semibold rounded-[3px] transition-colors"
+              style={{
+                background: isActive ? 'var(--color-primary)' : 'var(--color-cream)',
+                color: isActive ? 'white' : 'var(--color-ink)',
+                border: `1px solid ${isActive ? 'var(--color-primary)' : 'var(--color-border)'}`,
+              }}
+            >
+              {isJa ? opt.ja : opt.en}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Region filter */}
+      <div className="flex flex-wrap gap-1.5">
+        <button
+          data-active={region === 'all' ? 'true' : undefined}
+          onClick={() => onRegionChange('all')}
+          className="px-3 py-1 text-xs font-semibold rounded-[3px] transition-colors"
+          style={{
+            background: region === 'all' ? 'var(--color-ink)' : 'var(--color-cream)',
+            color: region === 'all' ? 'white' : 'var(--color-ink)',
+            border: `1px solid ${region === 'all' ? 'var(--color-ink)' : 'var(--color-border)'}`,
+          }}
+        >
+          {isJa ? 'すべて' : 'All'}
+        </button>
+        {regions.map((r) => {
+          const isActive = region === r;
+          return (
+            <button
+              key={r}
+              data-active={isActive ? 'true' : undefined}
+              onClick={() => onRegionChange(r)}
+              className="px-3 py-1 text-xs font-semibold rounded-[3px] transition-colors"
+              style={{
+                background: isActive ? 'var(--color-ink)' : 'var(--color-cream)',
+                color: isActive ? 'white' : 'var(--color-ink)',
+                border: `1px solid ${isActive ? 'var(--color-ink)' : 'var(--color-border)'}`,
+              }}
+            >
+              {r}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/calendar/HoverCard.tsx
+++ b/src/components/calendar/HoverCard.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import type { Race, Locale } from '@/lib/types';
+import { formatDate, getMainCategory } from '@/lib/utils';
+
+interface HoverCardProps {
+  race: Race | null;
+  locale: Locale;
+  position: { x: number; y: number };
+}
+
+export default function HoverCard({ race, locale, position }: HoverCardProps) {
+  if (!race) return null;
+
+  const isJa = locale === 'ja';
+  const name = isJa ? race.name_ja : (race.name_en ?? race.name_ja);
+  const city = isJa ? race.city_ja : race.city_en;
+  const mainCategory = getMainCategory(race.categories);
+
+  return (
+    <div
+      className="fixed z-50 pointer-events-none"
+      style={{
+        left: position.x + 12,
+        top: position.y + 12,
+        minWidth: 200,
+        maxWidth: 280,
+      }}
+    >
+      <div
+        className="rounded-[4px] p-3 shadow-lg"
+        style={{
+          background: 'white',
+          border: '1px solid var(--color-border)',
+        }}
+      >
+        <p className="font-semibold text-sm leading-snug mb-1" style={{ color: 'var(--color-ink)' }}>
+          {name}
+        </p>
+        <p className="text-xs mb-1" style={{ color: 'var(--color-mid)' }}>
+          📅 {formatDate(race.date, locale)}
+        </p>
+        <p className="text-xs mb-1" style={{ color: 'var(--color-mid)' }}>
+          📍 {city}
+        </p>
+        {mainCategory && (
+          <p className="text-xs" style={{ color: 'var(--color-mid)' }}>
+            🏃 {mainCategory.distance_km}km
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/calendar/MonthGrid.tsx
+++ b/src/components/calendar/MonthGrid.tsx
@@ -1,0 +1,251 @@
+'use client';
+
+import type { Race, EntryPeriod, Locale } from '@/lib/types';
+import { Link } from '@/i18n/navigation';
+
+interface MonthGridProps {
+  races: Race[];
+  year: number;
+  month: number; // 0-indexed
+  locale: Locale;
+  today: string;
+  onHover: (race: Race | null, pos: { x: number; y: number }) => void;
+}
+
+type EntryBand = {
+  race: Race;
+  period: EntryPeriod;
+  isStart: boolean;
+  isEnd: boolean;
+  isRowStart: boolean;
+};
+
+function getDaysInMonth(year: number, month: number): number {
+  return new Date(year, month + 1, 0).getDate();
+}
+
+function getFirstDayOfMonth(year: number, month: number): number {
+  return new Date(year, month, 1).getDay();
+}
+
+export default function MonthGrid({ races, year, month, locale, today, onHover }: MonthGridProps) {
+  const isJa = locale === 'ja';
+  const raceName = (race: Race) => isJa ? race.name_ja : (race.name_en ?? race.name_ja);
+
+  // Race day map
+  const raceDaysByDate = new Map<string, Race[]>();
+  races.forEach((race) => {
+    const key = race.date.split('T')[0];
+    if (!raceDaysByDate.has(key)) raceDaysByDate.set(key, []);
+    raceDaysByDate.get(key)!.push(race);
+  });
+
+  // Entry period bands with lane assignment
+  const monthStart = new Date(year, month, 1);
+  const monthEnd = new Date(year, month + 1, 0);
+
+  interface PeriodEntry {
+    race: Race;
+    period: EntryPeriod;
+    effectiveStart: string;
+    effectiveEnd: string;
+    key: string;
+  }
+  const allPeriods: PeriodEntry[] = [];
+
+  races.forEach((race) => {
+    const periods = race.entry_periods ?? [];
+    const effectivePeriods = periods.length > 0
+      ? periods
+      : (race.entry_start_date && race.entry_end_date
+          ? [{ id: 0, race_id: race.id, category_id: null, label_ja: '一般エントリー', label_en: 'General Entry', start_date: race.entry_start_date.split('T')[0], end_date: race.entry_end_date.split('T')[0], entry_fee: null, sort_order: 0 }]
+          : []);
+
+    effectivePeriods.forEach((period) => {
+      const periodStart = new Date(period.start_date + 'T00:00:00');
+      const periodEnd = new Date(period.end_date + 'T00:00:00');
+      if (periodStart > monthEnd || periodEnd < monthStart) return;
+
+      const effectiveStart = periodStart < monthStart ? monthStart : periodStart;
+      const effectiveEnd = periodEnd > monthEnd ? monthEnd : periodEnd;
+      const pad = (n: number) => String(n).padStart(2, '0');
+      const effStartStr = `${year}-${pad(effectiveStart.getMonth() + 1)}-${pad(effectiveStart.getDate())}`;
+      const effEndStr = `${year}-${pad(effectiveEnd.getMonth() + 1)}-${pad(effectiveEnd.getDate())}`;
+
+      allPeriods.push({ race, period, effectiveStart: effStartStr, effectiveEnd: effEndStr, key: `${race.id}__${period.id ?? period.start_date}` });
+    });
+  });
+
+  allPeriods.sort((a, b) =>
+    a.effectiveStart !== b.effectiveStart
+      ? a.effectiveStart.localeCompare(b.effectiveStart)
+      : a.race.name_ja.localeCompare(b.race.name_ja),
+  );
+
+  const laneMap = new Map<string, number>();
+  const laneLastEnd: string[] = [];
+  for (const pe of allPeriods) {
+    let lane = laneLastEnd.findIndex((end) => end < pe.effectiveStart);
+    if (lane === -1) lane = laneLastEnd.length;
+    laneLastEnd[lane] = pe.effectiveEnd;
+    laneMap.set(pe.key, lane);
+  }
+  const totalLanes = laneLastEnd.length;
+
+  const entryBandsByDate = new Map<string, EntryBand[]>();
+  races.forEach((race) => {
+    const periods = race.entry_periods ?? [];
+    const effectivePeriods = periods.length > 0
+      ? periods
+      : (race.entry_start_date && race.entry_end_date
+          ? [{ id: 0, race_id: race.id, category_id: null, label_ja: '一般エントリー', label_en: 'General Entry', start_date: race.entry_start_date.split('T')[0], end_date: race.entry_end_date.split('T')[0], entry_fee: null, sort_order: 0 }]
+          : []);
+
+    effectivePeriods.forEach((period) => {
+      const periodStart = new Date(period.start_date + 'T00:00:00');
+      const periodEnd = new Date(period.end_date + 'T00:00:00');
+      if (periodStart > monthEnd || periodEnd < monthStart) return;
+
+      const effectiveStart = periodStart < monthStart ? monthStart : periodStart;
+      const effectiveEnd = periodEnd > monthEnd ? monthEnd : periodEnd;
+
+      let cur = new Date(effectiveStart.getTime());
+      while (cur <= effectiveEnd) {
+        const d = cur.getDate();
+        const pad = (n: number) => String(n).padStart(2, '0');
+        const dateStr = `${year}-${pad(month + 1)}-${pad(d)}`;
+        const dow = cur.getDay();
+        if (!entryBandsByDate.has(dateStr)) entryBandsByDate.set(dateStr, []);
+        entryBandsByDate.get(dateStr)!.push({
+          race,
+          period,
+          isStart: dateStr === period.start_date,
+          isEnd: dateStr === period.end_date,
+          isRowStart: (dow === 0 || d === 1) && dateStr !== period.start_date,
+        });
+        cur = new Date(cur.getTime() + 86400000);
+      }
+    });
+  });
+
+  const daysInMonth = getDaysInMonth(year, month);
+  const firstDay = getFirstDayOfMonth(year, month);
+
+  const weekdayNames = isJa
+    ? ['日', '月', '火', '水', '木', '金', '土']
+    : ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+  return (
+    <div style={{ border: '1px solid var(--color-border)', borderRadius: 4, overflow: 'hidden' }}>
+      {/* Weekday headers */}
+      <div className="grid grid-cols-7" style={{ background: 'var(--color-cream)', borderBottom: '1px solid var(--color-border)' }}>
+        {weekdayNames.map((day, i) => (
+          <div
+            key={day}
+            className="p-3 text-center text-xs font-semibold"
+            style={{
+              color: i === 0 ? '#c0392b' : i === 6 ? 'var(--color-primary)' : 'var(--color-mid)',
+            }}
+          >
+            {day}
+          </div>
+        ))}
+      </div>
+
+      {/* Day cells */}
+      <div className="grid grid-cols-7">
+        {Array.from({ length: firstDay }).map((_, i) => (
+          <div
+            key={`empty-${i}`}
+            className="min-h-28"
+            style={{ borderBottom: '1px solid var(--color-border)', borderRight: '1px solid var(--color-border)', background: 'var(--color-cream)' }}
+          />
+        ))}
+
+        {Array.from({ length: daysInMonth }).map((_, i) => {
+          const day = i + 1;
+          const pad = (n: number) => String(n).padStart(2, '0');
+          const dateStr = `${year}-${pad(month + 1)}-${pad(day)}`;
+          const dayRaces = raceDaysByDate.get(dateStr) ?? [];
+          const entryBands = entryBandsByDate.get(dateStr) ?? [];
+          const isToday = dateStr === today;
+          const dayOfWeek = (firstDay + i) % 7;
+
+          return (
+            <div
+              key={day}
+              data-date={dateStr}
+              data-today={isToday ? 'true' : undefined}
+              className="min-h-28"
+              style={{
+                borderBottom: '1px solid var(--color-border)',
+                borderRight: '1px solid var(--color-border)',
+                background: isToday ? '#f0f4ff' : 'white',
+              }}
+            >
+              {/* Date number */}
+              <div className="px-2 pt-2 pb-1">
+                <span
+                  className="inline-flex items-center justify-center w-6 h-6 rounded-full text-xs font-medium"
+                  style={{
+                    background: isToday ? 'var(--color-primary)' : 'transparent',
+                    color: isToday ? 'white' : dayOfWeek === 0 ? '#c0392b' : dayOfWeek === 6 ? 'var(--color-primary)' : 'var(--color-ink)',
+                  }}
+                >
+                  {day}
+                </span>
+              </div>
+
+              {/* Entry bands */}
+              <div className="space-y-px">
+                {Array.from({ length: totalLanes }, (_, lane) => {
+                  const band = entryBands.find(
+                    (b) => laneMap.get(`${b.race.id}__${b.period.id ?? b.period.start_date}`) === lane,
+                  );
+                  if (!band) return <div key={lane} className="h-5" />;
+
+                  const label = band.isStart
+                    ? `受付 ${raceName(band.race)}`
+                    : band.isRowStart ? raceName(band.race) : '';
+
+                  const hasLabel = label !== '';
+                  let cx = `flex items-center h-5 text-xs transition-colors ${hasLabel ? 'overflow-visible relative z-10' : 'overflow-hidden'} `;
+                  if (band.isStart && band.isEnd) cx += 'mx-2 rounded-full px-2';
+                  else if (band.isStart) cx += 'ml-2 rounded-l-full pl-2 pr-1';
+                  else if (band.isEnd) cx += 'mr-2 rounded-r-full pl-1 pr-2';
+
+                  return (
+                    <Link
+                      key={lane}
+                      href={`/races/${band.race.id}?from=calendar`}
+                      className={cx}
+                      style={{ background: '#d1fae5', color: '#065f46' }}
+                    >
+                      {label && <span className="whitespace-nowrap">{label}</span>}
+                    </Link>
+                  );
+                })}
+              </div>
+
+              {/* Race day badges */}
+              <div className="px-2 mt-1 space-y-1">
+                {dayRaces.map((race) => (
+                  <Link
+                    key={race.id}
+                    href={`/races/${race.id}?from=calendar`}
+                    className="block text-xs rounded px-1.5 py-0.5 truncate transition-colors"
+                    style={{ background: 'var(--color-primary)', color: 'white' }}
+                    onMouseEnter={(e) => onHover(race, { x: e.clientX, y: e.clientY })}
+                    onMouseLeave={() => onHover(null, { x: 0, y: 0 })}
+                  >
+                    {raceName(race)}
+                  </Link>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/calendar/YearTimeline.tsx
+++ b/src/components/calendar/YearTimeline.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import type { Race, Locale } from '@/lib/types';
+import { Link } from '@/i18n/navigation';
+
+interface YearTimelineProps {
+  races: Race[];
+  year: number;
+  locale: Locale;
+  today: string;
+}
+
+const MONTH_LABELS_JA = ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月'];
+const MONTH_LABELS_EN = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+function dayOfYear(dateStr: string): number {
+  const d = new Date(dateStr + 'T00:00:00');
+  const start = new Date(d.getFullYear(), 0, 0);
+  const diff = d.getTime() - start.getTime();
+  return Math.floor(diff / 86400000);
+}
+
+function daysInYear(year: number): number {
+  return (year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0)) ? 366 : 365;
+}
+
+function monthStartDay(year: number, month: number): number {
+  const d = new Date(year, month, 1);
+  const start = new Date(year, 0, 0);
+  return Math.floor((d.getTime() - start.getTime()) / 86400000);
+}
+
+export default function YearTimeline({ races, year, locale, today }: YearTimelineProps) {
+  const isJa = locale === 'ja';
+  const monthLabels = isJa ? MONTH_LABELS_JA : MONTH_LABELS_EN;
+  const totalDays = daysInYear(year);
+
+  // 対象年の大会のみ
+  const yearRaces = races.filter((r) => r.date.startsWith(String(year)));
+  const raceName = (race: Race) => isJa ? race.name_ja : (race.name_en ?? race.name_ja);
+
+  const ROW_H = 28;
+  const LABEL_W = 160;
+  const CHART_W = 600;
+  const HEADER_H = 32;
+  const svgHeight = HEADER_H + yearRaces.length * ROW_H + 16;
+
+  const xForDay = (day: number) => LABEL_W + (day / totalDays) * CHART_W;
+
+  const todayDay = today.startsWith(String(year)) ? dayOfYear(today) : null;
+
+  return (
+    <div className="overflow-x-auto">
+      <svg
+        width={LABEL_W + CHART_W}
+        height={svgHeight}
+        style={{ fontFamily: 'var(--font-dm-sans, sans-serif)', fontSize: 12 }}
+      >
+        {/* Month grid lines & labels */}
+        {Array.from({ length: 12 }, (_, m) => {
+          const x = xForDay(monthStartDay(year, m));
+          return (
+            <g key={m}>
+              <line x1={x} y1={HEADER_H} x2={x} y2={svgHeight} stroke="var(--color-border)" strokeWidth={1} />
+              <text x={x + 4} y={HEADER_H - 6} fill="var(--color-mid)" fontSize={10}>
+                {monthLabels[m]}
+              </text>
+            </g>
+          );
+        })}
+
+        {/* Today line */}
+        {todayDay !== null && (
+          <line
+            x1={xForDay(todayDay)}
+            y1={HEADER_H}
+            x2={xForDay(todayDay)}
+            y2={svgHeight}
+            stroke="var(--color-primary)"
+            strokeWidth={1.5}
+            strokeDasharray="4,3"
+          />
+        )}
+
+        {/* Race rows */}
+        {yearRaces.map((race, i) => {
+          const y = HEADER_H + i * ROW_H;
+          const raceDay = dayOfYear(race.date);
+          const cx = xForDay(raceDay);
+          const name = raceName(race);
+
+          return (
+            <g key={race.id}>
+              {/* Entry period band */}
+              {race.entry_start_date && race.entry_end_date &&
+                race.entry_start_date.startsWith(String(year)) && (
+                <rect
+                  x={xForDay(dayOfYear(race.entry_start_date))}
+                  y={y + 10}
+                  width={Math.max(
+                    2,
+                    xForDay(dayOfYear(race.entry_end_date)) - xForDay(dayOfYear(race.entry_start_date))
+                  )}
+                  height={8}
+                  fill="#d1fae5"
+                  rx={2}
+                />
+              )}
+
+              {/* Race dot */}
+              <circle cx={cx} cy={y + 14} r={5} fill="var(--color-primary)" />
+
+              {/* Race name label */}
+              <Link href={`/races/${race.id}?from=calendar`}>
+                <text
+                  x={4}
+                  y={y + 18}
+                  fill="var(--color-ink)"
+                  fontSize={11}
+                  style={{ cursor: 'pointer' }}
+                >
+                  {name.length > 20 ? name.slice(0, 19) + '…' : name}
+                </text>
+              </Link>
+            </g>
+          );
+        })}
+      </svg>
+    </div>
+  );
+}

--- a/src/components/calendar/__tests__/CalendarView.test.tsx
+++ b/src/components/calendar/__tests__/CalendarView.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import CalendarView from '../CalendarView';
+import { makeRace } from '../../../lib/__tests__/fixtures';
+
+vi.mock('@/i18n/navigation', () => ({
+  Link: ({ href, children, ...props }: { href: string; children: React.ReactNode; className?: string }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+const REGIONS = ['北海道', '東北', '関東', '中部', '近畿', '中国', '四国', '九州・沖縄'];
+const PREF_TO_REGION: Record<string, string> = {
+  '13': '関東',
+  '27': '近畿',
+  '01': '北海道',
+};
+
+describe('CalendarView', () => {
+  it('初期状態でMonthGridが表示される', () => {
+    const { container } = render(
+      <CalendarView
+        races={[]}
+        year={2026}
+        month={3}
+        locale="ja"
+        today="2026-04-05"
+        regions={REGIONS}
+        prefToRegion={PREF_TO_REGION}
+      />
+    );
+    // MonthGrid はグリッドを持つ
+    expect(container.querySelector('.grid-cols-7')).not.toBeNull();
+  });
+
+  it('年間ビューボタンでYearTimelineに切り替わる', () => {
+    const { container } = render(
+      <CalendarView
+        races={[]}
+        year={2026}
+        month={3}
+        locale="ja"
+        today="2026-04-05"
+        regions={REGIONS}
+        prefToRegion={PREF_TO_REGION}
+      />
+    );
+    fireEvent.click(screen.getByText('年間'));
+    expect(container.querySelector('svg')).not.toBeNull();
+    expect(container.querySelector('.grid-cols-7')).toBeNull();
+  });
+
+  it('月表示ボタンでMonthGridに戻る', () => {
+    const { container } = render(
+      <CalendarView
+        races={[]}
+        year={2026}
+        month={3}
+        locale="ja"
+        today="2026-04-05"
+        regions={REGIONS}
+        prefToRegion={PREF_TO_REGION}
+      />
+    );
+    fireEvent.click(screen.getByText('年間'));
+    fireEvent.click(screen.getByText('月'));
+    expect(container.querySelector('.grid-cols-7')).not.toBeNull();
+  });
+
+  it('REGIONフィルターで対象外の大会が非表示になる', () => {
+    const race1 = makeRace({ name_ja: '東京マラソン', date: '2026-04-19', prefecture: '13' }); // 関東
+    const race2 = makeRace({ id: 'osaka-2026', name_ja: '大阪マラソン', date: '2026-04-26', prefecture: '27' }); // 近畿
+    render(
+      <CalendarView
+        races={[race1, race2]}
+        year={2026}
+        month={3}
+        locale="ja"
+        today="2026-04-05"
+        regions={REGIONS}
+        prefToRegion={PREF_TO_REGION}
+      />
+    );
+    // 関東フィルターをクリック
+    fireEvent.click(screen.getByText('関東'));
+    expect(screen.getByText('東京マラソン')).toBeInTheDocument();
+    expect(screen.queryByText('大阪マラソン')).toBeNull();
+  });
+
+  it('ControlBar が描画される', () => {
+    render(
+      <CalendarView
+        races={[]}
+        year={2026}
+        month={3}
+        locale="ja"
+        today="2026-04-05"
+        regions={REGIONS}
+        prefToRegion={PREF_TO_REGION}
+      />
+    );
+    expect(screen.getByText('受付中')).toBeInTheDocument();
+  });
+});

--- a/src/components/calendar/__tests__/ControlBar.test.tsx
+++ b/src/components/calendar/__tests__/ControlBar.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ControlBar from '../ControlBar';
+
+const REGIONS = ['北海道', '東北', '関東', '中部', '近畿', '中国', '四国', '九州・沖縄'];
+
+describe('ControlBar', () => {
+  it('STATUSボタンが描画される', () => {
+    render(<ControlBar status="all" region="all" onStatusChange={() => {}} onRegionChange={() => {}} regions={REGIONS} locale="ja" />);
+    expect(screen.getAllByText('すべて')).toHaveLength(2); // STATUS と REGION の両方
+    expect(screen.getByText('受付中')).toBeInTheDocument();
+    expect(screen.getByText('まもなく')).toBeInTheDocument();
+    expect(screen.getByText('終了')).toBeInTheDocument();
+  });
+
+  it('REGIONボタンが描画される', () => {
+    render(<ControlBar status="all" region="all" onStatusChange={() => {}} onRegionChange={() => {}} regions={REGIONS} locale="ja" />);
+    expect(screen.getByText('北海道')).toBeInTheDocument();
+    expect(screen.getByText('関東')).toBeInTheDocument();
+    expect(screen.getByText('九州・沖縄')).toBeInTheDocument();
+  });
+
+  it('STATUSをクリックすると onStatusChange が呼ばれる', () => {
+    const onStatusChange = vi.fn();
+    render(<ControlBar status="all" region="all" onStatusChange={onStatusChange} onRegionChange={() => {}} regions={REGIONS} locale="ja" />);
+    fireEvent.click(screen.getByText('受付中'));
+    expect(onStatusChange).toHaveBeenCalledWith('open');
+  });
+
+  it('REGIONをクリックすると onRegionChange が呼ばれる', () => {
+    const onRegionChange = vi.fn();
+    render(<ControlBar status="all" region="all" onStatusChange={() => {}} onRegionChange={onRegionChange} regions={REGIONS} locale="ja" />);
+    fireEvent.click(screen.getByText('関東'));
+    expect(onRegionChange).toHaveBeenCalledWith('関東');
+  });
+
+  it('active な STATUS ボタンが強調スタイルを持つ', () => {
+    const { container } = render(<ControlBar status="open" region="all" onStatusChange={() => {}} onRegionChange={() => {}} regions={REGIONS} locale="ja" />);
+    const activeBtn = container.querySelector('[data-active="true"]');
+    expect(activeBtn?.textContent).toBe('受付中');
+  });
+
+  it('en ロケールで英語ラベルが表示される', () => {
+    render(<ControlBar status="all" region="all" onStatusChange={() => {}} onRegionChange={() => {}} regions={REGIONS} locale="en" />);
+    expect(screen.getAllByText('All')).toHaveLength(2); // STATUS と REGION の両方
+    expect(screen.getByText('Open')).toBeInTheDocument();
+    expect(screen.getByText('Coming Soon')).toBeInTheDocument();
+    expect(screen.getByText('Closed')).toBeInTheDocument();
+  });
+});

--- a/src/components/calendar/__tests__/HoverCard.test.tsx
+++ b/src/components/calendar/__tests__/HoverCard.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import HoverCard from '../HoverCard';
+import { makeRace } from '../../../lib/__tests__/fixtures';
+
+describe('HoverCard', () => {
+  it('大会名が表示される', () => {
+    const race = makeRace({ name_ja: '長野マラソン2026', date: '2026-04-19' });
+    render(<HoverCard race={race} locale="ja" position={{ x: 100, y: 200 }} />);
+    expect(screen.getByText('長野マラソン2026')).toBeInTheDocument();
+  });
+
+  it('en ロケールで name_en が表示される', () => {
+    const race = makeRace({ name_en: 'Nagano Marathon 2026', date: '2026-04-19' });
+    render(<HoverCard race={race} locale="en" position={{ x: 0, y: 0 }} />);
+    expect(screen.getByText('Nagano Marathon 2026')).toBeInTheDocument();
+  });
+
+  it('開催日が表示される', () => {
+    const race = makeRace({ date: '2026-04-19' });
+    render(<HoverCard race={race} locale="ja" position={{ x: 0, y: 0 }} />);
+    expect(screen.getAllByText(/2026/).length).toBeGreaterThan(0);
+  });
+
+  it('race が null のとき何も描画しない', () => {
+    const { container } = render(<HoverCard race={null} locale="ja" position={{ x: 0, y: 0 }} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('position に応じた style が設定される', () => {
+    const race = makeRace({ date: '2026-04-19' });
+    const { container } = render(<HoverCard race={race} locale="ja" position={{ x: 120, y: 300 }} />);
+    const card = container.firstChild as HTMLElement;
+    // offset +12 が加算される
+    expect(card?.style.left).toContain('132');
+    expect(card?.style.top).toContain('312');
+  });
+
+  it('公式都市名が表示される', () => {
+    const race = makeRace({ city_ja: '長野市', date: '2026-04-19' });
+    render(<HoverCard race={race} locale="ja" position={{ x: 0, y: 0 }} />);
+    expect(screen.getByText(/長野市/)).toBeInTheDocument();
+  });
+});

--- a/src/components/calendar/__tests__/MonthGrid.test.tsx
+++ b/src/components/calendar/__tests__/MonthGrid.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import MonthGrid from '../MonthGrid';
+import { makeRace } from '../../../lib/__tests__/fixtures';
+
+// Link コンポーネントのモック
+vi.mock('@/i18n/navigation', () => ({
+  Link: ({ href, children, ...props }: { href: string; children: React.ReactNode; className?: string }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+const TODAY = '2026-04-05';
+
+describe('MonthGrid', () => {
+  it('7列のグリッドが描画される', () => {
+    const { container } = render(
+      <MonthGrid races={[]} year={2026} month={3} locale="ja" today={TODAY} onHover={() => {}} />
+    );
+    const header = container.querySelector('.grid-cols-7');
+    expect(header).not.toBeNull();
+  });
+
+  it('当月の日数分のセルが描画される（4月 = 30日）', () => {
+    const { container } = render(
+      <MonthGrid races={[]} year={2026} month={3} locale="ja" today={TODAY} onHover={() => {}} />
+    );
+    // 日付セルを数える（data-date 属性で識別）
+    const dayCells = container.querySelectorAll('[data-date]');
+    expect(dayCells).toHaveLength(30);
+  });
+
+  it('開催日のある大会名が表示される', () => {
+    const race = makeRace({ name_ja: '長野マラソン2026', date: '2026-04-19' });
+    render(
+      <MonthGrid races={[race]} year={2026} month={3} locale="ja" today={TODAY} onHover={() => {}} />
+    );
+    expect(screen.getByText('長野マラソン2026')).toBeInTheDocument();
+  });
+
+  it('en ロケールで name_en が表示される', () => {
+    const race = makeRace({ name_en: 'Nagano Marathon 2026', date: '2026-04-19' });
+    render(
+      <MonthGrid races={[race]} year={2026} month={3} locale="en" today={TODAY} onHover={() => {}} />
+    );
+    expect(screen.getByText('Nagano Marathon 2026')).toBeInTheDocument();
+  });
+
+  it('今日のセルに data-today 属性が付く', () => {
+    const { container } = render(
+      <MonthGrid races={[]} year={2026} month={3} locale="ja" today="2026-04-05" onHover={() => {}} />
+    );
+    expect(container.querySelector('[data-today="true"]')).not.toBeNull();
+  });
+
+  it('異なる月の大会は表示されない', () => {
+    const race = makeRace({ name_ja: '東京マラソン2026', date: '2026-03-15' }); // 3月
+    render(
+      <MonthGrid races={[race]} year={2026} month={3} locale="ja" today={TODAY} onHover={() => {}} /> // 4月
+    );
+    expect(screen.queryByText('東京マラソン2026')).toBeNull();
+  });
+});

--- a/src/components/calendar/__tests__/YearTimeline.test.tsx
+++ b/src/components/calendar/__tests__/YearTimeline.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import YearTimeline from '../YearTimeline';
+import { makeRace } from '../../../lib/__tests__/fixtures';
+
+vi.mock('@/i18n/navigation', () => ({
+  Link: ({ href, children, ...props }: { href: string; children: React.ReactNode; className?: string }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+describe('YearTimeline', () => {
+  it('SVGが描画される', () => {
+    const { container } = render(
+      <YearTimeline races={[]} year={2026} locale="ja" today="2026-04-05" />
+    );
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+
+  it('12ヶ月の月ラベルが描画される', () => {
+    render(<YearTimeline races={[]} year={2026} locale="ja" today="2026-04-05" />);
+    // 月ラベルが存在する（1月〜12月）
+    expect(screen.getByText('1月')).toBeInTheDocument();
+    expect(screen.getByText('12月')).toBeInTheDocument();
+  });
+
+  it('en ロケールで月ラベルが英語になる', () => {
+    render(<YearTimeline races={[]} year={2026} locale="en" today="2026-04-05" />);
+    expect(screen.getByText('Jan')).toBeInTheDocument();
+    expect(screen.getByText('Dec')).toBeInTheDocument();
+  });
+
+  it('大会名が表示される', () => {
+    const race = makeRace({ name_ja: '長野マラソン2026', date: '2026-04-19' });
+    render(<YearTimeline races={[race]} year={2026} locale="ja" today="2026-04-05" />);
+    expect(screen.getByText('長野マラソン2026')).toBeInTheDocument();
+  });
+
+  it('対象年以外の大会は表示されない', () => {
+    const race = makeRace({ name_ja: '東京2025', date: '2025-03-15' });
+    render(<YearTimeline races={[race]} year={2026} locale="ja" today="2026-04-05" />);
+    expect(screen.queryByText('東京2025')).toBeNull();
+  });
+
+  it('races が空でもクラッシュしない', () => {
+    expect(() =>
+      render(<YearTimeline races={[]} year={2026} locale="ja" today="2026-04-05" />)
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## 概要

Issue #44 Phase 4 の実装。カレンダーページにインタラクティブなフィルター・ビュー切替・ホバーカードを追加した。

## 変更内容

### 新コンポーネント（TDD）
- `ControlBar`: STATUS/REGION フィルター UI
- `HoverCard`: ホバー時ミニ情報カード
- `MonthGrid`: 月送りグリッド（Client Component 切り出し）
- `YearTimeline`: SVG ベース年間タイムライン
- `CalendarView`: ビュー切替・フィルター統合ラッパー

### page.tsx リファクタリング
- データ取得（Server Component）→ CalendarView（Client Component）に props 渡し
- `getPrefectures()` で prefecture→地方マップを生成してフィルター連携
- 旧パレット（gray-xxx）→ デザイントークン（--color-*）に統一

## テスト
- 新規 29 テスト追加（全 256 テスト通過）

https://claude.ai/code/session_01MeSiixT1wrzhANhurNwrnK