### PR TITLE
feat: Phase 2/3 データ充填・詳細ページデザイン刷新・UX改善

### DIFF
--- a/docs/update-history.md
+++ b/docs/update-history.md
@@ -522,3 +522,19 @@
 - `scripts/set-motif-data.js`: motif/tagline データを全件に適用するスクリプト
 - `scripts/build-course-highlights.js`: course_info から course_highlights を構造化するスクリプト
 - `migrations/seed-races-all.sql`: シードSQL再生成（新フィールド反映）
+
+## 2026-05-07 course_highlights をカテゴリ付随に変更・詳細ページデザイン刷新
+
+- `src/lib/db/schema.ts`: `race_course_highlights.km` を nullable 化、`category_id` FK (nullable) 追加
+- `src/lib/types.ts`: `RaceCourseHighlight` に `category_id` 追加・`km` nullable 化、`RaceCategory` に `course_highlights` 追加、`Race` から `course_highlights` 削除
+- `src/lib/data.ts`: highlights をカテゴリ別に振り分けるロジックを追加
+- `migrations/0006_high_mole_man.sql`: km nullable 化のテーブル再構築マイグレーション（手動修正）
+- `migrations/0007_yielding_obadiah_stane.sql`: category_id カラム追加
+- `scripts/generate-seed-races.js`: カテゴリレベルの course_highlights INSERT 追加、レースレベルも category_id=NULL で対応
+- `migrations/seed-races-all.sql`: シードSQL再生成
+- `src/components/races/detail/DetailHeader.tsx`: 詳細ページヘッダー全面刷新（モチーフバッジ・版次表示・メタ行）
+- `src/app/[locale]/races/[id]/page.tsx`: セクション番号化（01–10）、コース地図とハイライト横並びレイアウト
+- `src/components/course/CourseProfileSection.tsx`: sidebarContent prop 追加
+- `src/components/races/RaceBreadcrumb.tsx`: 背景変更後の文字色修正
+- `src/components/races/RaceRegistrationButtons.tsx`: クリーム背景向け色修正
+- `src/lib/__tests__/fixtures.ts`: makeRace・makeCategory・makeCourseHighlight を新スキーマに合わせて更新

--- a/docs/update-history.md
+++ b/docs/update-history.md
@@ -510,3 +510,15 @@
 - `src/components/calendar/YearTimeline.tsx`: SVG ベース年間タイムライン（TDD）
 - `src/components/calendar/CalendarView.tsx`: ビュー切替・フィルター統合ラッパー（TDD）
 - `src/app/[locale]/calendar/page.tsx`: CalendarView で再構成、デザイントークン統一
+
+## 2026-05-05 Phase 2/3 フィールドのデータ充填（Issue #49）
+
+- `src/data/races/*.json`（77件）: Phase 2/3 フィールドを一括設定
+  - `gallery` / `voices` / `time_buckets` / `course_highlights` を空配列としてフィールド追加
+  - `motif` / `motif_color` / `motif_romaji` を各大会の特徴・地域から設定（全77件）
+  - `tagline_ja` / `tagline_en` を各大会のキャッチコピーとして設定（全77件）
+  - `course_highlights` を既存の `course_info.highlights_ja/en` から構造化（61件）
+- `scripts/add-phase3-fields.js`: Phase 3 空配列フィールドを一括追加するスクリプト
+- `scripts/set-motif-data.js`: motif/tagline データを全件に適用するスクリプト
+- `scripts/build-course-highlights.js`: course_info から course_highlights を構造化するスクリプト
+- `migrations/seed-races-all.sql`: シードSQL再生成（新フィールド反映）

--- a/migrations/0006_high_mole_man.sql
+++ b/migrations/0006_high_mole_man.sql
@@ -1,0 +1,20 @@
+-- race_course_highlights.km を NOT NULL → nullable に変更（SQLite はテーブル再構築が必要）
+CREATE TABLE `race_course_highlights_new` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`race_id` text NOT NULL,
+	`km` real,
+	`name_ja` text NOT NULL,
+	`name_en` text,
+	`note_ja` text,
+	`note_en` text,
+	`sort_order` integer DEFAULT 0 NOT NULL,
+	FOREIGN KEY (`race_id`) REFERENCES `races`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `race_course_highlights_new` SELECT `id`, `race_id`, `km`, `name_ja`, `name_en`, `note_ja`, `note_en`, `sort_order` FROM `race_course_highlights`;
+--> statement-breakpoint
+DROP TABLE `race_course_highlights`;
+--> statement-breakpoint
+ALTER TABLE `race_course_highlights_new` RENAME TO `race_course_highlights`;
+--> statement-breakpoint
+CREATE INDEX `race_course_highlights_race_id_idx` ON `race_course_highlights` (`race_id`);

--- a/migrations/0007_yielding_obadiah_stane.sql
+++ b/migrations/0007_yielding_obadiah_stane.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `race_course_highlights` ADD `category_id` integer REFERENCES race_categories(id);

--- a/migrations/meta/0006_snapshot.json
+++ b/migrations/meta/0006_snapshot.json
@@ -1,8 +1,8 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "be139410-d719-4b0d-9c96-c66aadda0a7c",
-  "prevId": "dbbf7015-4312-41ea-ab41-3cb9fe6d72e9",
+  "id": "6c64b234-f9ad-4485-a9fa-8a54e1e52356",
+  "prevId": "be139410-d719-4b0d-9c96-c66aadda0a7c",
   "tables": {
     "access_points": {
       "name": "access_points",
@@ -949,6 +949,27 @@
           "notNull": false,
           "autoincrement": false
         },
+        "eligibility_ja": {
+          "name": "eligibility_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "eligibility_en": {
+          "name": "eligibility_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "course_gpx_file": {
+          "name": "course_gpx_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
         "waves": {
           "name": "waves",
           "type": "text",
@@ -979,6 +1000,163 @@
         "race_categories_race_id_races_id_fk": {
           "name": "race_categories_race_id_races_id_fk",
           "tableFrom": "race_categories",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_course_highlights": {
+      "name": "race_course_highlights",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "km": {
+          "name": "km",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name_ja": {
+          "name": "name_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_en": {
+          "name": "name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note_ja": {
+          "name": "note_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note_en": {
+          "name": "note_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "race_course_highlights_race_id_idx": {
+          "name": "race_course_highlights_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_course_highlights_race_id_races_id_fk": {
+          "name": "race_course_highlights_race_id_races_id_fk",
+          "tableFrom": "race_course_highlights",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_entry_links": {
+      "name": "race_entry_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "race_entry_links_race_id_idx": {
+          "name": "race_entry_links_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_entry_links_race_id_races_id_fk": {
+          "name": "race_entry_links_race_id_races_id_fk",
+          "tableFrom": "race_entry_links",
           "tableTo": "races",
           "columnsFrom": [
             "race_id"
@@ -1105,6 +1283,81 @@
       "uniqueConstraints": {},
       "checkConstraints": {}
     },
+    "race_gallery": {
+      "name": "race_gallery",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "src": {
+          "name": "src",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caption_ja": {
+          "name": "caption_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "caption_en": {
+          "name": "caption_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "race_gallery_race_id_idx": {
+          "name": "race_gallery_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_gallery_race_id_races_id_fk": {
+          "name": "race_gallery_race_id_races_id_fk",
+          "tableFrom": "race_gallery",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
     "race_results": {
       "name": "race_results",
       "columns": {
@@ -1207,6 +1460,13 @@
           "primaryKey": false,
           "notNull": false,
           "autoincrement": false
+        },
+        "avg_time": {
+          "name": "avg_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
         }
       },
       "indexes": {
@@ -1278,6 +1538,142 @@
       },
       "indexes": {},
       "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_time_buckets": {
+      "name": "race_time_buckets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pct": {
+          "name": "pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "race_time_buckets_race_id_idx": {
+          "name": "race_time_buckets_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_time_buckets_race_id_races_id_fk": {
+          "name": "race_time_buckets_race_id_races_id_fk",
+          "tableFrom": "race_time_buckets",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_voices": {
+      "name": "race_voices",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quote_ja": {
+          "name": "quote_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "race_voices_race_id_idx": {
+          "name": "race_voices_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_voices_race_id_races_id_fk": {
+          "name": "race_voices_race_id_races_id_fk",
+          "tableFrom": "race_voices",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "checkConstraints": {}
@@ -1423,6 +1819,14 @@
           "notNull": false,
           "autoincrement": false
         },
+        "entry_closed": {
+          "name": "entry_closed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
         "reception_type": {
           "name": "reception_type",
           "type": "text",
@@ -1527,6 +1931,62 @@
         },
         "course_notes_en": {
           "name": "course_notes_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "motif": {
+          "name": "motif",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "motif_color": {
+          "name": "motif_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "motif_romaji": {
+          "name": "motif_romaji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tagline_ja": {
+          "name": "tagline_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tagline_en": {
+          "name": "tagline_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hero_image_url": {
+          "name": "hero_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hero_caption_ja": {
+          "name": "hero_caption_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hero_caption_en": {
+          "name": "hero_caption_en",
           "type": "text",
           "primaryKey": false,
           "notNull": false,

--- a/migrations/meta/0007_snapshot.json
+++ b/migrations/meta/0007_snapshot.json
@@ -1,8 +1,8 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "be139410-d719-4b0d-9c96-c66aadda0a7c",
-  "prevId": "dbbf7015-4312-41ea-ab41-3cb9fe6d72e9",
+  "id": "294f48f5-745a-42f0-a18f-17cd4033dd48",
+  "prevId": "6c64b234-f9ad-4485-a9fa-8a54e1e52356",
   "tables": {
     "access_points": {
       "name": "access_points",
@@ -949,6 +949,27 @@
           "notNull": false,
           "autoincrement": false
         },
+        "eligibility_ja": {
+          "name": "eligibility_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "eligibility_en": {
+          "name": "eligibility_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "course_gpx_file": {
+          "name": "course_gpx_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
         "waves": {
           "name": "waves",
           "type": "text",
@@ -979,6 +1000,183 @@
         "race_categories_race_id_races_id_fk": {
           "name": "race_categories_race_id_races_id_fk",
           "tableFrom": "race_categories",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_course_highlights": {
+      "name": "race_course_highlights",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "km": {
+          "name": "km",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name_ja": {
+          "name": "name_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_en": {
+          "name": "name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note_ja": {
+          "name": "note_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note_en": {
+          "name": "note_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "race_course_highlights_race_id_idx": {
+          "name": "race_course_highlights_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_course_highlights_race_id_races_id_fk": {
+          "name": "race_course_highlights_race_id_races_id_fk",
+          "tableFrom": "race_course_highlights",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "race_course_highlights_category_id_race_categories_id_fk": {
+          "name": "race_course_highlights_category_id_race_categories_id_fk",
+          "tableFrom": "race_course_highlights",
+          "tableTo": "race_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_entry_links": {
+      "name": "race_entry_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "race_entry_links_race_id_idx": {
+          "name": "race_entry_links_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_entry_links_race_id_races_id_fk": {
+          "name": "race_entry_links_race_id_races_id_fk",
+          "tableFrom": "race_entry_links",
           "tableTo": "races",
           "columnsFrom": [
             "race_id"
@@ -1105,6 +1303,81 @@
       "uniqueConstraints": {},
       "checkConstraints": {}
     },
+    "race_gallery": {
+      "name": "race_gallery",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "src": {
+          "name": "src",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caption_ja": {
+          "name": "caption_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "caption_en": {
+          "name": "caption_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "race_gallery_race_id_idx": {
+          "name": "race_gallery_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_gallery_race_id_races_id_fk": {
+          "name": "race_gallery_race_id_races_id_fk",
+          "tableFrom": "race_gallery",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
     "race_results": {
       "name": "race_results",
       "columns": {
@@ -1207,6 +1480,13 @@
           "primaryKey": false,
           "notNull": false,
           "autoincrement": false
+        },
+        "avg_time": {
+          "name": "avg_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
         }
       },
       "indexes": {
@@ -1278,6 +1558,142 @@
       },
       "indexes": {},
       "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_time_buckets": {
+      "name": "race_time_buckets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pct": {
+          "name": "pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "race_time_buckets_race_id_idx": {
+          "name": "race_time_buckets_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_time_buckets_race_id_races_id_fk": {
+          "name": "race_time_buckets_race_id_races_id_fk",
+          "tableFrom": "race_time_buckets",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_voices": {
+      "name": "race_voices",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quote_ja": {
+          "name": "quote_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "race_voices_race_id_idx": {
+          "name": "race_voices_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_voices_race_id_races_id_fk": {
+          "name": "race_voices_race_id_races_id_fk",
+          "tableFrom": "race_voices",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "checkConstraints": {}
@@ -1423,6 +1839,14 @@
           "notNull": false,
           "autoincrement": false
         },
+        "entry_closed": {
+          "name": "entry_closed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
         "reception_type": {
           "name": "reception_type",
           "type": "text",
@@ -1527,6 +1951,62 @@
         },
         "course_notes_en": {
           "name": "course_notes_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "motif": {
+          "name": "motif",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "motif_color": {
+          "name": "motif_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "motif_romaji": {
+          "name": "motif_romaji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tagline_ja": {
+          "name": "tagline_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tagline_en": {
+          "name": "tagline_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hero_image_url": {
+          "name": "hero_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hero_caption_ja": {
+          "name": "hero_caption_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hero_caption_en": {
+          "name": "hero_caption_en",
           "type": "text",
           "primaryKey": false,
           "notNull": false,

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -43,6 +43,20 @@
       "when": 1776381028337,
       "tag": "0005_boring_corsair",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1778077962379,
+      "tag": "0006_high_mole_man",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1778112199465,
+      "tag": "0007_yielding_obadiah_stane",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/seed-races-all.sql
+++ b/migrations/seed-races-all.sql
@@ -1,5 +1,5 @@
 -- 自動生成: generate-seed-races.js
--- 生成日時: 2026-05-05T13:08:50.110Z
+-- 生成日時: 2026-05-08T14:21:54.324Z
 -- 対象ファイル数: 75 件（既存 2 件はskip）
 
 -- ==================
@@ -37,7 +37,7 @@ INSERT OR REPLACE INTO races (
   '2026-04-01',
   '2026-07-16',
   0,
-  'mail',
+  'pre_mail',
   '',
   '',
   '[]',
@@ -165,12 +165,12 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
   ('akita-nairiku-ultra-2026', 'other', 50, 420, '07:00', 250, 18000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 2);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('akita-nairiku-ultra-2026', NULL, '一般エントリー', 'General Entry', '2026-04-01', '2026-06-30', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('akita-nairiku-ultra-2026', NULL, '秋田内陸縦貫鉄道沿い', 'Along Akita Nairiku Railway', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('akita-nairiku-ultra-2026', NULL, '田沢湖高原', 'Tazawako Highland', NULL, NULL, 1);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('akita-nairiku-ultra-2026', NULL, '最大高低差531m', '531m elevation difference', NULL, NULL, 2);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('akita-nairiku-ultra-2026', NULL, NULL, '秋田内陸縦貫鉄道沿い', 'Along Akita Nairiku Railway', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('akita-nairiku-ultra-2026', NULL, NULL, '田沢湖高原', 'Tazawako Highland', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('akita-nairiku-ultra-2026', NULL, NULL, '最大高低差531m', '531m elevation difference', NULL, NULL, 2);
 
 -- ==================
 -- あおもり桜マラソン (aomori-sakura-marathon-2026)
@@ -207,7 +207,7 @@ INSERT OR REPLACE INTO races (
   '2025-11-01',
   '2026-01-30',
   0,
-  'mail',
+  'pre_mail',
   '',
   '',
   '["景色が良い","桜"]',
@@ -258,12 +258,12 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('aomori-sakura-marathon-2026', '["tshirt","medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('aomori-sakura-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-11-01', '2026-01-30', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('aomori-sakura-marathon-2026', NULL, '八甲田山', 'Mt. Hakkoda', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('aomori-sakura-marathon-2026', NULL, '陸奥湾', 'Mutsu Bay', NULL, NULL, 1);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('aomori-sakura-marathon-2026', NULL, '桜並木', 'cherry blossom trees', NULL, NULL, 2);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('aomori-sakura-marathon-2026', NULL, NULL, '八甲田山', 'Mt. Hakkoda', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('aomori-sakura-marathon-2026', NULL, NULL, '陸奥湾', 'Mutsu Bay', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('aomori-sakura-marathon-2026', NULL, NULL, '桜並木', 'cherry blossom trees', NULL, NULL, 2);
 
 -- ==================
 -- 旭川ハーフマラソン (asahikawa-half-marathon-2026)
@@ -345,8 +345,8 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
   ('asahikawa-half-marathon-2026', '10k', 10, 0, '08:50', 1000, 4500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 1);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('asahikawa-half-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-01', '2026-07-26', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('asahikawa-half-marathon-2026', NULL, '忠別川沿い', 'Along Chubetsu River', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('asahikawa-half-marathon-2026', NULL, NULL, '忠別川沿い', 'Along Chubetsu River', NULL, NULL, 0);
 
 -- ==================
 -- 別府大分毎日マラソン (beppu-oita-marathon-2026)
@@ -432,10 +432,10 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('beppu-oita-marathon-2026', '["tshirt"]', '大会Tシャツ', 'Race T-shirt', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('beppu-oita-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-08-29', '2025-09-11', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('beppu-oita-marathon-2026', NULL, '別府温泉街', 'Beppu hot spring town', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('beppu-oita-marathon-2026', NULL, '別大国道の海岸線', 'Betsudai coastal road', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('beppu-oita-marathon-2026', NULL, NULL, '別府温泉街', 'Beppu hot spring town', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('beppu-oita-marathon-2026', NULL, NULL, '別大国道の海岸線', 'Betsudai coastal road', NULL, NULL, 1);
 
 -- ==================
 -- びわ湖マラソン (biwako-marathon-2026)
@@ -472,7 +472,7 @@ INSERT OR REPLACE INTO races (
   '2025-08-01',
   '2025-10-31',
   0,
-  'mail',
+  'pre_mail',
   '',
   '',
   '["フラット","景色が良い","湖畔"]',
@@ -519,10 +519,10 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('biwako-marathon-2026', '温泉', 'おごと温泉', 'Ogoto Onsen', '琵琶湖西岸の温泉地。コース付近。レース後のリカバリーに便利。', 'Hot spring town on the west shore of Lake Biwa. Near the course. Convenient for post-race recovery.', 'コース付近', NULL, 35.1167, 135.8833);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('biwako-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-08-01', '2025-10-31', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('biwako-marathon-2026', NULL, '琵琶湖畔', 'Lake Biwa shore', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('biwako-marathon-2026', NULL, '比叡山', 'Mt. Hiei', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('biwako-marathon-2026', NULL, NULL, '琵琶湖畔', 'Lake Biwa shore', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('biwako-marathon-2026', NULL, NULL, '比叡山', 'Mt. Hiei', NULL, NULL, 1);
 
 -- ==================
 -- ちばアクアラインマラソン (chiba-aqualine-marathon-2026)
@@ -559,7 +559,7 @@ INSERT OR REPLACE INTO races (
   '2026-03-22',
   '2026-04-12',
   0,
-  'mail',
+  'pre_mail',
   '一般枠：3/22〜4/12。アスリート・学生・女性・海外枠：3/22〜5/7。レイトエントリー枠：5/31〜6/8。システム利用料別途。',
   'General entry: Mar 22 - Apr 12. Athlete/Student/Women/Overseas entries: Mar 22 - May 7. Late entry: May 31 - Jun 8. System fee applies separately.',
   '["大規模","日本陸連公認","景色が良い","橋","海沿い"]',
@@ -608,12 +608,12 @@ INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label
   ('chiba-aqualine-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-03-22', '2026-04-12', 16500, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('chiba-aqualine-marathon-2026', NULL, 'レイトエントリー', 'Late Entry', '2026-05-31', '2026-06-08', 16500, 1);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('chiba-aqualine-marathon-2026', NULL, '東京湾アクアライン', 'Tokyo Bay Aqualine', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('chiba-aqualine-marathon-2026', NULL, '海ほたる', 'Umihotaru PA', NULL, NULL, 1);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('chiba-aqualine-marathon-2026', NULL, '袖ケ浦の田園地帯', 'Sodegaura farmlands', NULL, NULL, 2);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('chiba-aqualine-marathon-2026', NULL, NULL, '東京湾アクアライン', 'Tokyo Bay Aqualine', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('chiba-aqualine-marathon-2026', NULL, NULL, '海ほたる', 'Umihotaru PA', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('chiba-aqualine-marathon-2026', NULL, NULL, '袖ケ浦の田園地帯', 'Sodegaura farmlands', NULL, NULL, 2);
 
 -- ==================
 -- 愛媛マラソン (ehime-marathon-2026)
@@ -699,10 +699,10 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('ehime-marathon-2026', '["tshirt","medal","towel"]', '大会オリジナルTシャツ、完走メダル、今治タオル（完走者）', 'Official race T-shirt, Finisher medal, Imabari towel (finishers)', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('ehime-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-08-01', '2025-08-19', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('ehime-marathon-2026', NULL, '松山城', 'Matsuyama Castle', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('ehime-marathon-2026', NULL, '道後温泉', 'Dogo Onsen', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('ehime-marathon-2026', NULL, NULL, '松山城', 'Matsuyama Castle', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('ehime-marathon-2026', NULL, NULL, '道後温泉', 'Dogo Onsen', NULL, NULL, 1);
 
 -- ==================
 -- 富士登山競走 (fuji-mountain-race-2026)
@@ -730,8 +730,8 @@ INSERT OR REPLACE INTO races (
   '19',
   '富士吉田市',
   'Fujiyoshida City',
-  'この山の頂には過酷に挑む価値がある',
-  'The summit of this mountain is well worth the challenge',
+  '',
+  '',
   'https://fujimountainrace.city.fujiyoshida.yamanashi.jp/',
   NULL,
   1,
@@ -739,7 +739,7 @@ INSERT OR REPLACE INTO races (
   '2026-03-28',
   '2026-04-06',
   1,
-  'mail',
+  'pre_mail',
   '受付不要。事前発送とする。
 申込後の住所変更、その他の変更事項については、必ず事務局へ連絡すること。
 大会当日、ナンバーカード、計測用RSタグを忘れると出走できなくなるので、注意すること。
@@ -759,11 +759,11 @@ Please note that if you forget your race number or timing chip on the day of the
   '',
   '',
   '',
-  '富士山',
+  '霊峰',
   '#4b5563',
-  'Fujisan',
-  '山頂を目指す、日本の頂への挑戦',
-  'Challenge to the summit — the ultimate mountain race',
+  'Reiho',
+  'この山の頂には過酷に挑む価値がある',
+  'The summit of this mountain is well worth the challenge',
   NULL,
   NULL,
   NULL,
@@ -873,12 +873,12 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('fujisan-marathon-2026', '温泉', '河口湖温泉', 'Lake Kawaguchi Onsen', '河口湖畔の温泉。富士山を望む露天風呂が魅力。レース後に最適。', 'Hot springs on the shore of Lake Kawaguchi. Open-air baths with Mt. Fuji views.', '会場付近', NULL, 35.51, 138.75);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('fujisan-marathon-2026', '["medal","tshirt","towel"]', '大会Tシャツ、完走メダル、フィニッシャータオル', 'Race T-shirt, Finisher medal, Finisher towel', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('fujisan-marathon-2026', NULL, '河口湖', 'Lake Kawaguchi', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('fujisan-marathon-2026', NULL, '西湖', 'Lake Saiko', NULL, NULL, 1);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('fujisan-marathon-2026', NULL, '紅葉の富士山', 'Mt. Fuji with autumn foliage', NULL, NULL, 2);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('fujisan-marathon-2026', NULL, NULL, '河口湖', 'Lake Kawaguchi', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('fujisan-marathon-2026', NULL, NULL, '西湖', 'Lake Saiko', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('fujisan-marathon-2026', NULL, NULL, '紅葉の富士山', 'Mt. Fuji with autumn foliage', NULL, NULL, 2);
 
 -- ==================
 -- 福知山マラソン (fukuchiyama-marathon-2026)
@@ -913,12 +913,12 @@ INSERT OR REPLACE INTO races (
   1,
   5400,
   '2026-05-01',
-  '2026-08-31',
+  '2026-05-17',
   0,
   'pre_day',
   '',
   '',
-  '["歴史ある大会","タフコース","川沿い","京都"]',
+  '["歴史ある大会"]',
   NULL,
   0,
   0,
@@ -963,17 +963,11 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('fukuchiyama-marathon-2026', '["medal","tshirt"]', '完走メダル、大会オリジナルTシャツ（レイト・直前申込を除く）', 'Finisher medal, Official race T-shirt (excluding late/last-minute entries)', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
-  ('fukuchiyama-marathon-2026', NULL, '早割', 'Early Bird', '2026-05-01', '2026-05-17', 11000, 0);
+  ('fukuchiyama-marathon-2026', NULL, '早割', 'Early Bird', '2026-05-01', '2026-05-17', 10000, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('fukuchiyama-marathon-2026', NULL, '一般', 'General', '2026-05-18', '2026-08-31', 11000, 1);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
-  ('fukuchiyama-marathon-2026', NULL, 'レイト（参加賞なし）', 'Late (no participation gift)', '2026-09-01', '2026-09-20', 11000, 2);
-INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
-  ('fukuchiyama-marathon-2026', NULL, '直前（参加賞なし）', 'Last-minute (no participation gift)', '2026-11-01', '2026-11-15', 11000, 3);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('fukuchiyama-marathon-2026', NULL, '由良川沿い', 'Along Yura River', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('fukuchiyama-marathon-2026', NULL, '福知山城周辺', 'near Fukuchiyama Castle', NULL, NULL, 1);
+  ('fukuchiyama-marathon-2026', NULL, '直前（参加賞なし）', 'Last-minute (no participation gift)', '2026-11-01', '2026-11-15', 11000, 2);
 
 -- ==================
 -- ふくい桜マラソン (fukui-sakura-marathon-2026)
@@ -1063,10 +1057,10 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('fukui-sakura-marathon-2026', '["medal","tshirt","towel"]', '大会Tシャツ、完走メダル、フィニッシャータオル', 'Race T-shirt, Finisher medal, Finisher towel', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('fukui-sakura-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-09-25', '2025-11-10', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('fukui-sakura-marathon-2026', NULL, '桜並木', 'Cherry blossom trees', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('fukui-sakura-marathon-2026', NULL, '足羽川', 'Asuwa River', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('fukui-sakura-marathon-2026', NULL, NULL, '桜並木', 'Cherry blossom trees', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('fukui-sakura-marathon-2026', NULL, NULL, '足羽川', 'Asuwa River', NULL, NULL, 1);
 
 -- ==================
 -- 福岡国際マラソン (fukuoka-international-marathon-2026)
@@ -1148,12 +1142,12 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('fukuoka-international-marathon-2026', 'グルメ', '博多ラーメン・もつ鍋', 'Hakata Ramen & Motsunabe', '福岡を代表するグルメ。中洲や天神の屋台街で楽しめる。', 'Fukuoka''s iconic dishes. Enjoy at street stalls in Nakasu and Tenjin.', '天神・中洲エリア', NULL, 33.5917, 130.4017);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('fukuoka-international-marathon-2026', '["tshirt"]', '大会Tシャツ', 'Race T-shirt', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('fukuoka-international-marathon-2026', NULL, '平和台陸上競技場', 'Heiwadai Athletics Stadium', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('fukuoka-international-marathon-2026', NULL, '大濠公園', 'Ohori Park', NULL, NULL, 1);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('fukuoka-international-marathon-2026', NULL, '海の中道方面', 'Uminonakamichi area', NULL, NULL, 2);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('fukuoka-international-marathon-2026', NULL, NULL, '平和台陸上競技場', 'Heiwadai Athletics Stadium', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('fukuoka-international-marathon-2026', NULL, NULL, '大濠公園', 'Ohori Park', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('fukuoka-international-marathon-2026', NULL, NULL, '海の中道方面', 'Uminonakamichi area', NULL, NULL, 2);
 
 -- ==================
 -- 福岡マラソン (fukuoka-marathon-2026)
@@ -1241,14 +1235,14 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('fukuoka-marathon-2026', '["medal","tshirt"]', '完走メダル、大会オリジナルTシャツ', 'Finisher medal, Official race T-shirt', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('fukuoka-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-20', '2026-05-20', 16000, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('fukuoka-marathon-2026', NULL, '天神スタート', 'Tenjin start', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('fukuoka-marathon-2026', NULL, '博多湾沿い', 'Hakata Bay coastline', NULL, NULL, 1);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('fukuoka-marathon-2026', NULL, '玄界灘', 'Genkai Sea', NULL, NULL, 2);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('fukuoka-marathon-2026', NULL, '糸島フィニッシュ', 'Itoshima finish', NULL, NULL, 3);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('fukuoka-marathon-2026', NULL, NULL, '天神スタート', 'Tenjin start', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('fukuoka-marathon-2026', NULL, NULL, '博多湾沿い', 'Hakata Bay coastline', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('fukuoka-marathon-2026', NULL, NULL, '玄界灘', 'Genkai Sea', NULL, NULL, 2);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('fukuoka-marathon-2026', NULL, NULL, '糸島フィニッシュ', 'Itoshima finish', NULL, NULL, 3);
 
 -- ==================
 -- ぐんまマラソン (gunma-marathon-2026)
@@ -1285,7 +1279,7 @@ INSERT OR REPLACE INTO races (
   '2026-04-09',
   '2026-08-17',
   0,
-  'mail',
+  'pre_mail',
   '参加者には、アスリートビブス、計測チップ、参加マニュアル等を申込時の住所に事前に発送します（10月下旬発送予定）。大会前日・当日の受付は行いません。
 
 エントリー締切後の住所変更は、郵便局にて転送手続きをお願いします。
@@ -1348,14 +1342,14 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('gunma-marathon-2026', '["medal","tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('gunma-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-09', '2026-08-17', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('gunma-marathon-2026', NULL, '赤城山', 'Mt. Akagi', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('gunma-marathon-2026', NULL, '榛名山', 'Mt. Haruna', NULL, NULL, 1);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('gunma-marathon-2026', NULL, '利根川', 'Tone River', NULL, NULL, 2);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('gunma-marathon-2026', NULL, '正田醤油スタジアム群馬', 'Shoda Shoyu Stadium Gunma', NULL, NULL, 3);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('gunma-marathon-2026', NULL, NULL, '赤城山', 'Mt. Akagi', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('gunma-marathon-2026', NULL, NULL, '榛名山', 'Mt. Haruna', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('gunma-marathon-2026', NULL, NULL, '利根川', 'Tone River', NULL, NULL, 2);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('gunma-marathon-2026', NULL, NULL, '正田醤油スタジアム群馬', 'Shoda Shoyu Stadium Gunma', NULL, NULL, 3);
 
 -- ==================
 -- さくらんぼマラソン大会 (higashine-sakuranbo-marathon-2026)
@@ -1441,10 +1435,10 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('higashine-sakuranbo-marathon-2026', '["tshirt","local_product","food"]', 'さくらんぼ「佐藤錦」、山形県産米おにぎり、大会記念Ｔシャツ、冷凍フルーツ（予定）', '', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('higashine-sakuranbo-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-02-01', '2026-03-31', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('higashine-sakuranbo-marathon-2026', NULL, 'フルーツライン', 'Fruit Line road', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('higashine-sakuranbo-marathon-2026', NULL, '神町駐屯地周辺', 'Kanomachi Garrison area', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('higashine-sakuranbo-marathon-2026', NULL, NULL, 'フルーツライン', 'Fruit Line road', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('higashine-sakuranbo-marathon-2026', NULL, NULL, '神町駐屯地周辺', 'Kanomachi Garrison area', NULL, NULL, 1);
 
 -- ==================
 -- 東日本ハーフマラソン (higashinipon-half-marathon-2026)
@@ -1526,10 +1520,10 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
   ('higashinipon-half-marathon-2026', 'other', 8, 70, '09:30', 1000, 3500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 1);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('higashinipon-half-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-01', '2026-08-17', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('higashinipon-half-marathon-2026', NULL, '在日米陸軍相模総合補給廠内', 'Inside US Army Sagami General Depot', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('higashinipon-half-marathon-2026', NULL, 'フラット周回コース', 'flat lap course', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('higashinipon-half-marathon-2026', NULL, NULL, '在日米陸軍相模総合補給廠内', 'Inside US Army Sagami General Depot', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('higashinipon-half-marathon-2026', NULL, NULL, 'フラット周回コース', 'flat lap course', NULL, NULL, 1);
 
 -- ==================
 -- 世界遺産姫路城マラソン (himeji-castle-marathon-2026)
@@ -1613,8 +1607,8 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('himeji-castle-marathon-2026', '["tshirt","medal","towel"]', '大会Tシャツ、完走メダル、フィニッシャータオル', 'Race T-shirt, Finisher medal, Finisher towel', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('himeji-castle-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-08-04', '2025-10-31', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('himeji-castle-marathon-2026', NULL, '姫路城', 'Himeji Castle', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('himeji-castle-marathon-2026', NULL, NULL, '姫路城', 'Himeji Castle', NULL, NULL, 0);
 
 -- ==================
 -- ひたちシーサイドマラソン (hitachi-seaside-marathon-2026)
@@ -1655,7 +1649,7 @@ With the scenery and the sea breeze pushing you forward, you can fully savor the
   '2026-04-13',
   '2026-08-31',
   0,
-  'mail',
+  'pre_mail',
   '大会当日の受付はありません。10月末（予定）にアスリートビブス・ランナーズチップ等を郵送いたしますので、忘れずにお持ちください',
   'There will be no on-site registration on the day of the event. We will mail your race bibs, timing chips, and other items by the end of October (tentative), so please be sure to bring them with you.',
   '[]',
@@ -1785,8 +1779,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('hofu-yomiuri-marathon-2026', '観光地', '防府天満宮', 'Hofu Tenmangu', '日本三大天神の一つ。学問の神様・菅原道真を祀る。コース付近。', 'One of Japan''s three great Tenmangu shrines. Enshrines Sugawara no Michizane, deity of learning.', 'コース付近', NULL, 34.0478, 131.5711);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('hofu-yomiuri-marathon-2026', '["medal"]', '完走メダル', 'Finisher medal', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('hofu-yomiuri-marathon-2026', NULL, '防府天満宮付近', 'Near Hofu Tenmangu Shrine', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('hofu-yomiuri-marathon-2026', NULL, NULL, '防府天満宮付近', 'Near Hofu Tenmangu Shrine', NULL, NULL, 0);
 
 -- ==================
 -- 北海道マラソン (hokkaido-marathon-2026)
@@ -1874,12 +1868,12 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('hokkaido-marathon-2026', '["tshirt","medal"]', '大会オリジナルTシャツ、完走メダル', 'Official race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('hokkaido-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-03-29', '2026-04-24', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('hokkaido-marathon-2026', NULL, '大通公園', 'Odori Park', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('hokkaido-marathon-2026', NULL, '北海道大学', 'Hokkaido University', NULL, NULL, 1);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('hokkaido-marathon-2026', NULL, '豊平川', 'Toyohira River', NULL, NULL, 2);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('hokkaido-marathon-2026', NULL, NULL, '大通公園', 'Odori Park', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('hokkaido-marathon-2026', NULL, NULL, '北海道大学', 'Hokkaido University', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('hokkaido-marathon-2026', NULL, NULL, '豊平川', 'Toyohira River', NULL, NULL, 2);
 
 -- ==================
 -- いぶすき菜の花マラソン (ibusuki-nanohana-2026)
@@ -1973,12 +1967,12 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('ibusuki-nanohana-2026', '温泉', '砂むし温泉', 'Sand Steam Bath (Sunamushi Onsen)', '指宿名物の砂蒸し温泉。海岸の天然砂の中に埋まって温まる独特の体験。レース後のリカバリーに最適。', 'Ibusuki''s famous sand steam bath. A unique experience of being buried in naturally heated sand on the beach. Perfect for post-race recovery.', '指宿市内', NULL, 31.2283, 130.6367);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('ibusuki-nanohana-2026', '["tshirt"]', '大会記念品（参加者全員）', 'Commemorative gift (all participants)', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('ibusuki-nanohana-2026', NULL, '開聞岳', 'Mt. Kaimon', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('ibusuki-nanohana-2026', NULL, '錦江湾', 'Kinko Bay', NULL, NULL, 1);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('ibusuki-nanohana-2026', NULL, '菜の花ロード', 'canola flower road', NULL, NULL, 2);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('ibusuki-nanohana-2026', NULL, NULL, '開聞岳', 'Mt. Kaimon', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('ibusuki-nanohana-2026', NULL, NULL, '錦江湾', 'Kinko Bay', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('ibusuki-nanohana-2026', NULL, NULL, '菜の花ロード', 'canola flower road', NULL, NULL, 2);
 
 -- ==================
 -- 一関国際ハーフマラソン (ichinoseki-half-marathon-2026)
@@ -2060,8 +2054,8 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
   ('ichinoseki-half-marathon-2026', '10k', 10, 85, '09:00', 500, 6000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 1);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('ichinoseki-half-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-01', '2026-06-30', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('ichinoseki-half-marathon-2026', NULL, '最大高低差15mのフラットコース', 'Flat course with only 15m elevation difference', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('ichinoseki-half-marathon-2026', NULL, NULL, '最大高低差15mのフラットコース', 'Flat course with only 15m elevation difference', NULL, NULL, 0);
 
 -- ==================
 -- 神々の島 壱岐ウルトラマラソン (iki-ultra-marathon-2026)
@@ -2098,7 +2092,7 @@ INSERT OR REPLACE INTO races (
   '2026-04-10',
   '2026-07-17',
   0,
-  'mail',
+  'pre_mail',
   'ゼッケン・計測タグ・参加賞等を事前発送します。前日受付は行いません',
   'Race bibs, timing tags, and participation prizes will be sent out in advance. There will be no registration the day before the event.',
   '["ウルトラマラソン"]',
@@ -2230,8 +2224,8 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('itabashi-city-marathon-2026', '["tshirt","medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('itabashi-city-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-08-01', '2025-11-24', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('itabashi-city-marathon-2026', NULL, '荒川河川敷', 'Arakawa Riverbank', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('itabashi-city-marathon-2026', NULL, NULL, '荒川河川敷', 'Arakawa Riverbank', NULL, NULL, 0);
 
 -- ==================
 -- いわきサンシャインマラソン (iwaki-sunshine-marathon-2026)
@@ -2321,8 +2315,8 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('iwaki-sunshine-marathon-2026', '["tshirt","medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('iwaki-sunshine-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-09-12', '2025-10-15', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('iwaki-sunshine-marathon-2026', NULL, '太平洋沿岸', 'Pacific coastline', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('iwaki-sunshine-marathon-2026', NULL, NULL, '太平洋沿岸', 'Pacific coastline', NULL, NULL, 0);
 
 -- ==================
 -- いわて盛岡シティマラソン (iwate-morioka-city-marathon-2026)
@@ -2602,8 +2596,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('kagawa-marathon-2026', '観光地', '栗林公園', 'Ritsurin Garden', '国の特別名勝。日本を代表する回遊式大名庭園。', 'A Special Place of Scenic Beauty. One of Japan''s finest strolling gardens.', '高松市内', NULL, 34.3289, 134.0467);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kagawa-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-10-06', '2025-11-24', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('kagawa-marathon-2026', NULL, '瀬戸内海', 'Seto Inland Sea', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kagawa-marathon-2026', NULL, NULL, '瀬戸内海', 'Seto Inland Sea', NULL, NULL, 0);
 
 -- ==================
 -- 鹿児島マラソン (kagoshima-marathon-2026)
@@ -2689,10 +2683,10 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('kagoshima-marathon-2026', '["tshirt","medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kagoshima-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-08-08', '2025-11-16', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('kagoshima-marathon-2026', NULL, '桜島', 'Sakurajima', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('kagoshima-marathon-2026', NULL, '錦江湾', 'Kinko Bay', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kagoshima-marathon-2026', NULL, NULL, '桜島', 'Sakurajima', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kagoshima-marathon-2026', NULL, NULL, '錦江湾', 'Kinko Bay', NULL, NULL, 1);
 
 -- ==================
 -- 下関海響マラソン (kaikyo-marathon-2026)
@@ -2780,12 +2774,12 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('kaikyo-marathon-2026', '["medal","tshirt"]', '完走メダル、大会オリジナルTシャツ', 'Finisher medal, Official race T-shirt', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kaikyo-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-05-15', '2026-07-12', 12000, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('kaikyo-marathon-2026', NULL, '関門海峡', 'Kanmon Strait', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('kaikyo-marathon-2026', NULL, '関門大橋', 'Kanmon Bridge', NULL, NULL, 1);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('kaikyo-marathon-2026', NULL, '巌流島', 'Ganryujima Island', NULL, NULL, 2);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kaikyo-marathon-2026', NULL, NULL, '関門海峡', 'Kanmon Strait', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kaikyo-marathon-2026', NULL, NULL, '関門大橋', 'Kanmon Bridge', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kaikyo-marathon-2026', NULL, NULL, '巌流島', 'Ganryujima Island', NULL, NULL, 2);
 
 -- ==================
 -- 金沢マラソン (kanazawa-marathon-2026)
@@ -2873,12 +2867,12 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('kanazawa-marathon-2026', '["medal","tshirt","local_product"]', '大会オリジナルTシャツ、完走メダル、地元特産品', 'Official race T-shirt, Finisher medal, Local specialty products', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kanazawa-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-10', '2026-05-20', 14000, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('kanazawa-marathon-2026', NULL, '兼六園', 'Kenroku-en Garden', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('kanazawa-marathon-2026', NULL, '金沢城', 'Kanazawa Castle', NULL, NULL, 1);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('kanazawa-marathon-2026', NULL, 'ひがし茶屋街付近', 'Higashi Chaya District area', NULL, NULL, 2);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kanazawa-marathon-2026', NULL, NULL, '兼六園', 'Kenroku-en Garden', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kanazawa-marathon-2026', NULL, NULL, '金沢城', 'Kanazawa Castle', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kanazawa-marathon-2026', NULL, NULL, 'ひがし茶屋街付近', 'Higashi Chaya District area', NULL, NULL, 2);
 
 -- ==================
 -- かすみがうらマラソン (kasumigaura-marathon-2026)
@@ -2966,8 +2960,8 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('kasumigaura-marathon-2026', '["tshirt","medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kasumigaura-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-12-01', '2026-01-25', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('kasumigaura-marathon-2026', NULL, '霞ヶ浦湖畔', 'Lake Kasumigaura shore', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kasumigaura-marathon-2026', NULL, NULL, '霞ヶ浦湖畔', 'Lake Kasumigaura shore', NULL, NULL, 0);
 
 -- ==================
 -- 勝田全国マラソン (katsuta-marathon-2026)
@@ -3140,10 +3134,10 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('kitakyushu-marathon-2026', '["tshirt","medal","towel"]', '大会Tシャツ、完走メダル、フィニッシャータオル', 'Race T-shirt, Finisher medal, Finisher towel', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kitakyushu-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-08-08', '2025-09-25', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('kitakyushu-marathon-2026', NULL, '小倉市街地', 'Kokura city center', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('kitakyushu-marathon-2026', NULL, '関門海峡', 'Kanmon Strait', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kitakyushu-marathon-2026', NULL, NULL, '小倉市街地', 'Kokura city center', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kitakyushu-marathon-2026', NULL, NULL, '関門海峡', 'Kanmon Strait', NULL, NULL, 1);
 
 -- ==================
 -- KIX泉州国際マラソン (kix-senshu-marathon-2026)
@@ -3227,8 +3221,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('kix-senshu-marathon-2026', '観光地', '岸和田城', 'Kishiwada Castle', 'だんじり祭りで有名な岸和田の城。コース付近。', 'The castle in Kishiwada, famous for the Danjiri Festival. Near the course.', 'コース付近', NULL, 34.4608, 135.3706);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kix-senshu-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-10-10', '2025-11-30', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('kix-senshu-marathon-2026', NULL, '泉州の海岸沿い', 'Senshu coastline', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kix-senshu-marathon-2026', NULL, NULL, '泉州の海岸沿い', 'Senshu coastline', NULL, NULL, 0);
 
 -- ==================
 -- 神戸マラソン (kobe-marathon-2026)
@@ -3334,12 +3328,12 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('kobe-marathon-2026', '["medal","tshirt","towel"]', '大会オリジナルTシャツ、完走メダル、フィニッシャータオル', 'Official race T-shirt, Finisher medal, Finisher towel', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kobe-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-17', '2026-06-01', 18000, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('kobe-marathon-2026', NULL, '明石海峡大橋', 'Akashi Kaikyo Bridge', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('kobe-marathon-2026', NULL, 'ポートアイランド', 'Port Island', NULL, NULL, 1);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('kobe-marathon-2026', NULL, 'ハーバーランド', 'Harborland', NULL, NULL, 2);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kobe-marathon-2026', NULL, NULL, '明石海峡大橋', 'Akashi Kaikyo Bridge', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kobe-marathon-2026', NULL, NULL, 'ポートアイランド', 'Port Island', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kobe-marathon-2026', NULL, NULL, 'ハーバーランド', 'Harborland', NULL, NULL, 2);
 
 -- ==================
 -- 高知龍馬マラソン (kochi-ryoma-marathon-2026)
@@ -3425,12 +3419,12 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('kochi-ryoma-marathon-2026', '["tshirt","medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kochi-ryoma-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-08-01', '2025-10-31', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('kochi-ryoma-marathon-2026', NULL, '太平洋', 'Pacific Ocean', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('kochi-ryoma-marathon-2026', NULL, '浦戸大橋', 'Urado Bridge', NULL, NULL, 1);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('kochi-ryoma-marathon-2026', NULL, '桂浜方面', 'Katsurahama area', NULL, NULL, 2);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kochi-ryoma-marathon-2026', NULL, NULL, '太平洋', 'Pacific Ocean', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kochi-ryoma-marathon-2026', NULL, NULL, '浦戸大橋', 'Urado Bridge', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kochi-ryoma-marathon-2026', NULL, NULL, '桂浜方面', 'Katsurahama area', NULL, NULL, 2);
 
 -- ==================
 -- 熊本城マラソン (kumamoto-castle-marathon-2026)
@@ -3516,8 +3510,8 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('kumamoto-castle-marathon-2026', '["tshirt","medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kumamoto-castle-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-07-29', '2025-09-24', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('kumamoto-castle-marathon-2026', NULL, '熊本城', 'Kumamoto Castle', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kumamoto-castle-marathon-2026', NULL, NULL, '熊本城', 'Kumamoto Castle', NULL, NULL, 0);
 
 -- ==================
 -- 京都マラソン (kyoto-marathon-2026)
@@ -3605,16 +3599,16 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('kyoto-marathon-2026', '["tshirt","medal"]', '大会オリジナルTシャツ、完走メダル', 'Official race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kyoto-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-07-17', '2025-09-22', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('kyoto-marathon-2026', NULL, '嵐山', 'Arashiyama', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('kyoto-marathon-2026', NULL, '金閣寺付近', 'near Kinkaku-ji', NULL, NULL, 1);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('kyoto-marathon-2026', NULL, '今出川通', 'Imadegawa-dori', NULL, NULL, 2);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('kyoto-marathon-2026', NULL, '銀閣寺付近', 'near Ginkaku-ji', NULL, NULL, 3);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('kyoto-marathon-2026', NULL, '平安神宮', 'Heian Shrine', NULL, NULL, 4);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kyoto-marathon-2026', NULL, NULL, '嵐山', 'Arashiyama', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kyoto-marathon-2026', NULL, NULL, '金閣寺付近', 'near Kinkaku-ji', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kyoto-marathon-2026', NULL, NULL, '今出川通', 'Imadegawa-dori', NULL, NULL, 2);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kyoto-marathon-2026', NULL, NULL, '銀閣寺付近', 'near Ginkaku-ji', NULL, NULL, 3);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kyoto-marathon-2026', NULL, NULL, '平安神宮', 'Heian Shrine', NULL, NULL, 4);
 
 -- ==================
 -- みえ松阪マラソン (mie-matsusaka-marathon-2026)
@@ -3696,8 +3690,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('mie-matsusaka-marathon-2026', 'グルメ', '松阪牛', 'Matsusaka Beef', '日本三大和牛の一つ。レース後のご褒美に。', 'One of Japan''s three premium wagyu. A reward after the race.', '松阪市内', NULL, 34.5778, 136.5312);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('mie-matsusaka-marathon-2026', '["tshirt","medal","local_product"]', '大会Tシャツ、完走メダル、松阪の特産品', 'Race T-shirt, Finisher medal, Matsusaka local products', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('mie-matsusaka-marathon-2026', NULL, '松阪の城下町', 'Matsusaka castle town', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('mie-matsusaka-marathon-2026', NULL, NULL, '松阪の城下町', 'Matsusaka castle town', NULL, NULL, 0);
 
 -- ==================
 -- 水戸黄門漫遊マラソン (mito-komon-manyu-marathon-2026)
@@ -3734,7 +3728,7 @@ INSERT OR REPLACE INTO races (
   '2026-04-16',
   '2026-06-30',
   1,
-  'mail',
+  'pre_mail',
   '',
   '',
   '["景色が良い","観光"]',
@@ -3783,10 +3777,10 @@ INSERT OR REPLACE INTO race_entry_links (race_id, site_name, url, sort_order) VA
   ('mito-komon-manyu-marathon-2026', 'RUNNET', 'https://runnet.jp/entry/runtes/user/pc/competitionDetailAction.do?raceId=387694&div=1', 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('mito-komon-manyu-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-16', '2026-06-30', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('mito-komon-manyu-marathon-2026', NULL, '偕楽園', 'Kairakuen Garden', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('mito-komon-manyu-marathon-2026', NULL, '千波湖', 'Lake Senba', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('mito-komon-manyu-marathon-2026', NULL, NULL, '偕楽園', 'Kairakuen Garden', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('mito-komon-manyu-marathon-2026', NULL, NULL, '千波湖', 'Lake Senba', NULL, NULL, 1);
 
 -- ==================
 -- 富士山クライムラン (mtfuji-climb-run-2026)
@@ -3969,10 +3963,10 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('nagoya-womens-marathon-2026', 'グルメ', '名古屋めし', 'Nagoya Meshi', '味噌カツ、ひつまぶし、手羽先など名古屋名物が充実。レース後のご褒美に。', 'Miso katsu, hitsumabushi, chicken wings and more Nagoya specialties. A reward after the race.', '名古屋市内', NULL, 35.1709, 136.8815);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('nagoya-womens-marathon-2026', '["medal","goods"]', 'ティファニー オリジナルペンダント（完走者全員）', 'Tiffany original pendant (all finishers)', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('nagoya-womens-marathon-2026', NULL, '名古屋ドーム（バンテリンドーム ナゴヤ）', 'Nagoya Dome (Vantelin Dome Nagoya)', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('nagoya-womens-marathon-2026', NULL, '名古屋城付近', 'near Nagoya Castle', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('nagoya-womens-marathon-2026', NULL, NULL, '名古屋ドーム（バンテリンドーム ナゴヤ）', 'Nagoya Dome (Vantelin Dome Nagoya)', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('nagoya-womens-marathon-2026', NULL, NULL, '名古屋城付近', 'near Nagoya Castle', NULL, NULL, 1);
 
 -- ==================
 -- NAHAマラソン (naha-marathon-2026)
@@ -4056,12 +4050,12 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('naha-marathon-2026', 'グルメ', '沖縄そば', 'Okinawa Soba', '沖縄を代表するご当地グルメ。あっさりとしたスープと太麺が特徴。レース後のエネルギー補給に。', 'Okinawa''s signature local dish. Characterized by light broth and thick noodles. Perfect for post-race energy.', '那覇市内各所', NULL, 26.3344, 127.7679);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('naha-marathon-2026', '["tshirt","medal"]', '大会オリジナルTシャツ、完走メダル', 'Official race T-shirt, Finisher medal', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('naha-marathon-2026', NULL, '国際通り', 'Kokusai Street', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('naha-marathon-2026', NULL, '那覇市街', 'Naha city', NULL, NULL, 1);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('naha-marathon-2026', NULL, '沖縄の風景', 'Okinawan scenery', NULL, NULL, 2);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('naha-marathon-2026', NULL, NULL, '国際通り', 'Kokusai Street', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('naha-marathon-2026', NULL, NULL, '那覇市街', 'Naha city', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('naha-marathon-2026', NULL, NULL, '沖縄の風景', 'Okinawan scenery', NULL, NULL, 2);
 
 -- ==================
 -- 奈良マラソン (nara-marathon-2026)
@@ -4145,14 +4139,14 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('nara-marathon-2026', '温泉', 'ゆららの湯 奈良店', 'Yurara no Yu Nara', '奈良市内の日帰り温泉施設。レース後のリカバリーに便利。', 'A day-trip hot spring facility in Nara city. Convenient for post-race recovery.', '奈良市内', NULL, 34.6851, 135.8048);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('nara-marathon-2026', '["tshirt","medal","towel"]', '大会オリジナルTシャツ、完走メダル、フィニッシャータオル', 'Official race T-shirt, Finisher medal, Finisher towel', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('nara-marathon-2026', NULL, '東大寺', 'Todai-ji', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('nara-marathon-2026', NULL, '春日大社', 'Kasuga Shrine', NULL, NULL, 1);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('nara-marathon-2026', NULL, '平城宮跡', 'Heijo Palace ruins', NULL, NULL, 2);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('nara-marathon-2026', NULL, '奈良公園', 'Nara Park', NULL, NULL, 3);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('nara-marathon-2026', NULL, NULL, '東大寺', 'Todai-ji', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('nara-marathon-2026', NULL, NULL, '春日大社', 'Kasuga Shrine', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('nara-marathon-2026', NULL, NULL, '平城宮跡', 'Heijo Palace ruins', NULL, NULL, 2);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('nara-marathon-2026', NULL, NULL, '奈良公園', 'Nara Park', NULL, NULL, 3);
 
 -- ==================
 -- 新潟シティマラソン (niigata-city-marathon-2026)
@@ -4401,10 +4395,10 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('okayama-marathon-2026', '["medal","tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('okayama-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-16', '2026-05-18', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('okayama-marathon-2026', NULL, '岡山城', 'Okayama Castle', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('okayama-marathon-2026', NULL, '後楽園', 'Korakuen Garden', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('okayama-marathon-2026', NULL, NULL, '岡山城', 'Okayama Castle', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('okayama-marathon-2026', NULL, NULL, '後楽園', 'Korakuen Garden', NULL, NULL, 1);
 
 -- ==================
 -- 奥信濃100トレイルランニングレース (okushinano100-2026)
@@ -4490,10 +4484,10 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
   ('okushinano100-2026', 'other', 8, 120, '07:30', 300, 5000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 3);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('okushinano100-2026', NULL, '一般エントリー', 'General Entry', '2025-12-14', '2026-05-10', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('okushinano100-2026', NULL, '奥信濃の山岳トレイル', 'Mountain trails of Okushinano', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('okushinano100-2026', NULL, '木島平村〜飯山市周辺', 'Kijimadaira to Iiyama area', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('okushinano100-2026', NULL, NULL, '奥信濃の山岳トレイル', 'Mountain trails of Okushinano', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('okushinano100-2026', NULL, NULL, '木島平村〜飯山市周辺', 'Kijimadaira to Iiyama area', NULL, NULL, 1);
 
 -- ==================
 -- 大阪マラソン (osaka-marathon-2026)
@@ -4579,14 +4573,14 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('osaka-marathon-2026', '温泉', 'スパワールド世界の大温泉', 'Spa World', '通天閣近くの大型温泉施設。レース後のリカバリーに。コースの近くにあり便利。', 'A large hot spring facility near Tsutenkaku. Convenient for post-race recovery, located near the course.', '通天閣付近', NULL, 34.6522, 135.5064);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('osaka-marathon-2026', '["tshirt","medal","towel"]', '参加記念Tシャツ、完走メダル、フィニッシャータオル', 'Commemorative T-shirt, Finisher medal, Finisher towel', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('osaka-marathon-2026', NULL, '大阪城', 'Osaka Castle', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('osaka-marathon-2026', NULL, '御堂筋', 'Midosuji', NULL, NULL, 1);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('osaka-marathon-2026', NULL, '通天閣', 'Tsutenkaku', NULL, NULL, 2);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('osaka-marathon-2026', NULL, '中之島', 'Nakanoshima', NULL, NULL, 3);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('osaka-marathon-2026', NULL, NULL, '大阪城', 'Osaka Castle', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('osaka-marathon-2026', NULL, NULL, '御堂筋', 'Midosuji', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('osaka-marathon-2026', NULL, NULL, '通天閣', 'Tsutenkaku', NULL, NULL, 2);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('osaka-marathon-2026', NULL, NULL, '中之島', 'Nakanoshima', NULL, NULL, 3);
 
 -- ==================
 -- 大阪・淀川市民マラソン (osaka-yodo-river-citizens-marathon-2026)
@@ -4631,7 +4625,7 @@ Based on themes such as “people,” “environment,” and “the Yodogawa Riv
   '2026-04-17',
   '2026-09-27',
   0,
-  'mail',
+  'pre_mail',
   '',
   '',
   '[]',
@@ -4765,10 +4759,10 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
   ('osj-ontake100-2026', 'ultra', 109, 1200, '00:00', 1200, 19000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 1);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('osj-ontake100-2026', NULL, '一般エントリー', 'General Entry', '2026-02-01', '2026-06-14', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('osj-ontake100-2026', NULL, '御嶽山麓国有林', 'National forest at Mt. Ontake base', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('osj-ontake100-2026', NULL, '特別開放区域', 'specially opened restricted area', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('osj-ontake100-2026', NULL, NULL, '御嶽山麓国有林', 'National forest at Mt. Ontake base', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('osj-ontake100-2026', NULL, NULL, '特別開放区域', 'specially opened restricted area', NULL, NULL, 1);
 
 -- ==================
 -- 佐渡トキマラソン (sado-toki-marathon-2026)
@@ -4805,7 +4799,7 @@ INSERT OR REPLACE INTO races (
   '2025-12-01',
   '2026-03-22',
   0,
-  'mail',
+  'pre_mail',
   '',
   '',
   '["景色が良い","離島"]',
@@ -4854,8 +4848,8 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('sado-toki-marathon-2026', '["medal","tshirt","local_product"]', '大会Tシャツ、完走メダル、佐渡の特産品', 'Race T-shirt, Finisher medal, Sado Island local products', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('sado-toki-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-12-01', '2026-03-22', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('sado-toki-marathon-2026', NULL, '佐渡島の自然', 'Nature of Sado Island', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('sado-toki-marathon-2026', NULL, NULL, '佐渡島の自然', 'Nature of Sado Island', NULL, NULL, 0);
 
 -- ==================
 -- さが桜マラソン (saga-sakura-marathon-2026)
@@ -4937,10 +4931,10 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('saga-sakura-marathon-2026', '観光地', '吉野ヶ里遺跡', 'Yoshinogari Ruins', '弥生時代の大規模環濠集落遺跡。国の特別史跡。佐賀市から近い。', 'A large-scale Yayoi period moated settlement. National Special Historic Site. Close to Saga city.', '佐賀市から車約20分', NULL, 33.3167, 130.3833);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('saga-sakura-marathon-2026', '["tshirt","medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('saga-sakura-marathon-2026', NULL, '桜並木', 'Cherry blossom trees', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('saga-sakura-marathon-2026', NULL, '佐賀平野', 'Saga Plain', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('saga-sakura-marathon-2026', NULL, NULL, '桜並木', 'Cherry blossom trees', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('saga-sakura-marathon-2026', NULL, NULL, '佐賀平野', 'Saga Plain', NULL, NULL, 1);
 
 -- ==================
 -- さいたまマラソン (saitama-marathon-2026)
@@ -5238,7 +5232,7 @@ Translated with DeepL.com (free version)',
   '2026-05-01',
   '2026-06-30',
   0,
-  'mail',
+  'pre_mail',
   '',
   '',
   '[]',
@@ -5458,10 +5452,10 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('shizuoka-marathon-2026', '観光地', '三保松原', 'Miho no Matsubara', '世界遺産「富士山」の構成資産。松林越しの富士山の眺望が美しい。', 'Part of the World Heritage ''Mt. Fuji''. Beautiful views of Mt. Fuji through pine groves.', '静岡市内から車約30分', NULL, 35.0136, 138.5167);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('shizuoka-marathon-2026', '["tshirt","medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('shizuoka-marathon-2026', NULL, '駿河湾', 'Suruga Bay', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('shizuoka-marathon-2026', NULL, '富士山', 'Mt. Fuji', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('shizuoka-marathon-2026', NULL, NULL, '駿河湾', 'Suruga Bay', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('shizuoka-marathon-2026', NULL, NULL, '富士山', 'Mt. Fuji', NULL, NULL, 1);
 
 -- ==================
 -- 湘南国際マラソン (shonan-international-marathon-2026)
@@ -5498,7 +5492,7 @@ INSERT OR REPLACE INTO races (
   '2026-04-04',
   '2026-09-09',
   0,
-  'mail',
+  'pre_mail',
   '計測タグは、ナンバーカードとともに事前に参加者へ発送します（事前のランナー受付はありません）。',
   'Timing tags will be sent to participants in advance along with their race numbers (there is no pre-race runner registration).',
   '["富士山","景色が良い","海沿い"]',
@@ -5547,12 +5541,12 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('shonan-international-marathon-2026', '["medal","tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('shonan-international-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-04', '2026-09-09', 16000, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('shonan-international-marathon-2026', NULL, '湘南海岸', 'Shonan coast', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('shonan-international-marathon-2026', NULL, '江の島', 'Enoshima', NULL, NULL, 1);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('shonan-international-marathon-2026', NULL, '富士山', 'Mt. Fuji', NULL, NULL, 2);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('shonan-international-marathon-2026', NULL, NULL, '湘南海岸', 'Shonan coast', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('shonan-international-marathon-2026', NULL, NULL, '江の島', 'Enoshima', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('shonan-international-marathon-2026', NULL, NULL, '富士山', 'Mt. Fuji', NULL, NULL, 2);
 
 -- ==================
 -- そうじゃ吉備路マラソン (soja-kibiji-marathon-2026)
@@ -5589,7 +5583,7 @@ INSERT OR REPLACE INTO races (
   '2025-10-01',
   '2026-01-03',
   0,
-  'mail',
+  'pre_mail',
   'すべての種目でナンバーカードを事前に発送させていただきます。
 そのため受付はございません。',
   'Number cards for all events will be sent out in advance.
@@ -5639,12 +5633,12 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('soja-kibiji-marathon-2026', '["medal","tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('soja-kibiji-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-10-01', '2026-01-03', 9100, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('soja-kibiji-marathon-2026', NULL, '備中国分寺五重塔', 'Bitchu Kokubunji five-story pagoda', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('soja-kibiji-marathon-2026', NULL, '古墳群', 'burial mounds', NULL, NULL, 1);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('soja-kibiji-marathon-2026', NULL, '吉備路', 'Kibiji', NULL, NULL, 2);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('soja-kibiji-marathon-2026', NULL, NULL, '備中国分寺五重塔', 'Bitchu Kokubunji five-story pagoda', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('soja-kibiji-marathon-2026', NULL, NULL, '古墳群', 'burial mounds', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('soja-kibiji-marathon-2026', NULL, NULL, '吉備路', 'Kibiji', NULL, NULL, 2);
 
 -- ==================
 -- 丹波篠山ABCマラソン (tamba-sasayama-abc-marathon-2026)
@@ -5726,10 +5720,10 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('tamba-sasayama-abc-marathon-2026', 'グルメ', '丹波篠山の黒豆・ぼたん鍋', 'Tamba-Sasayama Black Beans & Botan Nabe', '丹波の黒豆と猪肉のぼたん鍋が名物。秋〜冬が旬。', 'Famous for Tamba black beans and boar meat hot pot. Best in autumn-winter.', '篠山市内', NULL, 35.0764, 135.2203);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('tamba-sasayama-abc-marathon-2026', '["tshirt","local_product"]', '大会Tシャツ、丹波の特産品', 'Race T-shirt, Tamba local products', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('tamba-sasayama-abc-marathon-2026', NULL, '篠山城跡', 'Sasayama Castle ruins', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('tamba-sasayama-abc-marathon-2026', NULL, '田園風景', 'rural landscape', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tamba-sasayama-abc-marathon-2026', NULL, NULL, '篠山城跡', 'Sasayama Castle ruins', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tamba-sasayama-abc-marathon-2026', NULL, NULL, '田園風景', 'rural landscape', NULL, NULL, 1);
 
 -- ==================
 -- 館山若潮マラソン (tateyama-wakashio-2026)
@@ -5813,8 +5807,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('tateyama-wakashio-2026', 'グルメ', '房総の海鮮', 'Boso Seafood', '新鮮な海鮮が楽しめる。特に寿司や刺身がおすすめ。', 'Fresh seafood. Sushi and sashimi are especially recommended.', '館山市内', NULL, 34.9997, 139.8697);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('tateyama-wakashio-2026', '["tshirt","medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('tateyama-wakashio-2026', NULL, '房総の海岸線', 'Boso coastline', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tateyama-wakashio-2026', NULL, NULL, '房総の海岸線', 'Boso coastline', NULL, NULL, 0);
 
 -- ==================
 -- 田沢湖マラソン (tazawako-marathon-2026)
@@ -5852,7 +5846,7 @@ INSERT OR REPLACE INTO races (
   '2026-04-01',
   '2026-05-27',
   0,
-  'mail',
+  'pre_mail',
   '',
   '',
   '[]',
@@ -5980,8 +5974,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('tokushima-marathon-2026', '観光地', '鳴門の渦潮', 'Naruto Whirlpools', '世界三大潮流の一つ。大鳴門橋の遊歩道から渦潮を観察できる。', 'One of the world''s three great tidal currents. Observe whirlpools from the Onaruto Bridge walkway.', '徳島市から車約1時間', NULL, 34.2333, 134.6333);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('tokushima-marathon-2026', '["tshirt","medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('tokushima-marathon-2026', NULL, '吉野川', 'Yoshino River', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tokushima-marathon-2026', NULL, NULL, '吉野川', 'Yoshino River', NULL, NULL, 0);
 
 -- ==================
 -- 東京マラソン (tokyo-marathon-2026)
@@ -6073,18 +6067,18 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('tokyo-marathon-2026', '["medal","tshirt","towel"]', '参加記念Tシャツ（参加者全員）、完走メダル（完走者）、完走タオル（完走者）', 'Commemorative T-shirt (all participants), Finisher medal (finishers), Finisher towel (finishers)', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('tokyo-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-08-15', '2025-08-29', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('tokyo-marathon-2026', NULL, '東京都庁', 'Tokyo Metropolitan Government', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('tokyo-marathon-2026', NULL, '皇居', 'Imperial Palace', NULL, NULL, 1);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('tokyo-marathon-2026', NULL, '浅草雷門', 'Asakusa Kaminarimon', NULL, NULL, 2);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('tokyo-marathon-2026', NULL, '銀座', 'Ginza', NULL, NULL, 3);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('tokyo-marathon-2026', NULL, '東京タワー', 'Tokyo Tower', NULL, NULL, 4);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('tokyo-marathon-2026', NULL, '東京駅丸の内', 'Tokyo Station Marunouchi', NULL, NULL, 5);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tokyo-marathon-2026', NULL, NULL, '東京都庁', 'Tokyo Metropolitan Government', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tokyo-marathon-2026', NULL, NULL, '皇居', 'Imperial Palace', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tokyo-marathon-2026', NULL, NULL, '浅草雷門', 'Asakusa Kaminarimon', NULL, NULL, 2);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tokyo-marathon-2026', NULL, NULL, '銀座', 'Ginza', NULL, NULL, 3);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tokyo-marathon-2026', NULL, NULL, '東京タワー', 'Tokyo Tower', NULL, NULL, 4);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tokyo-marathon-2026', NULL, NULL, '東京駅丸の内', 'Tokyo Station Marunouchi', NULL, NULL, 5);
 
 -- ==================
 -- 東京マラソン (tokyo-marathon-2027)
@@ -6176,18 +6170,18 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('tokyo-marathon-2027', '["medal","tshirt","towel"]', '参加記念Tシャツ（参加者全員）、完走メダル（完走者）、完走タオル（完走者）', 'Commemorative T-shirt (all participants), Finisher medal (finishers), Finisher towel (finishers)', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('tokyo-marathon-2027', NULL, '一般エントリー', 'General Entry', '2026-08-14', '2026-08-28', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('tokyo-marathon-2027', NULL, '東京都庁', 'Tokyo Metropolitan Government', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('tokyo-marathon-2027', NULL, '皇居', 'Imperial Palace', NULL, NULL, 1);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('tokyo-marathon-2027', NULL, '浅草雷門', 'Asakusa Kaminarimon', NULL, NULL, 2);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('tokyo-marathon-2027', NULL, '銀座', 'Ginza', NULL, NULL, 3);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('tokyo-marathon-2027', NULL, '東京タワー', 'Tokyo Tower', NULL, NULL, 4);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('tokyo-marathon-2027', NULL, '東京駅丸の内', 'Tokyo Station Marunouchi', NULL, NULL, 5);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tokyo-marathon-2027', NULL, NULL, '東京都庁', 'Tokyo Metropolitan Government', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tokyo-marathon-2027', NULL, NULL, '皇居', 'Imperial Palace', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tokyo-marathon-2027', NULL, NULL, '浅草雷門', 'Asakusa Kaminarimon', NULL, NULL, 2);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tokyo-marathon-2027', NULL, NULL, '銀座', 'Ginza', NULL, NULL, 3);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tokyo-marathon-2027', NULL, NULL, '東京タワー', 'Tokyo Tower', NULL, NULL, 4);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tokyo-marathon-2027', NULL, NULL, '東京駅丸の内', 'Tokyo Station Marunouchi', NULL, NULL, 5);
 
 -- ==================
 -- 富里スイカロードレース (tomisato-suikaroad-2026)
@@ -6218,13 +6212,13 @@ INSERT OR REPLACE INTO races (
   'スイカの一大産地・千葉県富里市で毎年6月に開催される人気大会。エイドステーションでスイカを食べながら走れる名物大会。コース沿いのスイカ畑が広がる田園風景の中、7kmと10kmで競う。マイカップ給水対応。',
   'A popular race held every June in Tomisato City, Chiba, the top watermelon-producing area in Japan. Famous for eating watermelon at aid stations while running. Race through scenic watermelon fields in 7km and 10km distances. Supports personal cup hydration.',
   'https://tomisato-suikaroad.jp/',
-  0,
+  NULL,
   1,
   0,
   '2026-02-22',
   '2026-04-04',
   0,
-  'same_day',
+  'race_day',
   '雨天決行。スポーツエントリー（インターネット）で申込。先着順。',
   'Held rain or shine. Entry via Sports Entry (online). First-come, first-served.',
   '["ご当地エイド","ご当地グルメ","コスパが良い","初心者おすすめ","夏マラソン"]',
@@ -6238,9 +6232,9 @@ INSERT OR REPLACE INTO races (
   'Scenic watermelon fields',
   'エイドでスイカ配布。マイカップ給水対応。',
   'Watermelon served at aid stations. Personal cup hydration supported.',
-  'スイカ',
+  '給スイカ所',
   '#16a34a',
-  'Suika',
+  'KyuSuika',
   '日本一のスイカの産地・富里を走る、夏の風物詩',
   'Run Japan''s watermelon capital — a midsummer tradition',
   NULL,
@@ -6269,10 +6263,10 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
   ('tomisato-suikaroad-2026', 'other', 7, 90, '10:00', 5100, 6500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 1);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('tomisato-suikaroad-2026', '["tshirt"]', 'Tシャツ（大会当日、「Tシャツ引換所」で引き換え）', '', NULL, 0);
+INSERT OR REPLACE INTO race_entry_links (race_id, site_name, url, sort_order) VALUES
+  ('tomisato-suikaroad-2026', 'SPORT ENTRY', 'https://www.sportsentry.ne.jp/event/t/104032', 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('tomisato-suikaroad-2026', NULL, '一般エントリー', 'General Entry', '2026-02-22', '2026-04-04', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('tomisato-suikaroad-2026', NULL, 'スイカ畑の田園風景', 'Scenic watermelon fields', NULL, NULL, 0);
 
 -- ==================
 -- 鳥取マラソン (tottori-marathon-2026)
@@ -6363,10 +6357,10 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
 ', 'Race T-shirt', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('tottori-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-10-15', '2025-12-12', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('tottori-marathon-2026', NULL, '鳥取砂丘付近', 'Near Tottori Sand Dunes', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('tottori-marathon-2026', NULL, '日本海', 'Sea of Japan', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tottori-marathon-2026', NULL, NULL, '鳥取砂丘付近', 'Near Tottori Sand Dunes', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tottori-marathon-2026', NULL, NULL, '日本海', 'Sea of Japan', NULL, NULL, 1);
 
 -- ==================
 -- 洞爺湖マラソン (toyako-marathon-2026)
@@ -6452,10 +6446,10 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('toyako-marathon-2026', '["medal","tshirt"]', '大会Tシャツとトートバッグ及びフェイスタオル、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('toyako-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-02-01', '2026-03-08', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('toyako-marathon-2026', NULL, '洞爺湖', 'Lake Toya', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('toyako-marathon-2026', NULL, '羊蹄山', 'Mt. Yotei', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('toyako-marathon-2026', NULL, NULL, '洞爺湖', 'Lake Toya', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('toyako-marathon-2026', NULL, NULL, '羊蹄山', 'Mt. Yotei', NULL, NULL, 1);
 
 -- ==================
 -- 富山マラソン (toyama-marathon-2026)
@@ -6541,12 +6535,12 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('toyama-marathon-2026', '["medal","tshirt","towel"]', '大会Tシャツ、完走メダル・フィニッシャータオル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('toyama-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-11', '2026-06-30', 14000, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('toyama-marathon-2026', NULL, '立山連峰', 'Tateyama Mountains', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('toyama-marathon-2026', NULL, '新湊大橋', 'Shinminato Bridge', NULL, NULL, 1);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('toyama-marathon-2026', NULL, '富山湾', 'Toyama Bay', NULL, NULL, 2);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('toyama-marathon-2026', NULL, NULL, '立山連峰', 'Tateyama Mountains', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('toyama-marathon-2026', NULL, NULL, '新湊大橋', 'Shinminato Bridge', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('toyama-marathon-2026', NULL, NULL, '富山湾', 'Toyama Bay', NULL, NULL, 2);
 
 -- ==================
 -- つくばマラソン (tsukuba-marathon-2026)
@@ -6628,8 +6622,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('tsukuba-marathon-2026', '観光地', '筑波山', 'Mt. Tsukuba', '関東平野にそびえる名山。ロープウェイで山頂へ。コースからも望める。', 'A famous mountain rising from the Kanto Plain. Ropeway to the summit. Visible from the course.', 'つくば市から車約30分', NULL, 36.2253, 140.1);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('tsukuba-marathon-2026', '["medal","tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('tsukuba-marathon-2026', NULL, '筑波研究学園都市', 'Tsukuba Science City', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tsukuba-marathon-2026', NULL, NULL, '筑波研究学園都市', 'Tsukuba Science City', NULL, NULL, 0);
 
 -- ==================
 -- 日本最北端わっかない平和マラソン (wakkanai-peace-marathon-2026)
@@ -6715,12 +6709,12 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('wakkanai-peace-marathon-2026', '["medal","tshirt"]', '完走メダル、大会オリジナルTシャツ', 'Finisher medal, Official race T-shirt', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('wakkanai-peace-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-01', '2026-06-30', 10000, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('wakkanai-peace-marathon-2026', NULL, '稚内港北防波堤ドーム', 'Wakkanai Port Northern Breakwater Dome', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('wakkanai-peace-marathon-2026', NULL, '日本海', 'Sea of Japan', NULL, NULL, 1);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('wakkanai-peace-marathon-2026', NULL, '宗谷岬方面の眺望', 'views toward Cape Soya', NULL, NULL, 2);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('wakkanai-peace-marathon-2026', NULL, NULL, '稚内港北防波堤ドーム', 'Wakkanai Port Northern Breakwater Dome', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('wakkanai-peace-marathon-2026', NULL, NULL, '日本海', 'Sea of Japan', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('wakkanai-peace-marathon-2026', NULL, NULL, '宗谷岬方面の眺望', 'views toward Cape Soya', NULL, NULL, 2);
 
 -- ==================
 -- 横浜マラソン (yokohama-marathon-2026)
@@ -6806,12 +6800,12 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('yokohama-marathon-2026', '["medal","tshirt","towel"]', '大会Tシャツ、完走メダル、フィニッシャータオル', 'Race T-shirt, Finisher medal, Finisher towel', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('yokohama-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-08', '2026-05-08', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('yokohama-marathon-2026', NULL, 'みなとみらい', 'Minato Mirai', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('yokohama-marathon-2026', NULL, '赤レンガ倉庫', 'Red Brick Warehouse', NULL, NULL, 1);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('yokohama-marathon-2026', NULL, '首都高速湾岸線', 'Bayshore Expressway', NULL, NULL, 2);
-INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('yokohama-marathon-2026', NULL, '山下公園', 'Yamashita Park', NULL, NULL, 3);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('yokohama-marathon-2026', NULL, NULL, 'みなとみらい', 'Minato Mirai', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('yokohama-marathon-2026', NULL, NULL, '赤レンガ倉庫', 'Red Brick Warehouse', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('yokohama-marathon-2026', NULL, NULL, '首都高速湾岸線', 'Bayshore Expressway', NULL, NULL, 2);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('yokohama-marathon-2026', NULL, NULL, '山下公園', 'Yamashita Park', NULL, NULL, 3);
 

--- a/migrations/seed-races-all.sql
+++ b/migrations/seed-races-all.sql
@@ -1,5 +1,5 @@
 -- 自動生成: generate-seed-races.js
--- 生成日時: 2026-05-04T12:41:53.063Z
+-- 生成日時: 2026-05-05T13:08:50.110Z
 -- 対象ファイル数: 75 件（既存 2 件はskip）
 
 -- ==================
@@ -51,11 +51,11 @@ INSERT OR REPLACE INTO races (
   '',
   '',
   '',
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '流氷',
+  '#bfdbfe',
+  'Ryuhyo',
+  '流氷の大地を駆け抜ける春の42km',
+  'Run through the land of drift ice in spring',
   NULL,
   NULL,
   NULL,
@@ -132,11 +132,11 @@ INSERT OR REPLACE INTO races (
   'Along Akita Nairiku Railway, Tazawako Highland, 531m elevation difference',
   'きりたんぽ等ご当地グルメのエイドあり。',
   'Aid stations featuring local cuisine including kiritanpo.',
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '紅葉',
+  '#d4631a',
+  'Koyo',
+  '秋田内陸の紅葉の回廊を走る100km',
+  'A 100km journey through autumn foliage corridors',
   NULL,
   NULL,
   NULL,
@@ -165,6 +165,12 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
   ('akita-nairiku-ultra-2026', 'other', 50, 420, '07:00', 250, 18000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 2);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('akita-nairiku-ultra-2026', NULL, '一般エントリー', 'General Entry', '2026-04-01', '2026-06-30', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('akita-nairiku-ultra-2026', NULL, '秋田内陸縦貫鉄道沿い', 'Along Akita Nairiku Railway', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('akita-nairiku-ultra-2026', NULL, '田沢湖高原', 'Tazawako Highland', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('akita-nairiku-ultra-2026', NULL, '最大高低差531m', '531m elevation difference', NULL, NULL, 2);
 
 -- ==================
 -- あおもり桜マラソン (aomori-sakura-marathon-2026)
@@ -215,11 +221,11 @@ INSERT OR REPLACE INTO races (
   'Mt. Hakkoda, Mutsu Bay, cherry blossom trees',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '桜',
+  '#f9c1cc',
+  'Sakura',
+  '桜前線に乗って、青森を走る',
+  'Run through Aomori on the cherry blossom front',
   NULL,
   NULL,
   NULL,
@@ -252,6 +258,12 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('aomori-sakura-marathon-2026', '["tshirt","medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('aomori-sakura-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-11-01', '2026-01-30', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('aomori-sakura-marathon-2026', NULL, '八甲田山', 'Mt. Hakkoda', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('aomori-sakura-marathon-2026', NULL, '陸奥湾', 'Mutsu Bay', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('aomori-sakura-marathon-2026', NULL, '桜並木', 'cherry blossom trees', NULL, NULL, 2);
 
 -- ==================
 -- 旭川ハーフマラソン (asahikawa-half-marathon-2026)
@@ -302,11 +314,11 @@ INSERT OR REPLACE INTO races (
   'Along Chubetsu River',
   '',
   '',
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '大雪山',
+  '#dbeafe',
+  'Taisetsuzan',
+  '大雪山を仰ぎながら旭川の街を駆ける',
+  'Run through Asahikawa with Mt. Taisetsu in view',
   NULL,
   NULL,
   NULL,
@@ -333,6 +345,8 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
   ('asahikawa-half-marathon-2026', '10k', 10, 0, '08:50', 1000, 4500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 1);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('asahikawa-half-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-01', '2026-07-26', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('asahikawa-half-marathon-2026', NULL, '忠別川沿い', 'Along Chubetsu River', NULL, NULL, 0);
 
 -- ==================
 -- 別府大分毎日マラソン (beppu-oita-marathon-2026)
@@ -383,11 +397,11 @@ INSERT OR REPLACE INTO races (
   'Beppu hot spring town, Betsudai coastal road',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '温泉',
+  '#fed7aa',
+  'Onsen',
+  '湯けむりの街から、大分へ。歴史ある42.195km',
+  'From the city of hot springs to Oita — a storied 42.195km',
   NULL,
   NULL,
   NULL,
@@ -418,6 +432,10 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('beppu-oita-marathon-2026', '["tshirt"]', '大会Tシャツ', 'Race T-shirt', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('beppu-oita-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-08-29', '2025-09-11', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('beppu-oita-marathon-2026', NULL, '別府温泉街', 'Beppu hot spring town', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('beppu-oita-marathon-2026', NULL, '別大国道の海岸線', 'Betsudai coastal road', NULL, NULL, 1);
 
 -- ==================
 -- びわ湖マラソン (biwako-marathon-2026)
@@ -468,11 +486,11 @@ INSERT OR REPLACE INTO races (
   'Lake Biwa shore, Mt. Hiei',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '琵琶湖',
+  '#93c5fd',
+  'Biwako',
+  '日本最大の湖を舞台に、水の都を走る',
+  'Run along Japan''s largest lake',
   NULL,
   NULL,
   NULL,
@@ -501,6 +519,10 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('biwako-marathon-2026', '温泉', 'おごと温泉', 'Ogoto Onsen', '琵琶湖西岸の温泉地。コース付近。レース後のリカバリーに便利。', 'Hot spring town on the west shore of Lake Biwa. Near the course. Convenient for post-race recovery.', 'コース付近', NULL, 35.1167, 135.8833);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('biwako-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-08-01', '2025-10-31', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('biwako-marathon-2026', NULL, '琵琶湖畔', 'Lake Biwa shore', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('biwako-marathon-2026', NULL, '比叡山', 'Mt. Hiei', NULL, NULL, 1);
 
 -- ==================
 -- ちばアクアラインマラソン (chiba-aqualine-marathon-2026)
@@ -551,11 +573,11 @@ INSERT OR REPLACE INTO races (
   'Tokyo Bay Aqualine, Umihotaru PA, Sodegaura farmlands',
   '強風時は短縮コース（マラソン→31.4km、ハーフ→10.3km）に変更。給水16箇所、給食15箇所、関門9箇所。',
   'May be shortened to 31.4km / 10.3km in strong winds. 16 water stations, 15 food stations, 9 checkpoints.',
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '海',
+  '#0ea5e9',
+  'Umi',
+  '東京湾アクアラインを渡る、世界唯一のコース',
+  'The world-unique course crossing Tokyo Bay Aqua-Line',
   NULL,
   NULL,
   NULL,
@@ -586,6 +608,12 @@ INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label
   ('chiba-aqualine-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-03-22', '2026-04-12', 16500, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('chiba-aqualine-marathon-2026', NULL, 'レイトエントリー', 'Late Entry', '2026-05-31', '2026-06-08', 16500, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('chiba-aqualine-marathon-2026', NULL, '東京湾アクアライン', 'Tokyo Bay Aqualine', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('chiba-aqualine-marathon-2026', NULL, '海ほたる', 'Umihotaru PA', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('chiba-aqualine-marathon-2026', NULL, '袖ケ浦の田園地帯', 'Sodegaura farmlands', NULL, NULL, 2);
 
 -- ==================
 -- 愛媛マラソン (ehime-marathon-2026)
@@ -636,11 +664,11 @@ INSERT OR REPLACE INTO races (
   'Matsuyama Castle, Dogo Onsen',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  'みかん',
+  '#f97316',
+  'Mikan',
+  '蜜柑の香り漂う、瀬戸内の道を走る',
+  'Run through the Seto Inland citrus country',
   NULL,
   NULL,
   NULL,
@@ -671,6 +699,10 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('ehime-marathon-2026', '["tshirt","medal","towel"]', '大会オリジナルTシャツ、完走メダル、今治タオル（完走者）', 'Official race T-shirt, Finisher medal, Imabari towel (finishers)', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('ehime-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-08-01', '2025-08-19', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('ehime-marathon-2026', NULL, '松山城', 'Matsuyama Castle', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('ehime-marathon-2026', NULL, '道後温泉', 'Dogo Onsen', NULL, NULL, 1);
 
 -- ==================
 -- 富士登山競走 (fuji-mountain-race-2026)
@@ -727,11 +759,11 @@ Please note that if you forget your race number or timing chip on the day of the
   '',
   '',
   '',
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '富士山',
+  '#4b5563',
+  'Fujisan',
+  '山頂を目指す、日本の頂への挑戦',
+  'Challenge to the summit — the ultimate mountain race',
   NULL,
   NULL,
   NULL,
@@ -810,11 +842,11 @@ INSERT OR REPLACE INTO races (
   'Lake Kawaguchi, Lake Saiko, Mt. Fuji with autumn foliage',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '富士山',
+  '#2a4fa3',
+  'Fujisan',
+  '霊峰富士を望みながら駆ける、絶景のコース',
+  'Run with Japan''s sacred peak as your guide',
   NULL,
   NULL,
   NULL,
@@ -841,6 +873,12 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('fujisan-marathon-2026', '温泉', '河口湖温泉', 'Lake Kawaguchi Onsen', '河口湖畔の温泉。富士山を望む露天風呂が魅力。レース後に最適。', 'Hot springs on the shore of Lake Kawaguchi. Open-air baths with Mt. Fuji views.', '会場付近', NULL, 35.51, 138.75);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('fujisan-marathon-2026', '["medal","tshirt","towel"]', '大会Tシャツ、完走メダル、フィニッシャータオル', 'Race T-shirt, Finisher medal, Finisher towel', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('fujisan-marathon-2026', NULL, '河口湖', 'Lake Kawaguchi', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('fujisan-marathon-2026', NULL, '西湖', 'Lake Saiko', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('fujisan-marathon-2026', NULL, '紅葉の富士山', 'Mt. Fuji with autumn foliage', NULL, NULL, 2);
 
 -- ==================
 -- 福知山マラソン (fukuchiyama-marathon-2026)
@@ -891,11 +929,11 @@ INSERT OR REPLACE INTO races (
   'Along Yura River, near Fukuchiyama Castle',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '福知山城',
+  '#78350f',
+  'Fukuchiyama-jo',
+  '城下町・福知山の歴史街道を駆け抜ける',
+  'Run through the historic castle town of Fukuchiyama',
   NULL,
   NULL,
   NULL,
@@ -932,6 +970,10 @@ INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label
   ('fukuchiyama-marathon-2026', NULL, 'レイト（参加賞なし）', 'Late (no participation gift)', '2026-09-01', '2026-09-20', 11000, 2);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('fukuchiyama-marathon-2026', NULL, '直前（参加賞なし）', 'Last-minute (no participation gift)', '2026-11-01', '2026-11-15', 11000, 3);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('fukuchiyama-marathon-2026', NULL, '由良川沿い', 'Along Yura River', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('fukuchiyama-marathon-2026', NULL, '福知山城周辺', 'near Fukuchiyama Castle', NULL, NULL, 1);
 
 -- ==================
 -- ふくい桜マラソン (fukui-sakura-marathon-2026)
@@ -982,11 +1024,11 @@ INSERT OR REPLACE INTO races (
   'Cherry blossom trees, Asuwa River',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '桜',
+  '#f9c1cc',
+  'Sakura',
+  '福井の桜回廊を巡る、春の42km',
+  'A spring 42km through Fukui''s cherry blossom corridors',
   NULL,
   NULL,
   NULL,
@@ -1021,6 +1063,10 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('fukui-sakura-marathon-2026', '["medal","tshirt","towel"]', '大会Tシャツ、完走メダル、フィニッシャータオル', 'Race T-shirt, Finisher medal, Finisher towel', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('fukui-sakura-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-09-25', '2025-11-10', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('fukui-sakura-marathon-2026', NULL, '桜並木', 'Cherry blossom trees', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('fukui-sakura-marathon-2026', NULL, '足羽川', 'Asuwa River', NULL, NULL, 1);
 
 -- ==================
 -- 福岡国際マラソン (fukuoka-international-marathon-2026)
@@ -1071,11 +1117,11 @@ INSERT OR REPLACE INTO races (
   'Heiwadai Athletics Stadium, Ohori Park, Uminonakamichi area',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '博多',
+  '#1e3a5f',
+  'Hakata',
+  '国際都市・福岡が誇る、世界へ続く道',
+  'A world-class course in the international city of Fukuoka',
   NULL,
   NULL,
   NULL,
@@ -1102,6 +1148,12 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('fukuoka-international-marathon-2026', 'グルメ', '博多ラーメン・もつ鍋', 'Hakata Ramen & Motsunabe', '福岡を代表するグルメ。中洲や天神の屋台街で楽しめる。', 'Fukuoka''s iconic dishes. Enjoy at street stalls in Nakasu and Tenjin.', '天神・中洲エリア', NULL, 33.5917, 130.4017);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('fukuoka-international-marathon-2026', '["tshirt"]', '大会Tシャツ', 'Race T-shirt', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('fukuoka-international-marathon-2026', NULL, '平和台陸上競技場', 'Heiwadai Athletics Stadium', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('fukuoka-international-marathon-2026', NULL, '大濠公園', 'Ohori Park', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('fukuoka-international-marathon-2026', NULL, '海の中道方面', 'Uminonakamichi area', NULL, NULL, 2);
 
 -- ==================
 -- 福岡マラソン (fukuoka-marathon-2026)
@@ -1152,11 +1204,11 @@ INSERT OR REPLACE INTO races (
   'Tenjin start, Hakata Bay coastline, Genkai Sea, Itoshima finish',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '博多湾',
+  '#0284c7',
+  'Hakata-wan',
+  '博多の海沿いを走る、秋の風物詩',
+  'Run along Hakata Bay in autumn',
   NULL,
   NULL,
   NULL,
@@ -1189,6 +1241,14 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('fukuoka-marathon-2026', '["medal","tshirt"]', '完走メダル、大会オリジナルTシャツ', 'Finisher medal, Official race T-shirt', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('fukuoka-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-20', '2026-05-20', 16000, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('fukuoka-marathon-2026', NULL, '天神スタート', 'Tenjin start', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('fukuoka-marathon-2026', NULL, '博多湾沿い', 'Hakata Bay coastline', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('fukuoka-marathon-2026', NULL, '玄界灘', 'Genkai Sea', NULL, NULL, 2);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('fukuoka-marathon-2026', NULL, '糸島フィニッシュ', 'Itoshima finish', NULL, NULL, 3);
 
 -- ==================
 -- ぐんまマラソン (gunma-marathon-2026)
@@ -1249,11 +1309,11 @@ If you are unable to participate after registering, you do not need to contact u
   'Mt. Akagi, Mt. Haruna, Tone River, Shoda Shoyu Stadium Gunma',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '赤城山',
+  '#166534',
+  'Akagi-san',
+  '赤城を仰ぎ、前橋の大地を駆ける',
+  'Run across Maebashi plain with Mt. Akagi in view',
   NULL,
   NULL,
   NULL,
@@ -1288,6 +1348,14 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('gunma-marathon-2026', '["medal","tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('gunma-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-09', '2026-08-17', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('gunma-marathon-2026', NULL, '赤城山', 'Mt. Akagi', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('gunma-marathon-2026', NULL, '榛名山', 'Mt. Haruna', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('gunma-marathon-2026', NULL, '利根川', 'Tone River', NULL, NULL, 2);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('gunma-marathon-2026', NULL, '正田醤油スタジアム群馬', 'Shoda Shoyu Stadium Gunma', NULL, NULL, 3);
 
 -- ==================
 -- さくらんぼマラソン大会 (higashine-sakuranbo-marathon-2026)
@@ -1338,11 +1406,11 @@ INSERT OR REPLACE INTO races (
   'Fruit Line road, Kanomachi Garrison area',
   'スタート・フィニッシュ：陸上自衛隊神町駐屯地。',
   'Start/Finish: JGSDF Kanomachi Garrison.',
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  'さくらんぼ',
+  '#dc2626',
+  'Sakuranbo',
+  'さくらんぼの里・東根で走る、甘い42km',
+  'Run 42km in Japan''s cherry capital',
   NULL,
   NULL,
   NULL,
@@ -1373,6 +1441,10 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('higashine-sakuranbo-marathon-2026', '["tshirt","local_product","food"]', 'さくらんぼ「佐藤錦」、山形県産米おにぎり、大会記念Ｔシャツ、冷凍フルーツ（予定）', '', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('higashine-sakuranbo-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-02-01', '2026-03-31', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('higashine-sakuranbo-marathon-2026', NULL, 'フルーツライン', 'Fruit Line road', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('higashine-sakuranbo-marathon-2026', NULL, '神町駐屯地周辺', 'Kanomachi Garrison area', NULL, NULL, 1);
 
 -- ==================
 -- 東日本ハーフマラソン (higashinipon-half-marathon-2026)
@@ -1423,11 +1495,11 @@ INSERT OR REPLACE INTO races (
   'Inside US Army Sagami General Depot, flat lap course',
   'アメリカンフード提供。',
   'American food provided.',
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '桜',
+  '#f9c1cc',
+  'Sakura',
+  '立川の春を駆け抜ける東日本ハーフ',
+  'East Japan Half Marathon through spring Tachikawa',
   NULL,
   NULL,
   NULL,
@@ -1454,6 +1526,10 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
   ('higashinipon-half-marathon-2026', 'other', 8, 70, '09:30', 1000, 3500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 1);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('higashinipon-half-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-01', '2026-08-17', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('higashinipon-half-marathon-2026', NULL, '在日米陸軍相模総合補給廠内', 'Inside US Army Sagami General Depot', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('higashinipon-half-marathon-2026', NULL, 'フラット周回コース', 'flat lap course', NULL, NULL, 1);
 
 -- ==================
 -- 世界遺産姫路城マラソン (himeji-castle-marathon-2026)
@@ -1504,11 +1580,11 @@ INSERT OR REPLACE INTO races (
   'Himeji Castle',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '姫路城',
+  '#f8fafc',
+  'Himeji-jo',
+  '世界遺産・白鷺城を眺めながら走る42.195km',
+  'Run beneath the White Heron Castle, a World Heritage Site',
   NULL,
   NULL,
   NULL,
@@ -1537,6 +1613,8 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('himeji-castle-marathon-2026', '["tshirt","medal","towel"]', '大会Tシャツ、完走メダル、フィニッシャータオル', 'Race T-shirt, Finisher medal, Finisher towel', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('himeji-castle-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-08-04', '2025-10-31', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('himeji-castle-marathon-2026', NULL, '姫路城', 'Himeji Castle', NULL, NULL, 0);
 
 -- ==================
 -- ひたちシーサイドマラソン (hitachi-seaside-marathon-2026)
@@ -1591,11 +1669,11 @@ With the scenery and the sea breeze pushing you forward, you can fully savor the
   '',
   '',
   '',
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  'コキア',
+  '#dc2626',
+  'Kochiya',
+  '海浜公園のコキアが彩る、ひたちの秋',
+  'Run through Hitachi Seaside Park''s autumn kochia fields',
   NULL,
   NULL,
   NULL,
@@ -1676,11 +1754,11 @@ INSERT OR REPLACE INTO races (
   'Near Hofu Tenmangu Shrine',
   '制限時間4時間。サブ4の走力が必要。',
   '4-hour time limit. Sub-4 running ability required.',
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '防府天満宮',
+  '#92400e',
+  'Hofu-Tenmangu',
+  '日本最古の天満宮の参道を巡る歴史ある大会',
+  'Race through the grounds of Japan''s oldest Tenmangu shrine',
   NULL,
   NULL,
   NULL,
@@ -1707,6 +1785,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('hofu-yomiuri-marathon-2026', '観光地', '防府天満宮', 'Hofu Tenmangu', '日本三大天神の一つ。学問の神様・菅原道真を祀る。コース付近。', 'One of Japan''s three great Tenmangu shrines. Enshrines Sugawara no Michizane, deity of learning.', 'コース付近', NULL, 34.0478, 131.5711);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('hofu-yomiuri-marathon-2026', '["medal"]', '完走メダル', 'Finisher medal', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('hofu-yomiuri-marathon-2026', NULL, '防府天満宮付近', 'Near Hofu Tenmangu Shrine', NULL, NULL, 0);
 
 -- ==================
 -- 北海道マラソン (hokkaido-marathon-2026)
@@ -1757,11 +1837,11 @@ INSERT OR REPLACE INTO races (
   'Odori Park, Hokkaido University, Toyohira River',
   '夏開催のため暑さ対策が必須。制限時間6時間。',
   'Summer heat countermeasures essential. 6-hour time limit.',
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  'ライラック',
+  '#8b5cf6',
+  'Rairakku',
+  'ライラック香る大通公園から、北の大地を走る',
+  'From the lilac-scented Odori Park across Hokkaido',
   NULL,
   NULL,
   NULL,
@@ -1794,6 +1874,12 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('hokkaido-marathon-2026', '["tshirt","medal"]', '大会オリジナルTシャツ、完走メダル', 'Official race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('hokkaido-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-03-29', '2026-04-24', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('hokkaido-marathon-2026', NULL, '大通公園', 'Odori Park', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('hokkaido-marathon-2026', NULL, '北海道大学', 'Hokkaido University', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('hokkaido-marathon-2026', NULL, '豊平川', 'Toyohira River', NULL, NULL, 2);
 
 -- ==================
 -- いぶすき菜の花マラソン (ibusuki-nanohana-2026)
@@ -1844,11 +1930,11 @@ INSERT OR REPLACE INTO races (
   'Mt. Kaimon, Kinko Bay, canola flower road',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '菜の花',
+  '#eab308',
+  'Nanohana',
+  '黄金色の菜の花畑と薩摩の海を巡る42km',
+  'Run through golden rapeseed fields along the Satsuma sea',
   NULL,
   NULL,
   NULL,
@@ -1887,6 +1973,12 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('ibusuki-nanohana-2026', '温泉', '砂むし温泉', 'Sand Steam Bath (Sunamushi Onsen)', '指宿名物の砂蒸し温泉。海岸の天然砂の中に埋まって温まる独特の体験。レース後のリカバリーに最適。', 'Ibusuki''s famous sand steam bath. A unique experience of being buried in naturally heated sand on the beach. Perfect for post-race recovery.', '指宿市内', NULL, 31.2283, 130.6367);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('ibusuki-nanohana-2026', '["tshirt"]', '大会記念品（参加者全員）', 'Commemorative gift (all participants)', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('ibusuki-nanohana-2026', NULL, '開聞岳', 'Mt. Kaimon', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('ibusuki-nanohana-2026', NULL, '錦江湾', 'Kinko Bay', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('ibusuki-nanohana-2026', NULL, '菜の花ロード', 'canola flower road', NULL, NULL, 2);
 
 -- ==================
 -- 一関国際ハーフマラソン (ichinoseki-half-marathon-2026)
@@ -1937,11 +2029,11 @@ INSERT OR REPLACE INTO races (
   'Flat course with only 15m elevation difference',
   '賞金あり。ホノルルマラソン派遣特典あり。',
   'Prize money available. Invitation to Honolulu Marathon for top finishers.',
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '厳美渓',
+  '#065f46',
+  'Genbikei',
+  '厳美渓の渓谷美を感じながら走る一関ハーフ',
+  'Run through the scenic Genbikei gorge in Ichinoseki',
   NULL,
   NULL,
   NULL,
@@ -1968,6 +2060,8 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
   ('ichinoseki-half-marathon-2026', '10k', 10, 85, '09:00', 500, 6000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 1);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('ichinoseki-half-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-01', '2026-06-30', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('ichinoseki-half-marathon-2026', NULL, '最大高低差15mのフラットコース', 'Flat course with only 15m elevation difference', NULL, NULL, 0);
 
 -- ==================
 -- 神々の島 壱岐ウルトラマラソン (iki-ultra-marathon-2026)
@@ -2018,11 +2112,11 @@ INSERT OR REPLACE INTO races (
   '',
   '',
   '',
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '壱岐の海',
+  '#0891b2',
+  'Iki-no-Umi',
+  '玄界灘に浮かぶ神秘の島・壱岐を一周する',
+  'Circle the mystical island of Iki in the Genkai Sea',
   NULL,
   NULL,
   NULL,
@@ -2101,11 +2195,11 @@ INSERT OR REPLACE INTO races (
   'Arakawa Riverbank',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '荒川',
+  '#6b7280',
+  'Arakawa',
+  '荒川河川敷を駆ける、春の板橋シティマラソン',
+  'Run the Arakawa riverside in spring',
   NULL,
   NULL,
   NULL,
@@ -2136,6 +2230,8 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('itabashi-city-marathon-2026', '["tshirt","medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('itabashi-city-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-08-01', '2025-11-24', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('itabashi-city-marathon-2026', NULL, '荒川河川敷', 'Arakawa Riverbank', NULL, NULL, 0);
 
 -- ==================
 -- いわきサンシャインマラソン (iwaki-sunshine-marathon-2026)
@@ -2186,11 +2282,11 @@ INSERT OR REPLACE INTO races (
   'Pacific coastline',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '太平洋',
+  '#0369a1',
+  'Taiheiyo',
+  '太平洋の輝きとともに、いわきの海岸を走る',
+  'Run along Iwaki''s Pacific coast in sunshine',
   NULL,
   NULL,
   NULL,
@@ -2225,6 +2321,8 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('iwaki-sunshine-marathon-2026', '["tshirt","medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('iwaki-sunshine-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-09-12', '2025-10-15', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('iwaki-sunshine-marathon-2026', NULL, '太平洋沿岸', 'Pacific coastline', NULL, NULL, 0);
 
 -- ==================
 -- いわて盛岡シティマラソン (iwate-morioka-city-marathon-2026)
@@ -2305,11 +2403,11 @@ Translated with DeepL.com (free version)',
   '',
   '',
   '',
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '岩手山',
+  '#374151',
+  'Iwate-san',
+  '南部片富士・岩手山を望み、盛岡の街を駆ける',
+  'Run through Morioka with Mt. Iwate towering above',
   NULL,
   NULL,
   NULL,
@@ -2386,11 +2484,11 @@ INSERT OR REPLACE INTO races (
   '',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '平泉',
+  '#854d0e',
+  'Hiraizumi',
+  '世界遺産・平泉の黄金文化を感じながら走る',
+  'Run through Hiraizumi, the Golden City of World Heritage',
   NULL,
   NULL,
   NULL,
@@ -2471,11 +2569,11 @@ INSERT OR REPLACE INTO races (
   'Seto Inland Sea',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '瀬戸内海',
+  '#0284c7',
+  'Setonaikai',
+  '瀬戸内の穏やかな海を見渡しながら走る42km',
+  'Run along the serene shores of the Seto Inland Sea',
   NULL,
   NULL,
   NULL,
@@ -2504,6 +2602,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('kagawa-marathon-2026', '観光地', '栗林公園', 'Ritsurin Garden', '国の特別名勝。日本を代表する回遊式大名庭園。', 'A Special Place of Scenic Beauty. One of Japan''s finest strolling gardens.', '高松市内', NULL, 34.3289, 134.0467);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kagawa-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-10-06', '2025-11-24', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kagawa-marathon-2026', NULL, '瀬戸内海', 'Seto Inland Sea', NULL, NULL, 0);
 
 -- ==================
 -- 鹿児島マラソン (kagoshima-marathon-2026)
@@ -2554,11 +2654,11 @@ INSERT OR REPLACE INTO races (
   'Sakurajima, Kinko Bay',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '桜島',
+  '#991b1b',
+  'Sakura-jima',
+  '活火山・桜島を望む、薩摩の海岸を走る',
+  'Run along Kagoshima Bay with the volcanic Sakurajima in view',
   NULL,
   NULL,
   NULL,
@@ -2589,6 +2689,10 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('kagoshima-marathon-2026', '["tshirt","medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kagoshima-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-08-08', '2025-11-16', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kagoshima-marathon-2026', NULL, '桜島', 'Sakurajima', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kagoshima-marathon-2026', NULL, '錦江湾', 'Kinko Bay', NULL, NULL, 1);
 
 -- ==================
 -- 下関海響マラソン (kaikyo-marathon-2026)
@@ -2639,11 +2743,11 @@ INSERT OR REPLACE INTO races (
   'Kanmon Strait, Kanmon Bridge, Ganryujima Island',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '関門海峡',
+  '#1e40af',
+  'Kanmon-Kaikyo',
+  '本州と九州をつなぐ、関門海峡を渡る',
+  'Cross the Kanmon Strait connecting Honshu and Kyushu',
   NULL,
   NULL,
   NULL,
@@ -2676,6 +2780,12 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('kaikyo-marathon-2026', '["medal","tshirt"]', '完走メダル、大会オリジナルTシャツ', 'Finisher medal, Official race T-shirt', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kaikyo-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-05-15', '2026-07-12', 12000, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kaikyo-marathon-2026', NULL, '関門海峡', 'Kanmon Strait', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kaikyo-marathon-2026', NULL, '関門大橋', 'Kanmon Bridge', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kaikyo-marathon-2026', NULL, '巌流島', 'Ganryujima Island', NULL, NULL, 2);
 
 -- ==================
 -- 金沢マラソン (kanazawa-marathon-2026)
@@ -2726,11 +2836,11 @@ INSERT OR REPLACE INTO races (
   'Kenroku-en Garden, Kanazawa Castle, Higashi Chaya District area',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '兼六園',
+  '#14532d',
+  'Kenroku-en',
+  '加賀百万石の城下町・金沢を駆ける',
+  'Run through Kanazawa, the castle town of one million koku',
   NULL,
   NULL,
   NULL,
@@ -2763,6 +2873,12 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('kanazawa-marathon-2026', '["medal","tshirt","local_product"]', '大会オリジナルTシャツ、完走メダル、地元特産品', 'Official race T-shirt, Finisher medal, Local specialty products', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kanazawa-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-10', '2026-05-20', 14000, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kanazawa-marathon-2026', NULL, '兼六園', 'Kenroku-en Garden', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kanazawa-marathon-2026', NULL, '金沢城', 'Kanazawa Castle', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kanazawa-marathon-2026', NULL, 'ひがし茶屋街付近', 'Higashi Chaya District area', NULL, NULL, 2);
 
 -- ==================
 -- かすみがうらマラソン (kasumigaura-marathon-2026)
@@ -2813,11 +2929,11 @@ INSERT OR REPLACE INTO races (
   'Lake Kasumigaura shore',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '霞ヶ浦',
+  '#7dd3fc',
+  'Kasumigaura',
+  '日本第2位の湖・霞ヶ浦のほとりを走る',
+  'Run along the shores of Lake Kasumigaura, Japan''s 2nd largest lake',
   NULL,
   NULL,
   NULL,
@@ -2850,6 +2966,8 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('kasumigaura-marathon-2026', '["tshirt","medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kasumigaura-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-12-01', '2026-01-25', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kasumigaura-marathon-2026', NULL, '霞ヶ浦湖畔', 'Lake Kasumigaura shore', NULL, NULL, 0);
 
 -- ==================
 -- 勝田全国マラソン (katsuta-marathon-2026)
@@ -2900,11 +3018,11 @@ INSERT OR REPLACE INTO races (
   '',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '百里',
+  '#4b5563',
+  'Hyakuri',
+  '常陸の大地を駆け抜ける、勝田全国マラソン',
+  'Run across the Hitachi plains at Katsuta',
   NULL,
   NULL,
   NULL,
@@ -2987,11 +3105,11 @@ INSERT OR REPLACE INTO races (
   'Kokura city center, Kanmon Strait',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '洞海湾',
+  '#1d4ed8',
+  'Dokai-wan',
+  '北九州の海と工場夜景の街を走る',
+  'Run through Kitakyushu''s industrial waterfront',
   NULL,
   NULL,
   NULL,
@@ -3022,6 +3140,10 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('kitakyushu-marathon-2026', '["tshirt","medal","towel"]', '大会Tシャツ、完走メダル、フィニッシャータオル', 'Race T-shirt, Finisher medal, Finisher towel', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kitakyushu-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-08-08', '2025-09-25', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kitakyushu-marathon-2026', NULL, '小倉市街地', 'Kokura city center', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kitakyushu-marathon-2026', NULL, '関門海峡', 'Kanmon Strait', NULL, NULL, 1);
 
 -- ==================
 -- KIX泉州国際マラソン (kix-senshu-marathon-2026)
@@ -3072,11 +3194,11 @@ INSERT OR REPLACE INTO races (
   'Senshu coastline',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '大阪湾',
+  '#0ea5e9',
+  'Osaka-wan',
+  '関西国際空港を望む、泉州の海岸を駆ける',
+  'Run the Senshu coast with Kansai International Airport in view',
   NULL,
   NULL,
   NULL,
@@ -3105,6 +3227,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('kix-senshu-marathon-2026', '観光地', '岸和田城', 'Kishiwada Castle', 'だんじり祭りで有名な岸和田の城。コース付近。', 'The castle in Kishiwada, famous for the Danjiri Festival. Near the course.', 'コース付近', NULL, 34.4608, 135.3706);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kix-senshu-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-10-10', '2025-11-30', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kix-senshu-marathon-2026', NULL, '泉州の海岸沿い', 'Senshu coastline', NULL, NULL, 0);
 
 -- ==================
 -- 神戸マラソン (kobe-marathon-2026)
@@ -3173,11 +3297,11 @@ For relay runs, both runners must register together. Registration by one person,
   'Akashi Kaikyo Bridge, Port Island, Harborland',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '異人館',
+  '#b91c1c',
+  'Ijin-kan',
+  '港町・神戸の異国情緒あふれる街を走る',
+  'Run through the exotic port city of Kobe',
   NULL,
   NULL,
   NULL,
@@ -3210,6 +3334,12 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('kobe-marathon-2026', '["medal","tshirt","towel"]', '大会オリジナルTシャツ、完走メダル、フィニッシャータオル', 'Official race T-shirt, Finisher medal, Finisher towel', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kobe-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-17', '2026-06-01', 18000, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kobe-marathon-2026', NULL, '明石海峡大橋', 'Akashi Kaikyo Bridge', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kobe-marathon-2026', NULL, 'ポートアイランド', 'Port Island', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kobe-marathon-2026', NULL, 'ハーバーランド', 'Harborland', NULL, NULL, 2);
 
 -- ==================
 -- 高知龍馬マラソン (kochi-ryoma-marathon-2026)
@@ -3260,11 +3390,11 @@ INSERT OR REPLACE INTO races (
   'Pacific Ocean, Urado Bridge, Katsurahama area',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '坂本龍馬',
+  '#1a3a1a',
+  'Ryoma',
+  '龍馬の志を胸に、土佐の大地を駆け抜ける',
+  'Run the Tosa plains with the spirit of Ryoma',
   NULL,
   NULL,
   NULL,
@@ -3295,6 +3425,12 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('kochi-ryoma-marathon-2026', '["tshirt","medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kochi-ryoma-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-08-01', '2025-10-31', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kochi-ryoma-marathon-2026', NULL, '太平洋', 'Pacific Ocean', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kochi-ryoma-marathon-2026', NULL, '浦戸大橋', 'Urado Bridge', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kochi-ryoma-marathon-2026', NULL, '桂浜方面', 'Katsurahama area', NULL, NULL, 2);
 
 -- ==================
 -- 熊本城マラソン (kumamoto-castle-marathon-2026)
@@ -3345,11 +3481,11 @@ INSERT OR REPLACE INTO races (
   'Kumamoto Castle',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '熊本城',
+  '#1c1917',
+  'Kumamoto-jo',
+  '不落の名城・熊本城をめぐる感動の42km',
+  '42km around the legendary Kumamoto Castle',
   NULL,
   NULL,
   NULL,
@@ -3380,6 +3516,8 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('kumamoto-castle-marathon-2026', '["tshirt","medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kumamoto-castle-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-07-29', '2025-09-24', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kumamoto-castle-marathon-2026', NULL, '熊本城', 'Kumamoto Castle', NULL, NULL, 0);
 
 -- ==================
 -- 京都マラソン (kyoto-marathon-2026)
@@ -3430,11 +3568,11 @@ INSERT OR REPLACE INTO races (
   'Arashiyama, near Kinkaku-ji, Imadegawa-dori, near Ginkaku-ji, Heian Shrine',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '大文字山',
+  '#7f1d1d',
+  'Daimonji-yama',
+  '千年の古都・京都の世界遺産をめぐる',
+  'Run through Kyoto''s thousand years of world heritage',
   NULL,
   NULL,
   NULL,
@@ -3467,6 +3605,16 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('kyoto-marathon-2026', '["tshirt","medal"]', '大会オリジナルTシャツ、完走メダル', 'Official race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kyoto-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-07-17', '2025-09-22', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kyoto-marathon-2026', NULL, '嵐山', 'Arashiyama', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kyoto-marathon-2026', NULL, '金閣寺付近', 'near Kinkaku-ji', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kyoto-marathon-2026', NULL, '今出川通', 'Imadegawa-dori', NULL, NULL, 2);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kyoto-marathon-2026', NULL, '銀閣寺付近', 'near Ginkaku-ji', NULL, NULL, 3);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kyoto-marathon-2026', NULL, '平安神宮', 'Heian Shrine', NULL, NULL, 4);
 
 -- ==================
 -- みえ松阪マラソン (mie-matsusaka-marathon-2026)
@@ -3517,11 +3665,11 @@ INSERT OR REPLACE INTO races (
   'Matsusaka castle town',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '松阪牛',
+  '#7f1d1d',
+  'Matsusaka-gyu',
+  '松阪牛の里・松阪を走る、美食ランナーの聖地',
+  'Run through Matsusaka, home of Japan''s finest beef',
   NULL,
   NULL,
   NULL,
@@ -3548,6 +3696,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('mie-matsusaka-marathon-2026', 'グルメ', '松阪牛', 'Matsusaka Beef', '日本三大和牛の一つ。レース後のご褒美に。', 'One of Japan''s three premium wagyu. A reward after the race.', '松阪市内', NULL, 34.5778, 136.5312);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('mie-matsusaka-marathon-2026', '["tshirt","medal","local_product"]', '大会Tシャツ、完走メダル、松阪の特産品', 'Race T-shirt, Finisher medal, Matsusaka local products', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('mie-matsusaka-marathon-2026', NULL, '松阪の城下町', 'Matsusaka castle town', NULL, NULL, 0);
 
 -- ==================
 -- 水戸黄門漫遊マラソン (mito-komon-manyu-marathon-2026)
@@ -3598,11 +3748,11 @@ INSERT OR REPLACE INTO races (
   'Kairakuen Garden, Lake Senba',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '水戸黄門',
+  '#1c1917',
+  'Mito-Komon',
+  '助さん格さんも驚く、水戸を駆ける42km',
+  'Run through Mito as legends of the Komon await',
   NULL,
   NULL,
   NULL,
@@ -3633,6 +3783,10 @@ INSERT OR REPLACE INTO race_entry_links (race_id, site_name, url, sort_order) VA
   ('mito-komon-manyu-marathon-2026', 'RUNNET', 'https://runnet.jp/entry/runtes/user/pc/competitionDetailAction.do?raceId=387694&div=1', 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('mito-komon-manyu-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-16', '2026-06-30', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('mito-komon-manyu-marathon-2026', NULL, '偕楽園', 'Kairakuen Garden', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('mito-komon-manyu-marathon-2026', NULL, '千波湖', 'Lake Senba', NULL, NULL, 1);
 
 -- ==================
 -- 富士山クライムラン (mtfuji-climb-run-2026)
@@ -3701,11 +3855,11 @@ Sunday, September 13, 6:30 AM – 30 minutes before the start time of each wave'
   '',
   '',
   '',
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '富士山頂',
+  '#1e3a8a',
+  'Fujisan-cho',
+  '霊峰富士の頂へ、山岳レースの最高峰',
+  'Climb to the summit of Mt. Fuji — the ultimate trail race',
   NULL,
   NULL,
   NULL,
@@ -3782,11 +3936,11 @@ INSERT OR REPLACE INTO races (
   'Nagoya Dome (Vantelin Dome Nagoya), near Nagoya Castle',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '名古屋城',
+  '#c2410c',
+  'Nagoya-jo',
+  '女性ランナーの憧れ、名古屋の街を駆ける42km',
+  'The women''s marathon destination — run through Nagoya',
   NULL,
   NULL,
   NULL,
@@ -3815,6 +3969,10 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('nagoya-womens-marathon-2026', 'グルメ', '名古屋めし', 'Nagoya Meshi', '味噌カツ、ひつまぶし、手羽先など名古屋名物が充実。レース後のご褒美に。', 'Miso katsu, hitsumabushi, chicken wings and more Nagoya specialties. A reward after the race.', '名古屋市内', NULL, 35.1709, 136.8815);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('nagoya-womens-marathon-2026', '["medal","goods"]', 'ティファニー オリジナルペンダント（完走者全員）', 'Tiffany original pendant (all finishers)', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('nagoya-womens-marathon-2026', NULL, '名古屋ドーム（バンテリンドーム ナゴヤ）', 'Nagoya Dome (Vantelin Dome Nagoya)', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('nagoya-womens-marathon-2026', NULL, '名古屋城付近', 'near Nagoya Castle', NULL, NULL, 1);
 
 -- ==================
 -- NAHAマラソン (naha-marathon-2026)
@@ -3865,11 +4023,11 @@ INSERT OR REPLACE INTO races (
   'Kokusai Street, Naha city, Okinawan scenery',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  'ハイビスカス',
+  '#dc2626',
+  'Haibisukasu',
+  '南国の陽光と笑顔溢れる、那覇の42km',
+  'Run through tropical Naha with sunshine and smiles',
   NULL,
   NULL,
   NULL,
@@ -3898,6 +4056,12 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('naha-marathon-2026', 'グルメ', '沖縄そば', 'Okinawa Soba', '沖縄を代表するご当地グルメ。あっさりとしたスープと太麺が特徴。レース後のエネルギー補給に。', 'Okinawa''s signature local dish. Characterized by light broth and thick noodles. Perfect for post-race energy.', '那覇市内各所', NULL, 26.3344, 127.7679);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('naha-marathon-2026', '["tshirt","medal"]', '大会オリジナルTシャツ、完走メダル', 'Official race T-shirt, Finisher medal', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('naha-marathon-2026', NULL, '国際通り', 'Kokusai Street', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('naha-marathon-2026', NULL, '那覇市街', 'Naha city', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('naha-marathon-2026', NULL, '沖縄の風景', 'Okinawan scenery', NULL, NULL, 2);
 
 -- ==================
 -- 奈良マラソン (nara-marathon-2026)
@@ -3948,11 +4112,11 @@ INSERT OR REPLACE INTO races (
   'Todai-ji, Kasuga Shrine, Heijo Palace ruins, Nara Park',
   'アップダウンが多い。坂道対策が必要。',
   'Many hills. Hill training recommended.',
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '奈良の鹿',
+  '#92400e',
+  'Nara-no-Shika',
+  '奈良の鹿と世界遺産が待つ、古都の42km',
+  'Run through the ancient capital of Nara alongside sacred deer',
   NULL,
   NULL,
   NULL,
@@ -3981,6 +4145,14 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('nara-marathon-2026', '温泉', 'ゆららの湯 奈良店', 'Yurara no Yu Nara', '奈良市内の日帰り温泉施設。レース後のリカバリーに便利。', 'A day-trip hot spring facility in Nara city. Convenient for post-race recovery.', '奈良市内', NULL, 34.6851, 135.8048);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('nara-marathon-2026', '["tshirt","medal","towel"]', '大会オリジナルTシャツ、完走メダル、フィニッシャータオル', 'Official race T-shirt, Finisher medal, Finisher towel', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('nara-marathon-2026', NULL, '東大寺', 'Todai-ji', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('nara-marathon-2026', NULL, '春日大社', 'Kasuga Shrine', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('nara-marathon-2026', NULL, '平城宮跡', 'Heijo Palace ruins', NULL, NULL, 2);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('nara-marathon-2026', NULL, '奈良公園', 'Nara Park', NULL, NULL, 3);
 
 -- ==================
 -- 新潟シティマラソン (niigata-city-marathon-2026)
@@ -4031,11 +4203,11 @@ INSERT OR REPLACE INTO races (
   '',
   '',
   '',
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '信濃川',
+  '#0369a1',
+  'Shinano-gawa',
+  '日本一の大河・信濃川が流れる、米どころを走る',
+  'Run along the Shinano River, Japan''s longest',
   NULL,
   NULL,
   NULL,
@@ -4114,11 +4286,11 @@ INSERT OR REPLACE INTO races (
   '',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '抹茶',
+  '#4d7c0f',
+  'Matcha',
+  '日本有数の抹茶の産地・西尾を巡る42km',
+  'Run through Nishio, one of Japan''s top matcha-producing cities',
   NULL,
   NULL,
   NULL,
@@ -4196,11 +4368,11 @@ Loppi端末(ローソン・ミニストップ店頭)',
   'Okayama Castle, Korakuen Garden',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '桃',
+  '#f9a8d4',
+  'Momo',
+  '桃太郎の里・岡山を、晴れの国で走る',
+  'Run through Okayama, the sunny land of Momotaro',
   NULL,
   NULL,
   NULL,
@@ -4229,6 +4401,10 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('okayama-marathon-2026', '["medal","tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('okayama-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-16', '2026-05-18', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('okayama-marathon-2026', NULL, '岡山城', 'Okayama Castle', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('okayama-marathon-2026', NULL, '後楽園', 'Korakuen Garden', NULL, NULL, 1);
 
 -- ==================
 -- 奥信濃100トレイルランニングレース (okushinano100-2026)
@@ -4279,11 +4455,11 @@ INSERT OR REPLACE INTO races (
   'Mountain trails of Okushinano, Kijimadaira to Iiyama area',
   '3日間開催（6/5〜6/7）。登山道整備活動も実施。',
   '3-day event (Jun 5–7). Trail maintenance activities also conducted.',
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '北アルプス',
+  '#1e40af',
+  'Kita-Arupusu',
+  '北アルプスの麓・奥信濃を走る100km',
+  '100km through the foothills of the Northern Alps',
   NULL,
   NULL,
   NULL,
@@ -4314,6 +4490,10 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
   ('okushinano100-2026', 'other', 8, 120, '07:30', 300, 5000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 3);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('okushinano100-2026', NULL, '一般エントリー', 'General Entry', '2025-12-14', '2026-05-10', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('okushinano100-2026', NULL, '奥信濃の山岳トレイル', 'Mountain trails of Okushinano', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('okushinano100-2026', NULL, '木島平村〜飯山市周辺', 'Kijimadaira to Iiyama area', NULL, NULL, 1);
 
 -- ==================
 -- 大阪マラソン (osaka-marathon-2026)
@@ -4364,11 +4544,11 @@ INSERT OR REPLACE INTO races (
   'Osaka Castle, Midosuji, Tsutenkaku, Nakanoshima',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '大阪城',
+  '#92400e',
+  'Osaka-jo',
+  '笑いと活気溢れる、天下の台所・大阪を走る',
+  'Run through Osaka, the nation''s kitchen of energy',
   NULL,
   NULL,
   NULL,
@@ -4399,6 +4579,14 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('osaka-marathon-2026', '温泉', 'スパワールド世界の大温泉', 'Spa World', '通天閣近くの大型温泉施設。レース後のリカバリーに。コースの近くにあり便利。', 'A large hot spring facility near Tsutenkaku. Convenient for post-race recovery, located near the course.', '通天閣付近', NULL, 34.6522, 135.5064);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('osaka-marathon-2026', '["tshirt","medal","towel"]', '参加記念Tシャツ、完走メダル、フィニッシャータオル', 'Commemorative T-shirt, Finisher medal, Finisher towel', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('osaka-marathon-2026', NULL, '大阪城', 'Osaka Castle', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('osaka-marathon-2026', NULL, '御堂筋', 'Midosuji', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('osaka-marathon-2026', NULL, '通天閣', 'Tsutenkaku', NULL, NULL, 2);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('osaka-marathon-2026', NULL, '中之島', 'Nakanoshima', NULL, NULL, 3);
 
 -- ==================
 -- 大阪・淀川市民マラソン (osaka-yodo-river-citizens-marathon-2026)
@@ -4457,11 +4645,11 @@ Based on themes such as “people,” “environment,” and “the Yodogawa Riv
   '',
   '',
   '',
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '淀川',
+  '#0284c7',
+  'Yodogawa',
+  '淀川の流れに沿って、大阪の街を走る',
+  'Run along the Yodo River through Osaka',
   NULL,
   NULL,
   NULL,
@@ -4546,11 +4734,11 @@ INSERT OR REPLACE INTO races (
   'National forest at Mt. Ontake base, specially opened restricted area',
   '100マイル：7/18(土)20:00スタート。100K：7/19(日)0:00スタート。',
   '100 Mile: Jul 18 (Sat) 20:00 start. 100K: Jul 19 (Sun) 00:00 start.',
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '御嶽山',
+  '#1c1917',
+  'Ontake-san',
+  '霊峰・御嶽山の麓を巡る、100kmの山岳路',
+  '100km through the sacred slopes of Mt. Ontake',
   NULL,
   NULL,
   NULL,
@@ -4577,6 +4765,10 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
   ('osj-ontake100-2026', 'ultra', 109, 1200, '00:00', 1200, 19000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 1);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('osj-ontake100-2026', NULL, '一般エントリー', 'General Entry', '2026-02-01', '2026-06-14', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('osj-ontake100-2026', NULL, '御嶽山麓国有林', 'National forest at Mt. Ontake base', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('osj-ontake100-2026', NULL, '特別開放区域', 'specially opened restricted area', NULL, NULL, 1);
 
 -- ==================
 -- 佐渡トキマラソン (sado-toki-marathon-2026)
@@ -4627,11 +4819,11 @@ INSERT OR REPLACE INTO races (
   'Nature of Sado Island',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '朱鷺',
+  '#fb7185',
+  'Toki',
+  '朱鷺舞う離島・佐渡で走る、自然豊かな42km',
+  'Run the island of Sado where the endangered crested ibis soars',
   NULL,
   NULL,
   NULL,
@@ -4662,6 +4854,8 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('sado-toki-marathon-2026', '["medal","tshirt","local_product"]', '大会Tシャツ、完走メダル、佐渡の特産品', 'Race T-shirt, Finisher medal, Sado Island local products', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('sado-toki-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-12-01', '2026-03-22', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('sado-toki-marathon-2026', NULL, '佐渡島の自然', 'Nature of Sado Island', NULL, NULL, 0);
 
 -- ==================
 -- さが桜マラソン (saga-sakura-marathon-2026)
@@ -4712,11 +4906,11 @@ INSERT OR REPLACE INTO races (
   'Cherry blossom trees, Saga Plain',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '桜',
+  '#f9c1cc',
+  'Sakura',
+  '佐賀城址の桜を愛でながら走る、春の42km',
+  'Run beneath cherry blossoms at Saga Castle in spring',
   NULL,
   NULL,
   NULL,
@@ -4743,6 +4937,10 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('saga-sakura-marathon-2026', '観光地', '吉野ヶ里遺跡', 'Yoshinogari Ruins', '弥生時代の大規模環濠集落遺跡。国の特別史跡。佐賀市から近い。', 'A large-scale Yayoi period moated settlement. National Special Historic Site. Close to Saga city.', '佐賀市から車約20分', NULL, 33.3167, 130.3833);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('saga-sakura-marathon-2026', '["tshirt","medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('saga-sakura-marathon-2026', NULL, '桜並木', 'Cherry blossom trees', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('saga-sakura-marathon-2026', NULL, '佐賀平野', 'Saga Plain', NULL, NULL, 1);
 
 -- ==================
 -- さいたまマラソン (saitama-marathon-2026)
@@ -4793,11 +4991,11 @@ INSERT OR REPLACE INTO races (
   '',
   '2026年大会は積雪のため中止',
   '2026 edition cancelled due to heavy snow',
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '荒川',
+  '#0369a1',
+  'Arakawa',
+  '荒川の雄大な流れとともに走る、さいたまの42km',
+  'Run along the vast Arakawa River through Saitama',
   NULL,
   NULL,
   NULL,
@@ -4963,11 +5161,11 @@ EQUIPMENT
   '',
   '',
   '',
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '高原',
+  '#166534',
+  'Kogen',
+  '志賀高原の雄大な自然の中を走る100kmトレイル',
+  '100km trail through the majestic nature of Shiga Kogen',
   NULL,
   NULL,
   NULL,
@@ -5054,11 +5252,11 @@ Translated with DeepL.com (free version)',
   '',
   '',
   '',
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '大井川',
+  '#15803d',
+  'Oi-gawa',
+  '南アルプスから流れる大井川沿いを走る42km',
+  'Run along the Oi River flowing down from the Southern Alps',
   NULL,
   NULL,
   NULL,
@@ -5138,11 +5336,11 @@ INSERT OR REPLACE INTO races (
   '',
   '',
   '',
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '信越五岳',
+  '#065f46',
+  'Shin-etsu-Gogaku',
+  '信越の五つの山を巡る、100マイルの挑戦',
+  'A 100-mile challenge through five peaks of the Shin-Etsu mountains',
   NULL,
   NULL,
   NULL,
@@ -5229,11 +5427,11 @@ INSERT OR REPLACE INTO races (
   'Suruga Bay, Mt. Fuji',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '富士山',
+  '#2a4fa3',
+  'Fujisan',
+  '富士山を正面に望む、海岸線の42km',
+  'Run the coastline with Mt. Fuji straight ahead',
   NULL,
   NULL,
   NULL,
@@ -5260,6 +5458,10 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('shizuoka-marathon-2026', '観光地', '三保松原', 'Miho no Matsubara', '世界遺産「富士山」の構成資産。松林越しの富士山の眺望が美しい。', 'Part of the World Heritage ''Mt. Fuji''. Beautiful views of Mt. Fuji through pine groves.', '静岡市内から車約30分', NULL, 35.0136, 138.5167);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('shizuoka-marathon-2026', '["tshirt","medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('shizuoka-marathon-2026', NULL, '駿河湾', 'Suruga Bay', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('shizuoka-marathon-2026', NULL, '富士山', 'Mt. Fuji', NULL, NULL, 1);
 
 -- ==================
 -- 湘南国際マラソン (shonan-international-marathon-2026)
@@ -5310,11 +5512,11 @@ INSERT OR REPLACE INTO races (
   'Shonan coast, Enoshima, Mt. Fuji',
   'マイボトル・マイカップ必携。紙コップでの給水なし。',
   'Must carry your own bottle/cup. No paper cup water service.',
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '湘南の海',
+  '#0ea5e9',
+  'Shonan-no-Umi',
+  '湘南の海風を感じながら走る、江ノ島から湘南へ',
+  'Run the Shonan coast from Enoshima with ocean breezes',
   NULL,
   NULL,
   NULL,
@@ -5345,6 +5547,12 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('shonan-international-marathon-2026', '["medal","tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('shonan-international-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-04', '2026-09-09', 16000, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('shonan-international-marathon-2026', NULL, '湘南海岸', 'Shonan coast', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('shonan-international-marathon-2026', NULL, '江の島', 'Enoshima', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('shonan-international-marathon-2026', NULL, '富士山', 'Mt. Fuji', NULL, NULL, 2);
 
 -- ==================
 -- そうじゃ吉備路マラソン (soja-kibiji-marathon-2026)
@@ -5398,11 +5606,11 @@ Therefore, there is no registration required.',
   'Bitchu Kokubunji five-story pagoda, burial mounds, Kibiji',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '吉備路',
+  '#854d0e',
+  'Kibiji',
+  '吉備路の古代ロマンを感じながら走る42km',
+  'Run the ancient Kibiji road through Soja''s historic landscape',
   NULL,
   NULL,
   NULL,
@@ -5431,6 +5639,12 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('soja-kibiji-marathon-2026', '["medal","tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('soja-kibiji-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-10-01', '2026-01-03', 9100, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('soja-kibiji-marathon-2026', NULL, '備中国分寺五重塔', 'Bitchu Kokubunji five-story pagoda', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('soja-kibiji-marathon-2026', NULL, '古墳群', 'burial mounds', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('soja-kibiji-marathon-2026', NULL, '吉備路', 'Kibiji', NULL, NULL, 2);
 
 -- ==================
 -- 丹波篠山ABCマラソン (tamba-sasayama-abc-marathon-2026)
@@ -5481,11 +5695,11 @@ INSERT OR REPLACE INTO races (
   'Sasayama Castle ruins, rural landscape',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '城下町',
+  '#1c1917',
+  'Jokamachi',
+  '丹波篠山・城下町の風情漂う黒豆の里を走る',
+  'Run through the castle town of Tamba Sasayama, home of black soybeans',
   NULL,
   NULL,
   NULL,
@@ -5512,6 +5726,10 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('tamba-sasayama-abc-marathon-2026', 'グルメ', '丹波篠山の黒豆・ぼたん鍋', 'Tamba-Sasayama Black Beans & Botan Nabe', '丹波の黒豆と猪肉のぼたん鍋が名物。秋〜冬が旬。', 'Famous for Tamba black beans and boar meat hot pot. Best in autumn-winter.', '篠山市内', NULL, 35.0764, 135.2203);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('tamba-sasayama-abc-marathon-2026', '["tshirt","local_product"]', '大会Tシャツ、丹波の特産品', 'Race T-shirt, Tamba local products', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tamba-sasayama-abc-marathon-2026', NULL, '篠山城跡', 'Sasayama Castle ruins', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tamba-sasayama-abc-marathon-2026', NULL, '田園風景', 'rural landscape', NULL, NULL, 1);
 
 -- ==================
 -- 館山若潮マラソン (tateyama-wakashio-2026)
@@ -5562,11 +5780,11 @@ INSERT OR REPLACE INTO races (
   'Boso coastline',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '若潮',
+  '#0369a1',
+  'Wakashio',
+  '太平洋に面した館山の若潮を感じながら走る',
+  'Run Tateyama''s Pacific coast on the fresh tides of spring',
   NULL,
   NULL,
   NULL,
@@ -5595,6 +5813,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('tateyama-wakashio-2026', 'グルメ', '房総の海鮮', 'Boso Seafood', '新鮮な海鮮が楽しめる。特に寿司や刺身がおすすめ。', 'Fresh seafood. Sushi and sashimi are especially recommended.', '館山市内', NULL, 34.9997, 139.8697);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('tateyama-wakashio-2026', '["tshirt","medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tateyama-wakashio-2026', NULL, '房総の海岸線', 'Boso coastline', NULL, NULL, 0);
 
 -- ==================
 -- 田沢湖マラソン (tazawako-marathon-2026)
@@ -5646,11 +5866,11 @@ INSERT OR REPLACE INTO races (
   '',
   '',
   '',
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '田沢湖',
+  '#1e40af',
+  'Tazawako',
+  '日本最深の湖・田沢湖を一望しながら走る',
+  'Run overlooking Lake Tazawa, Japan''s deepest lake',
   NULL,
   NULL,
   NULL,
@@ -5729,11 +5949,11 @@ INSERT OR REPLACE INTO races (
   'Yoshino River',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '阿波おどり',
+  '#ea580c',
+  'Awa-Odori',
+  '踊る阿呆に走る阿呆！阿波の国を駆け抜ける',
+  'Run the land of Awa dance — the spirit of Tokushima',
   NULL,
   NULL,
   NULL,
@@ -5760,6 +5980,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('tokushima-marathon-2026', '観光地', '鳴門の渦潮', 'Naruto Whirlpools', '世界三大潮流の一つ。大鳴門橋の遊歩道から渦潮を観察できる。', 'One of the world''s three great tidal currents. Observe whirlpools from the Onaruto Bridge walkway.', '徳島市から車約1時間', NULL, 34.2333, 134.6333);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('tokushima-marathon-2026', '["tshirt","medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tokushima-marathon-2026', NULL, '吉野川', 'Yoshino River', NULL, NULL, 0);
 
 -- ==================
 -- 東京マラソン (tokyo-marathon-2026)
@@ -5810,11 +6032,11 @@ INSERT OR REPLACE INTO races (
   'Tokyo Metropolitan Government, Imperial Palace, Asakusa Kaminarimon, Ginza, Tokyo Tower, Tokyo Station Marunouchi',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '東京の街',
+  '#1e293b',
+  'Tokyo-no-Machi',
+  '世界6大メジャーの一つ、東京の街を駆け抜ける',
+  'Race through Tokyo — one of the six World Marathon Majors',
   NULL,
   NULL,
   NULL,
@@ -5851,6 +6073,18 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('tokyo-marathon-2026', '["medal","tshirt","towel"]', '参加記念Tシャツ（参加者全員）、完走メダル（完走者）、完走タオル（完走者）', 'Commemorative T-shirt (all participants), Finisher medal (finishers), Finisher towel (finishers)', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('tokyo-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-08-15', '2025-08-29', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tokyo-marathon-2026', NULL, '東京都庁', 'Tokyo Metropolitan Government', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tokyo-marathon-2026', NULL, '皇居', 'Imperial Palace', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tokyo-marathon-2026', NULL, '浅草雷門', 'Asakusa Kaminarimon', NULL, NULL, 2);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tokyo-marathon-2026', NULL, '銀座', 'Ginza', NULL, NULL, 3);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tokyo-marathon-2026', NULL, '東京タワー', 'Tokyo Tower', NULL, NULL, 4);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tokyo-marathon-2026', NULL, '東京駅丸の内', 'Tokyo Station Marunouchi', NULL, NULL, 5);
 
 -- ==================
 -- 東京マラソン (tokyo-marathon-2027)
@@ -5901,11 +6135,11 @@ INSERT OR REPLACE INTO races (
   'Tokyo Metropolitan Government, Imperial Palace, Asakusa Kaminarimon, Ginza, Tokyo Tower, Tokyo Station Marunouchi',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '東京の街',
+  '#1e293b',
+  'Tokyo-no-Machi',
+  '世界6大メジャーの一つ、東京の街を駆け抜ける',
+  'Race through Tokyo — one of the six World Marathon Majors',
   NULL,
   NULL,
   NULL,
@@ -5942,6 +6176,18 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('tokyo-marathon-2027', '["medal","tshirt","towel"]', '参加記念Tシャツ（参加者全員）、完走メダル（完走者）、完走タオル（完走者）', 'Commemorative T-shirt (all participants), Finisher medal (finishers), Finisher towel (finishers)', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('tokyo-marathon-2027', NULL, '一般エントリー', 'General Entry', '2026-08-14', '2026-08-28', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tokyo-marathon-2027', NULL, '東京都庁', 'Tokyo Metropolitan Government', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tokyo-marathon-2027', NULL, '皇居', 'Imperial Palace', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tokyo-marathon-2027', NULL, '浅草雷門', 'Asakusa Kaminarimon', NULL, NULL, 2);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tokyo-marathon-2027', NULL, '銀座', 'Ginza', NULL, NULL, 3);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tokyo-marathon-2027', NULL, '東京タワー', 'Tokyo Tower', NULL, NULL, 4);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tokyo-marathon-2027', NULL, '東京駅丸の内', 'Tokyo Station Marunouchi', NULL, NULL, 5);
 
 -- ==================
 -- 富里スイカロードレース (tomisato-suikaroad-2026)
@@ -5992,11 +6238,11 @@ INSERT OR REPLACE INTO races (
   'Scenic watermelon fields',
   'エイドでスイカ配布。マイカップ給水対応。',
   'Watermelon served at aid stations. Personal cup hydration supported.',
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  'スイカ',
+  '#16a34a',
+  'Suika',
+  '日本一のスイカの産地・富里を走る、夏の風物詩',
+  'Run Japan''s watermelon capital — a midsummer tradition',
   NULL,
   NULL,
   NULL,
@@ -6025,6 +6271,8 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('tomisato-suikaroad-2026', '["tshirt"]', 'Tシャツ（大会当日、「Tシャツ引換所」で引き換え）', '', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('tomisato-suikaroad-2026', NULL, '一般エントリー', 'General Entry', '2026-02-22', '2026-04-04', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tomisato-suikaroad-2026', NULL, 'スイカ畑の田園風景', 'Scenic watermelon fields', NULL, NULL, 0);
 
 -- ==================
 -- 鳥取マラソン (tottori-marathon-2026)
@@ -6075,11 +6323,11 @@ INSERT OR REPLACE INTO races (
   'Near Tottori Sand Dunes, Sea of Japan',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '砂丘',
+  '#d4a853',
+  'Sakyu',
+  '日本最大の砂丘を望む、山陰の大地を走る',
+  'Run the San-in coast with Japan''s great sand dunes in view',
   NULL,
   NULL,
   NULL,
@@ -6115,6 +6363,10 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
 ', 'Race T-shirt', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('tottori-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-10-15', '2025-12-12', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tottori-marathon-2026', NULL, '鳥取砂丘付近', 'Near Tottori Sand Dunes', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tottori-marathon-2026', NULL, '日本海', 'Sea of Japan', NULL, NULL, 1);
 
 -- ==================
 -- 洞爺湖マラソン (toyako-marathon-2026)
@@ -6165,11 +6417,11 @@ INSERT OR REPLACE INTO races (
   'Lake Toya, Mt. Yotei',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '洞爺湖',
+  '#0369a1',
+  'Toyako',
+  '洞爺湖の湖畔を巡る、北海道の爽快42km',
+  'Circle the shores of Lake Toya in refreshing Hokkaido',
   NULL,
   NULL,
   NULL,
@@ -6200,6 +6452,10 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('toyako-marathon-2026', '["medal","tshirt"]', '大会Tシャツとトートバッグ及びフェイスタオル、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('toyako-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-02-01', '2026-03-08', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('toyako-marathon-2026', NULL, '洞爺湖', 'Lake Toya', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('toyako-marathon-2026', NULL, '羊蹄山', 'Mt. Yotei', NULL, NULL, 1);
 
 -- ==================
 -- 富山マラソン (toyama-marathon-2026)
@@ -6250,11 +6506,11 @@ INSERT OR REPLACE INTO races (
   'Tateyama Mountains, Shinminato Bridge, Toyama Bay',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '立山連峰',
+  '#1e3a8a',
+  'Tateyama-Rempo',
+  '立山連峰と富山湾を望む、360度の絶景コース',
+  'Run with panoramic views of the Tateyama Range and Toyama Bay',
   NULL,
   NULL,
   NULL,
@@ -6285,6 +6541,12 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('toyama-marathon-2026', '["medal","tshirt","towel"]', '大会Tシャツ、完走メダル・フィニッシャータオル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('toyama-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-11', '2026-06-30', 14000, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('toyama-marathon-2026', NULL, '立山連峰', 'Tateyama Mountains', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('toyama-marathon-2026', NULL, '新湊大橋', 'Shinminato Bridge', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('toyama-marathon-2026', NULL, '富山湾', 'Toyama Bay', NULL, NULL, 2);
 
 -- ==================
 -- つくばマラソン (tsukuba-marathon-2026)
@@ -6335,11 +6597,11 @@ INSERT OR REPLACE INTO races (
   'Tsukuba Science City',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '筑波山',
+  '#374151',
+  'Tsukuba-san',
+  '西の富士、東の筑波。科学の街を快走する',
+  'Run through the science city with Mt. Tsukuba as your landmark',
   NULL,
   NULL,
   NULL,
@@ -6366,6 +6628,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('tsukuba-marathon-2026', '観光地', '筑波山', 'Mt. Tsukuba', '関東平野にそびえる名山。ロープウェイで山頂へ。コースからも望める。', 'A famous mountain rising from the Kanto Plain. Ropeway to the summit. Visible from the course.', 'つくば市から車約30分', NULL, 36.2253, 140.1);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('tsukuba-marathon-2026', '["medal","tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('tsukuba-marathon-2026', NULL, '筑波研究学園都市', 'Tsukuba Science City', NULL, NULL, 0);
 
 -- ==================
 -- 日本最北端わっかない平和マラソン (wakkanai-peace-marathon-2026)
@@ -6416,11 +6680,11 @@ INSERT OR REPLACE INTO races (
   'Wakkanai Port Northern Breakwater Dome, Sea of Japan, views toward Cape Soya',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '宗谷岬',
+  '#0c4a6e',
+  'Soya-Misaki',
+  '日本最北端・宗谷岬を目指す平和の42km',
+  'Run toward Cape Soya, Japan''s northernmost point',
   NULL,
   NULL,
   NULL,
@@ -6451,6 +6715,12 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('wakkanai-peace-marathon-2026', '["medal","tshirt"]', '完走メダル、大会オリジナルTシャツ', 'Finisher medal, Official race T-shirt', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('wakkanai-peace-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-01', '2026-06-30', 10000, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('wakkanai-peace-marathon-2026', NULL, '稚内港北防波堤ドーム', 'Wakkanai Port Northern Breakwater Dome', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('wakkanai-peace-marathon-2026', NULL, '日本海', 'Sea of Japan', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('wakkanai-peace-marathon-2026', NULL, '宗谷岬方面の眺望', 'views toward Cape Soya', NULL, NULL, 2);
 
 -- ==================
 -- 横浜マラソン (yokohama-marathon-2026)
@@ -6501,11 +6771,11 @@ INSERT OR REPLACE INTO races (
   'Minato Mirai, Red Brick Warehouse, Bayshore Expressway, Yamashita Park',
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  '港',
+  '#0e4f8a',
+  'Minato',
+  '開港の街・横浜の海と丘を駆け抜ける',
+  'Run through Yokohama''s historic port city of sea and hills',
   NULL,
   NULL,
   NULL,
@@ -6536,4 +6806,12 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
   ('yokohama-marathon-2026', '["medal","tshirt","towel"]', '大会Tシャツ、完走メダル、フィニッシャータオル', 'Race T-shirt, Finisher medal, Finisher towel', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('yokohama-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-08', '2026-05-08', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('yokohama-marathon-2026', NULL, 'みなとみらい', 'Minato Mirai', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('yokohama-marathon-2026', NULL, '赤レンガ倉庫', 'Red Brick Warehouse', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('yokohama-marathon-2026', NULL, '首都高速湾岸線', 'Bayshore Expressway', NULL, NULL, 2);
+INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('yokohama-marathon-2026', NULL, '山下公園', 'Yamashita Park', NULL, NULL, 3);
 

--- a/scripts/add-phase3-fields.js
+++ b/scripts/add-phase3-fields.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+/**
+ * Phase 3 フィールドを全レース JSON に追加するスクリプト
+ * gallery / voices / time_buckets / course_highlights を空配列で挿入
+ */
+const fs = require('fs');
+const path = require('path');
+
+const RACES_DIR = path.join(__dirname, '../src/data/races');
+const files = fs.readdirSync(RACES_DIR).filter(f => f.endsWith('.json') && f !== 'index.json');
+
+let updated = 0;
+for (const file of files) {
+  const filePath = path.join(RACES_DIR, file);
+  const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+
+  let changed = false;
+  if (!('gallery' in data)) { data.gallery = []; changed = true; }
+  if (!('voices' in data)) { data.voices = []; changed = true; }
+  if (!('time_buckets' in data)) { data.time_buckets = []; changed = true; }
+  if (!('course_highlights' in data)) { data.course_highlights = []; changed = true; }
+
+  if (changed) {
+    fs.writeFileSync(filePath, JSON.stringify(data, null, 2) + '\n', 'utf8');
+    updated++;
+  }
+}
+
+console.log(`Updated: ${updated}/${files.length} files`);

--- a/scripts/build-course-highlights.js
+++ b/scripts/build-course-highlights.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+/**
+ * course_info.highlights_ja/en を course_highlights 配列に構造化するスクリプト
+ * カンマ・読点で分割してポイントリストを生成
+ */
+const fs = require('fs');
+const path = require('path');
+
+const RACES_DIR = path.join(__dirname, '../src/data/races');
+const files = fs.readdirSync(RACES_DIR).filter(f => f.endsWith('.json') && f !== 'index.json');
+
+let updated = 0;
+
+for (const file of files) {
+  const filePath = path.join(RACES_DIR, file);
+  const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+
+  const ci = data.course_info || {};
+  const hlJa = ci.highlights_ja;
+  const hlEn = ci.highlights_en;
+
+  if (!hlJa || data.course_highlights.length > 0) continue;
+
+  // 「、」「，」「, 」で分割してポイント化
+  const pointsJa = hlJa.split(/[、,，]+/).map(s => s.trim()).filter(Boolean);
+  const pointsEn = hlEn ? hlEn.split(/,\s*/).map(s => s.trim()).filter(Boolean) : [];
+
+  data.course_highlights = pointsJa.map((nameJa, i) => ({
+    name_ja: nameJa,
+    name_en: pointsEn[i] ?? null,
+    description_ja: null,
+    description_en: null,
+  }));
+
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2) + '\n', 'utf8');
+  updated++;
+}
+
+console.log(`Updated: ${updated}/${files.length} files`);

--- a/scripts/generate-seed-races.js
+++ b/scripts/generate-seed-races.js
@@ -104,11 +104,18 @@ function generateRaceSQL(r) {
   lines.push(`DELETE FROM race_time_buckets WHERE race_id = ${esc(r.id)};`);
   lines.push(`DELETE FROM race_course_highlights WHERE race_id = ${esc(r.id)};`);
 
-  // race_categories
+  // race_categories（+ カテゴリに付随する course_highlights）
   if (r.categories && r.categories.length > 0) {
     r.categories.forEach((cat, idx) => {
       lines.push(`INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   (${esc(r.id)}, ${esc(cat.distance_type)}, ${esc(cat.distance_km)}, ${esc(cat.time_limit_minutes || 0)}, ${esc(cat.start_time || '')}, ${esc(cat.capacity || 0)}, ${esc(cat.entry_fee ?? null)}, ${esc(cat.entry_fee_u25 ?? null)}, ${esc(cat.name_ja ?? null)}, ${esc(cat.name_en ?? null)}, ${esc(cat.description_ja ?? null)}, ${esc(cat.description_en ?? null)}, ${esc(cat.eligibility_ja ?? null)}, ${esc(cat.eligibility_en ?? null)}, ${esc(cat.course_gpx_file ?? null)}, ${escJson(cat.waves || [])}, ${idx});`);
+      // カテゴリ直下の course_highlights: last_insert_rowid() で category_id を取得
+      if (cat.course_highlights && cat.course_highlights.length > 0) {
+        cat.course_highlights.forEach((ch, cidx) => {
+          lines.push(`INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  (${esc(r.id)}, last_insert_rowid(), ${esc(ch.km)}, ${esc(ch.name_ja)}, ${esc(ch.name_en ?? null)}, ${esc(ch.note_ja ?? null)}, ${esc(ch.note_en ?? null)}, ${cidx});`);
+        });
+      }
     });
   }
 
@@ -200,11 +207,11 @@ function generateRaceSQL(r) {
     });
   }
 
-  // race_course_highlights
+  // race_course_highlights（レースレベル: category_id = NULL → メインカテゴリに振り分け）
   if (r.course_highlights && r.course_highlights.length > 0) {
     r.course_highlights.forEach((ch, idx) => {
-      lines.push(`INSERT OR REPLACE INTO race_course_highlights (race_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  (${esc(r.id)}, ${esc(ch.km)}, ${esc(ch.name_ja)}, ${esc(ch.name_en ?? null)}, ${esc(ch.note_ja ?? null)}, ${esc(ch.note_en ?? null)}, ${idx});`);
+      lines.push(`INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  (${esc(r.id)}, NULL, ${esc(ch.km)}, ${esc(ch.name_ja)}, ${esc(ch.name_en ?? null)}, ${esc(ch.note_ja ?? null)}, ${esc(ch.note_en ?? null)}, ${idx});`);
     });
   }
 

--- a/scripts/set-motif-data.js
+++ b/scripts/set-motif-data.js
@@ -1,0 +1,580 @@
+#!/usr/bin/env node
+/**
+ * 全レース JSON に motif / motif_color / motif_romaji / tagline_ja / tagline_en を設定するスクリプト
+ */
+const fs = require('fs');
+const path = require('path');
+
+const RACES_DIR = path.join(__dirname, '../src/data/races');
+
+// id → motifデータのマップ
+const MOTIF_DATA = {
+  'abashiri-marathon-2026': {
+    motif: '流氷',
+    motif_color: '#bfdbfe',
+    motif_romaji: 'Ryuhyo',
+    tagline_ja: '流氷の大地を駆け抜ける春の42km',
+    tagline_en: 'Run through the land of drift ice in spring',
+  },
+  'akita-nairiku-ultra-2026': {
+    motif: '紅葉',
+    motif_color: '#d4631a',
+    motif_romaji: 'Koyo',
+    tagline_ja: '秋田内陸の紅葉の回廊を走る100km',
+    tagline_en: 'A 100km journey through autumn foliage corridors',
+  },
+  'aomori-sakura-marathon-2026': {
+    motif: '桜',
+    motif_color: '#f9c1cc',
+    motif_romaji: 'Sakura',
+    tagline_ja: '桜前線に乗って、青森を走る',
+    tagline_en: 'Run through Aomori on the cherry blossom front',
+  },
+  'asahikawa-half-marathon-2026': {
+    motif: '大雪山',
+    motif_color: '#dbeafe',
+    motif_romaji: 'Taisetsuzan',
+    tagline_ja: '大雪山を仰ぎながら旭川の街を駆ける',
+    tagline_en: 'Run through Asahikawa with Mt. Taisetsu in view',
+  },
+  'beppu-oita-marathon-2026': {
+    motif: '温泉',
+    motif_color: '#fed7aa',
+    motif_romaji: 'Onsen',
+    tagline_ja: '湯けむりの街から、大分へ。歴史ある42.195km',
+    tagline_en: 'From the city of hot springs to Oita — a storied 42.195km',
+  },
+  'biwako-marathon-2026': {
+    motif: '琵琶湖',
+    motif_color: '#93c5fd',
+    motif_romaji: 'Biwako',
+    tagline_ja: '日本最大の湖を舞台に、水の都を走る',
+    tagline_en: "Run along Japan's largest lake",
+  },
+  'challenge-fuji5lakes-2026': {
+    motif: '富士五湖',
+    motif_color: '#2563eb',
+    motif_romaji: 'Fuji-Goko',
+    tagline_ja: '富士五湖を巡る、究極のチャレンジ',
+    tagline_en: 'The ultimate challenge around the five Fuji lakes',
+  },
+  'chiba-aqualine-marathon-2026': {
+    motif: '海',
+    motif_color: '#0ea5e9',
+    motif_romaji: 'Umi',
+    tagline_ja: '東京湾アクアラインを渡る、世界唯一のコース',
+    tagline_en: 'The world-unique course crossing Tokyo Bay Aqua-Line',
+  },
+  'ehime-marathon-2026': {
+    motif: 'みかん',
+    motif_color: '#f97316',
+    motif_romaji: 'Mikan',
+    tagline_ja: '蜜柑の香り漂う、瀬戸内の道を走る',
+    tagline_en: 'Run through the Seto Inland citrus country',
+  },
+  'fuji-mountain-race-2026': {
+    motif: '富士山',
+    motif_color: '#4b5563',
+    motif_romaji: 'Fujisan',
+    tagline_ja: '山頂を目指す、日本の頂への挑戦',
+    tagline_en: 'Challenge to the summit — the ultimate mountain race',
+  },
+  'fujisan-marathon-2026': {
+    motif: '富士山',
+    motif_color: '#2a4fa3',
+    motif_romaji: 'Fujisan',
+    tagline_ja: '霊峰富士を望みながら駆ける、絶景のコース',
+    tagline_en: "Run with Japan's sacred peak as your guide",
+  },
+  'fukuchiyama-marathon-2026': {
+    motif: '福知山城',
+    motif_color: '#78350f',
+    motif_romaji: 'Fukuchiyama-jo',
+    tagline_ja: '城下町・福知山の歴史街道を駆け抜ける',
+    tagline_en: "Run through the historic castle town of Fukuchiyama",
+  },
+  'fukui-sakura-marathon-2026': {
+    motif: '桜',
+    motif_color: '#f9c1cc',
+    motif_romaji: 'Sakura',
+    tagline_ja: '福井の桜回廊を巡る、春の42km',
+    tagline_en: "A spring 42km through Fukui's cherry blossom corridors",
+  },
+  'fukuoka-international-marathon-2026': {
+    motif: '博多',
+    motif_color: '#1e3a5f',
+    motif_romaji: 'Hakata',
+    tagline_ja: '国際都市・福岡が誇る、世界へ続く道',
+    tagline_en: 'A world-class course in the international city of Fukuoka',
+  },
+  'fukuoka-marathon-2026': {
+    motif: '博多湾',
+    motif_color: '#0284c7',
+    motif_romaji: 'Hakata-wan',
+    tagline_ja: '博多の海沿いを走る、秋の風物詩',
+    tagline_en: "Run along Hakata Bay in autumn",
+  },
+  'gunma-marathon-2026': {
+    motif: '赤城山',
+    motif_color: '#166534',
+    motif_romaji: 'Akagi-san',
+    tagline_ja: '赤城を仰ぎ、前橋の大地を駆ける',
+    tagline_en: "Run across Maebashi plain with Mt. Akagi in view",
+  },
+  'higashine-sakuranbo-marathon-2026': {
+    motif: 'さくらんぼ',
+    motif_color: '#dc2626',
+    motif_romaji: 'Sakuranbo',
+    tagline_ja: 'さくらんぼの里・東根で走る、甘い42km',
+    tagline_en: "Run 42km in Japan's cherry capital",
+  },
+  'higashinipon-half-marathon-2026': {
+    motif: '桜',
+    motif_color: '#f9c1cc',
+    motif_romaji: 'Sakura',
+    tagline_ja: '立川の春を駆け抜ける東日本ハーフ',
+    tagline_en: 'East Japan Half Marathon through spring Tachikawa',
+  },
+  'himeji-castle-marathon-2026': {
+    motif: '姫路城',
+    motif_color: '#f8fafc',
+    motif_romaji: 'Himeji-jo',
+    tagline_ja: '世界遺産・白鷺城を眺めながら走る42.195km',
+    tagline_en: "Run beneath the White Heron Castle, a World Heritage Site",
+  },
+  'hitachi-seaside-marathon-2026': {
+    motif: 'コキア',
+    motif_color: '#dc2626',
+    motif_romaji: 'Kochiya',
+    tagline_ja: '海浜公園のコキアが彩る、ひたちの秋',
+    tagline_en: "Run through Hitachi Seaside Park's autumn kochia fields",
+  },
+  'hofu-yomiuri-marathon-2026': {
+    motif: '防府天満宮',
+    motif_color: '#92400e',
+    motif_romaji: 'Hofu-Tenmangu',
+    tagline_ja: '日本最古の天満宮の参道を巡る歴史ある大会',
+    tagline_en: "Race through the grounds of Japan's oldest Tenmangu shrine",
+  },
+  'hokkaido-marathon-2026': {
+    motif: 'ライラック',
+    motif_color: '#8b5cf6',
+    motif_romaji: 'Rairakku',
+    tagline_ja: 'ライラック香る大通公園から、北の大地を走る',
+    tagline_en: 'From the lilac-scented Odori Park across Hokkaido',
+  },
+  'ibusuki-nanohana-2026': {
+    motif: '菜の花',
+    motif_color: '#eab308',
+    motif_romaji: 'Nanohana',
+    tagline_ja: '黄金色の菜の花畑と薩摩の海を巡る42km',
+    tagline_en: 'Run through golden rapeseed fields along the Satsuma sea',
+  },
+  'ichinoseki-half-marathon-2026': {
+    motif: '厳美渓',
+    motif_color: '#065f46',
+    motif_romaji: 'Genbikei',
+    tagline_ja: '厳美渓の渓谷美を感じながら走る一関ハーフ',
+    tagline_en: "Run through the scenic Genbikei gorge in Ichinoseki",
+  },
+  'iki-ultra-marathon-2026': {
+    motif: '壱岐の海',
+    motif_color: '#0891b2',
+    motif_romaji: 'Iki-no-Umi',
+    tagline_ja: '玄界灘に浮かぶ神秘の島・壱岐を一周する',
+    tagline_en: "Circle the mystical island of Iki in the Genkai Sea",
+  },
+  'itabashi-city-marathon-2026': {
+    motif: '荒川',
+    motif_color: '#6b7280',
+    motif_romaji: 'Arakawa',
+    tagline_ja: '荒川河川敷を駆ける、春の板橋シティマラソン',
+    tagline_en: "Run the Arakawa riverside in spring",
+  },
+  'iwaki-sunshine-marathon-2026': {
+    motif: '太平洋',
+    motif_color: '#0369a1',
+    motif_romaji: 'Taiheiyo',
+    tagline_ja: '太平洋の輝きとともに、いわきの海岸を走る',
+    tagline_en: "Run along Iwaki's Pacific coast in sunshine",
+  },
+  'iwate-morioka-city-marathon-2026': {
+    motif: '岩手山',
+    motif_color: '#374151',
+    motif_romaji: 'Iwate-san',
+    tagline_ja: '南部片富士・岩手山を望み、盛岡の街を駆ける',
+    tagline_en: "Run through Morioka with Mt. Iwate towering above",
+  },
+  'iwate-oshu-kirameki-marathon-2026': {
+    motif: '平泉',
+    motif_color: '#854d0e',
+    motif_romaji: 'Hiraizumi',
+    tagline_ja: '世界遺産・平泉の黄金文化を感じながら走る',
+    tagline_en: "Run through Hiraizumi, the Golden City of World Heritage",
+  },
+  'kagawa-marathon-2026': {
+    motif: '瀬戸内海',
+    motif_color: '#0284c7',
+    motif_romaji: 'Setonaikai',
+    tagline_ja: '瀬戸内の穏やかな海を見渡しながら走る42km',
+    tagline_en: "Run along the serene shores of the Seto Inland Sea",
+  },
+  'kagoshima-marathon-2026': {
+    motif: '桜島',
+    motif_color: '#991b1b',
+    motif_romaji: 'Sakura-jima',
+    tagline_ja: '活火山・桜島を望む、薩摩の海岸を走る',
+    tagline_en: "Run along Kagoshima Bay with the volcanic Sakurajima in view",
+  },
+  'kaikyo-marathon-2026': {
+    motif: '関門海峡',
+    motif_color: '#1e40af',
+    motif_romaji: 'Kanmon-Kaikyo',
+    tagline_ja: '本州と九州をつなぐ、関門海峡を渡る',
+    tagline_en: "Cross the Kanmon Strait connecting Honshu and Kyushu",
+  },
+  'kanazawa-marathon-2026': {
+    motif: '兼六園',
+    motif_color: '#14532d',
+    motif_romaji: 'Kenroku-en',
+    tagline_ja: '加賀百万石の城下町・金沢を駆ける',
+    tagline_en: "Run through Kanazawa, the castle town of one million koku",
+  },
+  'kasumigaura-marathon-2026': {
+    motif: '霞ヶ浦',
+    motif_color: '#7dd3fc',
+    motif_romaji: 'Kasumigaura',
+    tagline_ja: '日本第2位の湖・霞ヶ浦のほとりを走る',
+    tagline_en: "Run along the shores of Lake Kasumigaura, Japan's 2nd largest lake",
+  },
+  'katsuta-marathon-2026': {
+    motif: '百里',
+    motif_color: '#4b5563',
+    motif_romaji: 'Hyakuri',
+    tagline_ja: '常陸の大地を駆け抜ける、勝田全国マラソン',
+    tagline_en: "Run across the Hitachi plains at Katsuta",
+  },
+  'kitakyushu-marathon-2026': {
+    motif: '洞海湾',
+    motif_color: '#1d4ed8',
+    motif_romaji: 'Dokai-wan',
+    tagline_ja: '北九州の海と工場夜景の街を走る',
+    tagline_en: "Run through Kitakyushu's industrial waterfront",
+  },
+  'kix-senshu-marathon-2026': {
+    motif: '大阪湾',
+    motif_color: '#0ea5e9',
+    motif_romaji: 'Osaka-wan',
+    tagline_ja: '関西国際空港を望む、泉州の海岸を駆ける',
+    tagline_en: "Run the Senshu coast with Kansai International Airport in view",
+  },
+  'kobe-marathon-2026': {
+    motif: '異人館',
+    motif_color: '#b91c1c',
+    motif_romaji: 'Ijin-kan',
+    tagline_ja: '港町・神戸の異国情緒あふれる街を走る',
+    tagline_en: "Run through the exotic port city of Kobe",
+  },
+  'kochi-ryoma-marathon-2026': {
+    motif: '坂本龍馬',
+    motif_color: '#1a3a1a',
+    motif_romaji: 'Ryoma',
+    tagline_ja: '龍馬の志を胸に、土佐の大地を駆け抜ける',
+    tagline_en: "Run the Tosa plains with the spirit of Ryoma",
+  },
+  'kumamoto-castle-marathon-2026': {
+    motif: '熊本城',
+    motif_color: '#1c1917',
+    motif_romaji: 'Kumamoto-jo',
+    tagline_ja: '不落の名城・熊本城をめぐる感動の42km',
+    tagline_en: "42km around the legendary Kumamoto Castle",
+  },
+  'kyoto-marathon-2026': {
+    motif: '大文字山',
+    motif_color: '#7f1d1d',
+    motif_romaji: 'Daimonji-yama',
+    tagline_ja: '千年の古都・京都の世界遺産をめぐる',
+    tagline_en: "Run through Kyoto's thousand years of world heritage",
+  },
+  'mie-matsusaka-marathon-2026': {
+    motif: '松阪牛',
+    motif_color: '#7f1d1d',
+    tagline_ja: '松阪牛の里・松阪を走る、美食ランナーの聖地',
+    tagline_en: "Run through Matsusaka, home of Japan's finest beef",
+    motif_romaji: 'Matsusaka-gyu',
+  },
+  'mito-komon-manyu-marathon-2026': {
+    motif: '水戸黄門',
+    motif_color: '#1c1917',
+    motif_romaji: 'Mito-Komon',
+    tagline_ja: '助さん格さんも驚く、水戸を駆ける42km',
+    tagline_en: "Run through Mito as legends of the Komon await",
+  },
+  'mtfuji-climb-run-2026': {
+    motif: '富士山頂',
+    motif_color: '#1e3a8a',
+    motif_romaji: 'Fujisan-cho',
+    tagline_ja: '霊峰富士の頂へ、山岳レースの最高峰',
+    tagline_en: "Climb to the summit of Mt. Fuji — the ultimate trail race",
+  },
+  'nagano-marathon-2026': {
+    motif: '善光寺',
+    motif_color: '#78350f',
+    motif_romaji: 'Zenko-ji',
+    tagline_ja: '長野オリンピックの遺産を巡る、信濃の春',
+    tagline_en: "Run through Nagano's Olympic legacy in spring Shinano",
+  },
+  'nagoya-womens-marathon-2026': {
+    motif: '名古屋城',
+    motif_color: '#c2410c',
+    motif_romaji: 'Nagoya-jo',
+    tagline_ja: '女性ランナーの憧れ、名古屋の街を駆ける42km',
+    tagline_en: "The women's marathon destination — run through Nagoya",
+  },
+  'naha-marathon-2026': {
+    motif: 'ハイビスカス',
+    motif_color: '#dc2626',
+    motif_romaji: 'Haibisukasu',
+    tagline_ja: '南国の陽光と笑顔溢れる、那覇の42km',
+    tagline_en: "Run through tropical Naha with sunshine and smiles",
+  },
+  'nara-marathon-2026': {
+    motif: '奈良の鹿',
+    motif_color: '#92400e',
+    motif_romaji: 'Nara-no-Shika',
+    tagline_ja: '奈良の鹿と世界遺産が待つ、古都の42km',
+    tagline_en: "Run through the ancient capital of Nara alongside sacred deer",
+  },
+  'niigata-city-marathon-2026': {
+    motif: '信濃川',
+    motif_color: '#0369a1',
+    motif_romaji: 'Shinano-gawa',
+    tagline_ja: '日本一の大河・信濃川が流れる、米どころを走る',
+    tagline_en: "Run along the Shinano River, Japan's longest",
+  },
+  'nishio-marathon-2026': {
+    motif: '抹茶',
+    motif_color: '#4d7c0f',
+    motif_romaji: 'Matcha',
+    tagline_ja: '日本有数の抹茶の産地・西尾を巡る42km',
+    tagline_en: "Run through Nishio, one of Japan's top matcha-producing cities",
+  },
+  'okayama-marathon-2026': {
+    motif: '桃',
+    motif_color: '#f9a8d4',
+    motif_romaji: 'Momo',
+    tagline_ja: '桃太郎の里・岡山を、晴れの国で走る',
+    tagline_en: "Run through Okayama, the sunny land of Momotaro",
+  },
+  'okushinano100-2026': {
+    motif: '北アルプス',
+    motif_color: '#1e40af',
+    motif_romaji: 'Kita-Arupusu',
+    tagline_ja: '北アルプスの麓・奥信濃を走る100km',
+    tagline_en: "100km through the foothills of the Northern Alps",
+  },
+  'osaka-marathon-2026': {
+    motif: '大阪城',
+    motif_color: '#92400e',
+    motif_romaji: 'Osaka-jo',
+    tagline_ja: '笑いと活気溢れる、天下の台所・大阪を走る',
+    tagline_en: "Run through Osaka, the nation's kitchen of energy",
+  },
+  'osaka-yodo-river-citizens-marathon-2026': {
+    motif: '淀川',
+    motif_color: '#0284c7',
+    motif_romaji: 'Yodogawa',
+    tagline_ja: '淀川の流れに沿って、大阪の街を走る',
+    tagline_en: "Run along the Yodo River through Osaka",
+  },
+  'osj-ontake100-2026': {
+    motif: '御嶽山',
+    motif_color: '#1c1917',
+    motif_romaji: 'Ontake-san',
+    tagline_ja: '霊峰・御嶽山の麓を巡る、100kmの山岳路',
+    tagline_en: "100km through the sacred slopes of Mt. Ontake",
+  },
+  'sado-toki-marathon-2026': {
+    motif: '朱鷺',
+    motif_color: '#fb7185',
+    motif_romaji: 'Toki',
+    tagline_ja: '朱鷺舞う離島・佐渡で走る、自然豊かな42km',
+    tagline_en: "Run the island of Sado where the endangered crested ibis soars",
+  },
+  'saga-sakura-marathon-2026': {
+    motif: '桜',
+    motif_color: '#f9c1cc',
+    motif_romaji: 'Sakura',
+    tagline_ja: '佐賀城址の桜を愛でながら走る、春の42km',
+    tagline_en: "Run beneath cherry blossoms at Saga Castle in spring",
+  },
+  'saitama-marathon-2026': {
+    motif: '荒川',
+    motif_color: '#0369a1',
+    motif_romaji: 'Arakawa',
+    tagline_ja: '荒川の雄大な流れとともに走る、さいたまの42km',
+    tagline_en: "Run along the vast Arakawa River through Saitama",
+  },
+  'shiga-kogen100-2026': {
+    motif: '高原',
+    motif_color: '#166534',
+    motif_romaji: 'Kogen',
+    tagline_ja: '志賀高原の雄大な自然の中を走る100kmトレイル',
+    tagline_en: "100km trail through the majestic nature of Shiga Kogen",
+  },
+  'shimada-oigawa-marathon-2026': {
+    motif: '大井川',
+    motif_color: '#15803d',
+    motif_romaji: 'Oi-gawa',
+    tagline_ja: '南アルプスから流れる大井川沿いを走る42km',
+    tagline_en: "Run along the Oi River flowing down from the Southern Alps",
+  },
+  'shinetsu5mountains-trail-100-2026': {
+    motif: '信越五岳',
+    motif_color: '#065f46',
+    motif_romaji: 'Shin-etsu-Gogaku',
+    tagline_ja: '信越の五つの山を巡る、100マイルの挑戦',
+    tagline_en: "A 100-mile challenge through five peaks of the Shin-Etsu mountains",
+  },
+  'shizuoka-marathon-2026': {
+    motif: '富士山',
+    motif_color: '#2a4fa3',
+    motif_romaji: 'Fujisan',
+    tagline_ja: '富士山を正面に望む、海岸線の42km',
+    tagline_en: "Run the coastline with Mt. Fuji straight ahead",
+  },
+  'shonan-international-marathon-2026': {
+    motif: '湘南の海',
+    motif_color: '#0ea5e9',
+    motif_romaji: 'Shonan-no-Umi',
+    tagline_ja: '湘南の海風を感じながら走る、江ノ島から湘南へ',
+    tagline_en: "Run the Shonan coast from Enoshima with ocean breezes",
+  },
+  'soja-kibiji-marathon-2026': {
+    motif: '吉備路',
+    motif_color: '#854d0e',
+    motif_romaji: 'Kibiji',
+    tagline_ja: '吉備路の古代ロマンを感じながら走る42km',
+    tagline_en: "Run the ancient Kibiji road through Soja's historic landscape",
+  },
+  'tamba-sasayama-abc-marathon-2026': {
+    motif: '城下町',
+    motif_color: '#1c1917',
+    motif_romaji: 'Jokamachi',
+    tagline_ja: '丹波篠山・城下町の風情漂う黒豆の里を走る',
+    tagline_en: "Run through the castle town of Tamba Sasayama, home of black soybeans",
+  },
+  'tateyama-wakashio-2026': {
+    motif: '若潮',
+    motif_color: '#0369a1',
+    motif_romaji: 'Wakashio',
+    tagline_ja: '太平洋に面した館山の若潮を感じながら走る',
+    tagline_en: "Run Tateyama's Pacific coast on the fresh tides of spring",
+  },
+  'tazawako-marathon-2026': {
+    motif: '田沢湖',
+    motif_color: '#1e40af',
+    motif_romaji: 'Tazawako',
+    tagline_ja: '日本最深の湖・田沢湖を一望しながら走る',
+    tagline_en: "Run overlooking Lake Tazawa, Japan's deepest lake",
+  },
+  'tokushima-marathon-2026': {
+    motif: '阿波おどり',
+    motif_color: '#ea580c',
+    motif_romaji: 'Awa-Odori',
+    tagline_ja: '踊る阿呆に走る阿呆！阿波の国を駆け抜ける',
+    tagline_en: "Run the land of Awa dance — the spirit of Tokushima",
+  },
+  'tokyo-marathon-2026': {
+    motif: '東京の街',
+    motif_color: '#1e293b',
+    motif_romaji: 'Tokyo-no-Machi',
+    tagline_ja: '世界6大メジャーの一つ、東京の街を駆け抜ける',
+    tagline_en: "Race through Tokyo — one of the six World Marathon Majors",
+  },
+  'tokyo-marathon-2027': {
+    motif: '東京の街',
+    motif_color: '#1e293b',
+    motif_romaji: 'Tokyo-no-Machi',
+    tagline_ja: '世界6大メジャーの一つ、東京の街を駆け抜ける',
+    tagline_en: "Race through Tokyo — one of the six World Marathon Majors",
+  },
+  'tomisato-suikaroad-2026': {
+    motif: 'スイカ',
+    motif_color: '#16a34a',
+    motif_romaji: 'Suika',
+    tagline_ja: '日本一のスイカの産地・富里を走る、夏の風物詩',
+    tagline_en: "Run Japan's watermelon capital — a midsummer tradition",
+  },
+  'tottori-marathon-2026': {
+    motif: '砂丘',
+    motif_color: '#d4a853',
+    motif_romaji: 'Sakyu',
+    tagline_ja: '日本最大の砂丘を望む、山陰の大地を走る',
+    tagline_en: "Run the San-in coast with Japan's great sand dunes in view",
+  },
+  'toyako-marathon-2026': {
+    motif: '洞爺湖',
+    motif_color: '#0369a1',
+    motif_romaji: 'Toyako',
+    tagline_ja: '洞爺湖の湖畔を巡る、北海道の爽快42km',
+    tagline_en: "Circle the shores of Lake Toya in refreshing Hokkaido",
+  },
+  'toyama-marathon-2026': {
+    motif: '立山連峰',
+    motif_color: '#1e3a8a',
+    motif_romaji: 'Tateyama-Rempo',
+    tagline_ja: '立山連峰と富山湾を望む、360度の絶景コース',
+    tagline_en: "Run with panoramic views of the Tateyama Range and Toyama Bay",
+  },
+  'tsukuba-marathon-2026': {
+    motif: '筑波山',
+    motif_color: '#374151',
+    motif_romaji: 'Tsukuba-san',
+    tagline_ja: '西の富士、東の筑波。科学の街を快走する',
+    tagline_en: "Run through the science city with Mt. Tsukuba as your landmark",
+  },
+  'wakkanai-peace-marathon-2026': {
+    motif: '宗谷岬',
+    motif_color: '#0c4a6e',
+    motif_romaji: 'Soya-Misaki',
+    tagline_ja: '日本最北端・宗谷岬を目指す平和の42km',
+    tagline_en: "Run toward Cape Soya, Japan's northernmost point",
+  },
+  'yokohama-marathon-2026': {
+    motif: '港',
+    motif_color: '#0e4f8a',
+    motif_romaji: 'Minato',
+    tagline_ja: '開港の街・横浜の海と丘を駆け抜ける',
+    tagline_en: "Run through Yokohama's historic port city of sea and hills",
+  },
+};
+
+const files = fs.readdirSync(RACES_DIR).filter(f => f.endsWith('.json') && f !== 'index.json');
+
+let updated = 0;
+let skipped = 0;
+
+for (const file of files) {
+  const id = file.replace('.json', '');
+  const filePath = path.join(RACES_DIR, file);
+  const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+
+  const motifData = MOTIF_DATA[id];
+  if (!motifData) {
+    console.warn(`⚠ No motif data for: ${id}`);
+    skipped++;
+    continue;
+  }
+
+  data.motif = motifData.motif;
+  data.motif_color = motifData.motif_color;
+  data.motif_romaji = motifData.motif_romaji;
+  data.tagline_ja = motifData.tagline_ja;
+  data.tagline_en = motifData.tagline_en;
+
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2) + '\n', 'utf8');
+  updated++;
+}
+
+console.log(`Updated: ${updated}, Skipped: ${skipped}, Total: ${files.length}`);

--- a/src/app/[locale]/calendar/page.tsx
+++ b/src/app/[locale]/calendar/page.tsx
@@ -73,7 +73,18 @@ export default async function CalendarPage({
         >
           ← {t('prev')}
         </Link>
-        <h2 className="text-lg font-bold">{monthLabel}</h2>
+        <div className="flex items-center gap-3">
+          <h2 className="text-lg font-bold">{monthLabel}</h2>
+          {(year !== todayYear || month !== todayMonth0 - 1) && (
+            <Link
+              href={`?year=${todayYear}&month=${todayMonth0 - 1}`}
+              className="px-3 py-1 text-xs font-medium rounded-[3px] transition-colors no-underline"
+              style={{ background: 'var(--color-primary)', color: 'white' }}
+            >
+              {isJa ? '今月' : 'Today'}
+            </Link>
+          )}
+        </div>
         <Link
           href={`?year=${nextMonth.year}&month=${nextMonth.month}`}
           className="px-4 py-1.5 text-sm font-medium rounded-[3px] transition-colors no-underline"

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,7 +1,7 @@
 import { useTranslations } from 'next-intl';
 import { getTranslations } from 'next-intl/server';
 import type { Metadata } from 'next';
-import { getUpcomingRaces, getOpenEntryRaces, getSoonOpeningEntryRaces } from '@/lib/data';
+import { getUpcomingRaces, getOpenEntryRaces, getSoonOpeningEntryRaces, getTotalRaceCount, getOpenEntryCount } from '@/lib/data';
 import HomeSections from '@/components/home/HomeSections';
 import { Link } from '@/i18n/navigation';
 import type { Locale } from '@/lib/types';
@@ -33,11 +33,12 @@ function CaptionBar({ raceCount }: { raceCount: number }) {
 }
 
 // ─── Hero ────────────────────────────────────────────
-function HeroSection({ raceCount }: { raceCount: number }) {
+function HeroSection({ raceCount, openEntryCount }: { raceCount: number; openEntryCount: number }) {
   const t = useTranslations('home.hero');
 
   const stats = [
     { num: raceCount.toLocaleString(), label: '掲載大会', sub: 'races' },
+    { num: openEntryCount.toLocaleString(), label: '受付中', sub: 'open entry' },
     { num: '47',  label: '都道府県', sub: 'pref.' },
   ];
 
@@ -287,11 +288,14 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
     getSoonOpeningEntryRaces(6),
   ]);
 
-  const totalRaces = upcomingRaces.length + openEntryRaces.length + soonOpeningRaces.length;
+  const [totalRaces, openEntryCount] = await Promise.all([
+    getTotalRaceCount(),
+    getOpenEntryCount(),
+  ]);
 
   return (
     <>
-      <HeroSection raceCount={totalRaces || 1247} />
+      <HeroSection raceCount={totalRaces} openEntryCount={openEntryCount} />
       <HomeSections
         upcoming={upcomingRaces}
         openEntry={openEntryRaces}

--- a/src/app/[locale]/races/[id]/page.tsx
+++ b/src/app/[locale]/races/[id]/page.tsx
@@ -63,25 +63,24 @@ const NEARBY_TYPE: Record<NearbySpotType, { en: string; icon: string }> = {
   '宿泊': { en: 'Stay', icon: '🏨' },
 };
 
-function SectionLabel({ children }: { children: React.ReactNode }) {
+function SectionHeading({ num, title, subtitle }: { num: string; title: string; subtitle?: string }) {
   return (
-    <p
-      className="text-[0.68rem] font-bold tracking-[0.16em] uppercase mb-1"
-      style={{ color: 'var(--color-primary)' }}
-    >
-      {children}
-    </p>
-  );
-}
-
-function SectionTitle({ children }: { children: React.ReactNode }) {
-  return (
-    <h2
-      className="font-serif text-2xl font-bold mb-5"
-      style={{ color: 'var(--color-ink)' }}
-    >
-      {children}
-    </h2>
+    <div className="flex items-baseline gap-3 mb-6">
+      <span
+        className="text-[0.65rem] font-mono tracking-wider shrink-0"
+        style={{ color: 'var(--color-primary)' }}
+      >
+        {num}
+      </span>
+      <h2 className="text-xl font-bold" style={{ color: 'var(--color-ink)' }}>
+        {title}
+      </h2>
+      {subtitle && (
+        <span className="text-sm italic hidden sm:inline" style={{ color: 'var(--color-mid)' }}>
+          — {subtitle}
+        </span>
+      )}
+    </div>
   );
 }
 
@@ -183,109 +182,45 @@ export default async function RaceDetailPage({
       </div>
 
       {/* ── Hero ── */}
-      <DetailHeader race={race} locale={locale} raceName={raceName} />
-
-      {/* ── メタ情報ストリップ ── */}
-      <div style={{ background: 'var(--color-ink)' }} className="text-white">
-        <div className="max-w-4xl mx-auto px-4 sm:px-6 py-4">
-          {/* Tags */}
-          {race.tags.length > 0 && (
-            <div className="flex flex-wrap gap-2 mb-3">
-              {race.tags.map((tag) => (
-                <span
-                  key={tag}
-                  className="text-[0.68rem] font-semibold px-2.5 py-0.5 rounded-[3px]"
-                  style={{ background: 'rgba(255,255,255,0.12)', color: 'rgba(255,255,255,0.8)' }}
-                >
-                  {tag}
-                </span>
-              ))}
-            </div>
-          )}
-
-          {/* Meta row */}
-          <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm mb-4" style={{ color: 'var(--color-light)' }}>
-            <span>📅 {formatDate(race.date, locale)}</span>
-            <span>📍 {getRaceCity(race, locale)}</span>
-            {mainCategory && <span>🏃 {mainCategory.distance_km}km</span>}
-          </div>
-
-          {/* Entry status + official site */}
-          <div className="flex flex-wrap items-center gap-3">
-            {!isPast && isEntryOpen && (
-              <span
-                className="text-xs font-bold px-3 py-1 rounded-[3px] tracking-[0.06em] uppercase"
-                style={{ background: 'var(--color-primary)', color: 'white' }}
-              >
-                {t('entryOpen')}
-              </span>
-            )}
-            {!isPast && isNotYetOpen && (
-              <span
-                className="text-xs font-semibold px-3 py-1 rounded-[3px]"
-                style={{ background: 'rgba(255,255,255,0.12)', color: 'rgba(255,255,255,0.7)' }}
-              >
-                {t('notYetOpen')}
-              </span>
-            )}
-            {!isPast && race.entry_closed && (
-              <span
-                className="text-xs font-semibold px-3 py-1 rounded-[3px]"
-                style={{ background: 'rgba(255,255,255,0.12)', color: 'rgba(255,255,255,0.7)' }}
-              >
-                {t('entryClosed')}
-              </span>
-            )}
-            {isPast && (
-              <span
-                className="text-xs font-semibold px-3 py-1 rounded-[3px]"
-                style={{ background: 'rgba(255,255,255,0.1)', color: 'rgba(255,255,255,0.5)' }}
-              >
-                {t('entryClosed')}
-              </span>
-            )}
-            {race.official_url && (
-              <a
-                href={race.official_url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-xs font-semibold px-4 py-1.5 rounded-[3px] transition-colors no-underline"
-                style={{ background: 'white', color: 'var(--color-ink)' }}
-              >
-                {t('website')} ↗
-              </a>
-            )}
-          </div>
-
-          {/* 登録ボタン */}
-          {!isPast && (
-            <RaceRegistrationButtons
-              raceId={race.id}
-              raceName={raceName}
-              raceDate={race.date}
-              categories={race.categories.map((c) => ({
-                id: c.id,
-                name_ja: c.name_ja,
-                name_en: c.name_en,
-                distance_km: c.distance_km,
-                distance_type: c.distance_type,
-              }))}
-              entryPeriods={race.entry_periods
-                .filter((p) => p.start_date >= today)
-                .map((p) => ({
-                  id: p.id,
-                  label_ja: p.label_ja,
-                  label_en: p.label_en,
-                  start_date: p.start_date,
-                }))}
-              today={today}
-            />
-          )}
-        </div>
-      </div>
+      <DetailHeader
+        race={race}
+        locale={locale}
+        raceName={raceName}
+        isEntryOpen={isEntryOpen}
+        isNotYetOpen={isNotYetOpen}
+        isPast={isPast}
+        t={t}
+      />
 
       {/* ── AnchorBar ── */}
       <AnchorBar items={anchorItems} />
+
+      {/* ── 登録ボタン ── */}
+      {!isPast && (
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 pt-4">
+          <RaceRegistrationButtons
+            raceId={race.id}
+            raceName={raceName}
+            raceDate={race.date}
+            categories={race.categories.map((c) => ({
+              id: c.id,
+              name_ja: c.name_ja,
+              name_en: c.name_en,
+              distance_km: c.distance_km,
+              distance_type: c.distance_type,
+            }))}
+            entryPeriods={race.entry_periods
+              .filter((p) => p.start_date >= today)
+              .map((p) => ({
+                id: p.id,
+                label_ja: p.label_ja,
+                label_en: p.label_en,
+                start_date: p.start_date,
+              }))}
+            today={today}
+          />
+        </div>
+      )}
 
       {/* ── Content ── */}
       <div
@@ -293,108 +228,212 @@ export default async function RaceDetailPage({
         style={{ color: 'var(--color-ink)' }}
       >
 
-        {/* Overview */}
-        {(raceDesc || race.tags.length > 0) && (
-          <section>
-            <SectionLabel>{locale === 'ja' ? '概要' : 'Overview'}</SectionLabel>
-            <SectionTitle>{t('overview')}</SectionTitle>
-            <OverviewSection race={race} locale={locale} />
-          </section>
-        )}
+        {/* ── Section 01: 概要・基本要項 ── */}
+        <section id="overview" style={{ scrollMarginTop: '3.5rem' }}>
+          <SectionHeading
+            num="01"
+            title={locale === 'ja' ? '概要・基本要項' : 'Overview'}
+            subtitle={locale === 'ja' ? 'Overview' : '概要・基本要項'}
+          />
 
-        {/* Categories & Course */}
-        <section id="course">
-          <SectionLabel>{locale === 'ja' ? 'コース' : 'Course'}</SectionLabel>
-          <SectionTitle>{t('course')}</SectionTitle>
+          {/* スタットグリッド */}
+          {mainCategory && (
+            <Card className="mb-5">
+              <div className="grid grid-cols-2 sm:grid-cols-3 gap-x-6 gap-y-6">
+                {/* 距離 */}
+                <div>
+                  <p className="text-[0.58rem] tracking-[0.18em] uppercase font-semibold mb-1.5" style={{ color: 'var(--color-mid)' }}>
+                    {locale === 'ja' ? 'Distance' : 'Distance'}
+                  </p>
+                  <p className="font-bold leading-none" style={{ fontSize: '1.9rem', color: 'var(--color-ink)' }}>
+                    {mainCategory.distance_km}
+                    <span className="text-sm font-medium ml-1" style={{ color: 'var(--color-ink2)' }}>km</span>
+                  </p>
+                </div>
 
-          {/* Categories table */}
-          <Card className="mb-4 overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr style={{ borderBottom: '2px solid var(--color-border)' }}>
-                  <th className="text-left pb-2.5 font-semibold" style={{ color: 'var(--color-mid)' }}>{t('category')}</th>
-                  <th className="text-right pb-2.5 font-semibold" style={{ color: 'var(--color-mid)' }}>{t('distance')}</th>
-                  <th className="text-right pb-2.5 font-semibold" style={{ color: 'var(--color-mid)' }}>{t('cutoffTime')}</th>
-                  <th className="text-right pb-2.5 font-semibold" style={{ color: 'var(--color-mid)' }}>{t('startTime')}</th>
-                  <th className="text-right pb-2.5 font-semibold" style={{ color: 'var(--color-mid)' }}>{t('fee')}</th>
-                </tr>
-              </thead>
-              <tbody>
-                {race.categories.map((cat, i) => {
-                  const eligibility = locale === 'ja' ? cat.eligibility_ja : cat.eligibility_en;
-                  const isLast = i === race.categories.length - 1;
-                  return (
-                    <Fragment key={i}>
-                      <tr
-                        style={!eligibility ? { borderBottom: isLast ? 'none' : '1px solid var(--color-border)' } : undefined}
-                      >
-                        <td className="py-3 font-medium">{getCategoryLabel(cat, locale)}</td>
-                        <td className="py-3 text-right">{cat.distance_km}km</td>
-                        <td className="py-3 text-right">
-                          {cat.time_limit_minutes > 0
-                            ? `${Math.floor(cat.time_limit_minutes / 60)}:${String(cat.time_limit_minutes % 60).padStart(2, '0')}`
-                            : '—'}
-                        </td>
-                        <td className="py-3 text-right">{cat.start_time || '—'}</td>
-                        <td className="py-3 text-right">
-                          {cat.entry_fee
-                            ? formatCurrency(cat.entry_fee)
-                            : race.entry_fee
-                              ? formatCurrency(race.entry_fee)
-                              : '—'}
-                        </td>
-                      </tr>
-                      {eligibility && (
+                {/* 制限時間 */}
+                {mainCategory.time_limit_minutes > 0 && (
+                  <div>
+                    <p className="text-[0.58rem] tracking-[0.18em] uppercase font-semibold mb-1.5" style={{ color: 'var(--color-mid)' }}>
+                      Time Limit
+                    </p>
+                    <p className="font-bold leading-none" style={{ fontSize: '1.9rem', color: 'var(--color-ink)' }}>
+                      {Math.floor(mainCategory.time_limit_minutes / 60)}
+                      {mainCategory.time_limit_minutes % 60 > 0 && `:${String(mainCategory.time_limit_minutes % 60).padStart(2, '0')}`}
+                      <span className="text-sm font-medium ml-1" style={{ color: 'var(--color-ink2)' }}>
+                        {mainCategory.time_limit_minutes % 60 === 0 ? (locale === 'ja' ? '時間' : 'hrs') : ''}
+                      </span>
+                    </p>
+                  </div>
+                )}
+
+                {/* 定員 */}
+                {(mainCategory.capacity > 0 || race.entry_capacity > 0) && (
+                  <div>
+                    <p className="text-[0.58rem] tracking-[0.18em] uppercase font-semibold mb-1.5" style={{ color: 'var(--color-mid)' }}>
+                      Capacity
+                    </p>
+                    <p className="font-bold leading-none" style={{ fontSize: '1.9rem', color: 'var(--color-ink)' }}>
+                      {(mainCategory.capacity > 0 ? mainCategory.capacity : race.entry_capacity).toLocaleString()}
+                      <span className="text-sm font-medium ml-1" style={{ color: 'var(--color-ink2)' }}>
+                        {locale === 'ja' ? '人' : ''}
+                      </span>
+                    </p>
+                  </div>
+                )}
+
+                {/* 参加費 */}
+                {(race.entry_fee || mainCategory.entry_fee) && (
+                  <div>
+                    <p className="text-[0.58rem] tracking-[0.18em] uppercase font-semibold mb-1.5" style={{ color: 'var(--color-mid)' }}>
+                      Entry Fee
+                    </p>
+                    <p className="font-bold leading-none" style={{ fontSize: '1.9rem', color: 'var(--color-ink)' }}>
+                      {formatCurrency(mainCategory.entry_fee ?? race.entry_fee!)}
+                    </p>
+                  </div>
+                )}
+
+                {/* 高低差 */}
+                {race.course_info.elevation_diff_m > 0 && (
+                  <div>
+                    <p className="text-[0.58rem] tracking-[0.18em] uppercase font-semibold mb-1.5" style={{ color: 'var(--color-mid)' }}>
+                      Elevation
+                    </p>
+                    <p className="font-bold leading-none" style={{ fontSize: '1.9rem', color: 'var(--color-ink)' }}>
+                      +{race.course_info.elevation_diff_m}
+                      <span className="text-sm font-medium ml-1" style={{ color: 'var(--color-ink2)' }}>m</span>
+                    </p>
+                  </div>
+                )}
+
+              </div>
+            </Card>
+          )}
+
+          <OverviewSection race={race} locale={locale} />
+        </section>
+
+        {/* ── Section 02: コース紹介 ── */}
+        <section id="course" style={{ scrollMarginTop: '3.5rem' }}>
+          <SectionHeading
+            num="02"
+            title={locale === 'ja' ? 'コース紹介' : 'Course'}
+            subtitle={locale === 'ja' ? 'Course Map & Elevation' : 'コース紹介'}
+          />
+
+          {/* カテゴリテーブル（複数カテゴリの場合のみ） */}
+          {race.categories.length > 1 && (
+            <Card className="mb-5 overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr style={{ borderBottom: '2px solid var(--color-border)' }}>
+                    <th className="text-left pb-2.5 font-semibold" style={{ color: 'var(--color-mid)' }}>{t('category')}</th>
+                    <th className="text-right pb-2.5 font-semibold" style={{ color: 'var(--color-mid)' }}>{t('distance')}</th>
+                    <th className="text-right pb-2.5 font-semibold" style={{ color: 'var(--color-mid)' }}>{t('cutoffTime')}</th>
+                    <th className="text-right pb-2.5 font-semibold" style={{ color: 'var(--color-mid)' }}>{t('startTime')}</th>
+                    <th className="text-right pb-2.5 font-semibold" style={{ color: 'var(--color-mid)' }}>{t('fee')}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {race.categories.map((cat, i) => {
+                    const eligibility = locale === 'ja' ? cat.eligibility_ja : cat.eligibility_en;
+                    const isLast = i === race.categories.length - 1;
+                    return (
+                      <Fragment key={i}>
                         <tr
-                          style={{ borderBottom: isLast ? 'none' : '1px solid var(--color-border)' }}
+                          style={!eligibility ? { borderBottom: isLast ? 'none' : '1px solid var(--color-border)' } : undefined}
                         >
-                          <td colSpan={5} className="pb-3 text-xs whitespace-pre-line" style={{ color: 'var(--color-mid)' }}>
-                            {locale === 'ja' ? '参加資格: ' : 'Eligibility: '}{eligibility}
+                          <td className="py-3 font-medium">{getCategoryLabel(cat, locale)}</td>
+                          <td className="py-3 text-right">{cat.distance_km}km</td>
+                          <td className="py-3 text-right">
+                            {cat.time_limit_minutes > 0
+                              ? `${Math.floor(cat.time_limit_minutes / 60)}:${String(cat.time_limit_minutes % 60).padStart(2, '0')}`
+                              : '—'}
+                          </td>
+                          <td className="py-3 text-right">{cat.start_time || '—'}</td>
+                          <td className="py-3 text-right">
+                            {cat.entry_fee
+                              ? formatCurrency(cat.entry_fee)
+                              : race.entry_fee
+                                ? formatCurrency(race.entry_fee)
+                                : '—'}
                           </td>
                         </tr>
+                        {eligibility && (
+                          <tr style={{ borderBottom: isLast ? 'none' : '1px solid var(--color-border)' }}>
+                            <td colSpan={5} className="pb-3 text-xs whitespace-pre-line" style={{ color: 'var(--color-mid)' }}>
+                              {locale === 'ja' ? '参加資格: ' : 'Eligibility: '}{eligibility}
+                            </td>
+                          </tr>
+                        )}
+                      </Fragment>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </Card>
+          )}
+
+          {/* コースプロフィール（地図+ハイライト横並び → 高低差チャート） */}
+          {(() => {
+            const highlightsSidebar = (cat: typeof race.categories[0] | null) => cat && cat.course_highlights.length > 0 ? (
+              <div>
+                <p className="text-[0.58rem] tracking-[0.18em] uppercase font-semibold mb-3" style={{ color: 'var(--color-mid)' }}>
+                  Highlights
+                </p>
+                <ol className="space-y-3.5">
+                  {cat.course_highlights.map((h) => (
+                    <li key={h.id} className="flex gap-2.5">
+                      {h.km != null && (
+                        <span
+                          className="font-mono text-[0.65rem] font-bold shrink-0 mt-0.5 w-10 text-right"
+                          style={{ color: 'var(--color-primary)' }}
+                        >
+                          {h.km}km
+                        </span>
                       )}
-                    </Fragment>
-                  );
-                })}
-              </tbody>
-            </table>
-          </Card>
-
-          {/* コースプロフィール（地図 + 高低差チャート） */}
-          {race.categories.some((c) => c.course_gpx_file) ? (
-            race.categories
-              .filter((c) => c.course_gpx_file)
-              .map((cat, i) => (
-                <div key={i} className="mb-6">
-                  <p className="text-xs font-semibold uppercase tracking-wide mb-2" style={{ color: 'var(--color-mid)' }}>
-                    {getCategoryLabel(cat, locale)}
-                  </p>
-                  <CourseProfileSection profileKey={cat.course_gpx_file!} locale={locale} />
-                </div>
-              ))
-          ) : race.course_gpx_file ? (
-            <div className="mb-4">
-              <CourseProfileSection profileKey={id} locale={locale} />
-            </div>
-          ) : null}
-
-          {/* Course info */}
-          {(race.course_info.max_elevation_m > 0 || race.course_info.highlights_ja) && (
-            <Card>
-              <div className="grid grid-cols-3 gap-4 mb-4">
-                <div className="text-center">
-                  <p className="text-xl font-bold">{race.course_info.max_elevation_m}m</p>
-                  <p className="text-xs mt-0.5" style={{ color: 'var(--color-mid)' }}>{t('maxElev')}</p>
-                </div>
-                <div className="text-center">
-                  <p className="text-xl font-bold">{race.course_info.min_elevation_m}m</p>
-                  <p className="text-xs mt-0.5" style={{ color: 'var(--color-mid)' }}>{t('minElev')}</p>
-                </div>
-                <div className="text-center">
-                  <p className="text-xl font-bold">{race.course_info.elevation_diff_m}m</p>
-                  <p className="text-xs mt-0.5" style={{ color: 'var(--color-mid)' }}>{t('diff')}</p>
-                </div>
+                      <div>
+                        <p className="text-sm font-medium leading-snug" style={{ color: 'var(--color-ink)' }}>
+                          {locale === 'ja' ? h.name_ja : (h.name_en ?? h.name_ja)}
+                        </p>
+                        {(locale === 'ja' ? h.note_ja : h.note_en) && (
+                          <p className="text-xs mt-0.5 leading-snug" style={{ color: 'var(--color-mid)' }}>
+                            {locale === 'ja' ? h.note_ja : h.note_en}
+                          </p>
+                        )}
+                      </div>
+                    </li>
+                  ))}
+                </ol>
               </div>
+            ) : undefined;
+
+            if (race.categories.some((c) => c.course_gpx_file)) {
+              return race.categories.filter((c) => c.course_gpx_file).map((cat, i) => (
+                <div key={i} className="mb-6">
+                  {race.categories.filter((c) => c.course_gpx_file).length > 1 && (
+                    <p className="text-xs font-semibold uppercase tracking-wide mb-2" style={{ color: 'var(--color-mid)' }}>
+                      {getCategoryLabel(cat, locale)}
+                    </p>
+                  )}
+                  <CourseProfileSection profileKey={cat.course_gpx_file!} locale={locale} sidebarContent={highlightsSidebar(cat)} />
+                </div>
+              ));
+            }
+            if (race.course_gpx_file) {
+              return (
+                <div className="mb-5">
+                  <CourseProfileSection profileKey={id} locale={locale} sidebarContent={highlightsSidebar(race.categories[0] ?? null)} />
+                </div>
+              );
+            }
+            return null;
+          })()}
+
+          {/* コース情報（認定・メモ） */}
+          {(race.course_info.certification.length > 0 || race.course_info.notes_ja) && (
+            <Card>
               {race.course_info.certification.length > 0 && (
                 <div className="flex flex-wrap gap-2 mb-3">
                   {race.course_info.certification.map((cert) => (
@@ -408,14 +447,9 @@ export default async function RaceDetailPage({
                   ))}
                 </div>
               )}
-              {(locale === 'ja' ? race.course_info.highlights_ja : race.course_info.highlights_en) && (
-                <p className="text-sm leading-relaxed" style={{ color: 'var(--color-ink2)' }}>
-                  {locale === 'ja' ? race.course_info.highlights_ja : race.course_info.highlights_en}
-                </p>
-              )}
               {(locale === 'ja' ? race.course_info.notes_ja : race.course_info.notes_en) && (
                 <p
-                  className="text-xs mt-3 p-3 rounded-[3px] leading-relaxed"
+                  className="text-xs p-3 rounded-[3px] leading-relaxed"
                   style={{ background: '#fff8f0', border: '1px solid #f0d9c0', color: '#7a4f1a' }}
                 >
                   ⚠️ {locale === 'ja' ? race.course_info.notes_ja : race.course_info.notes_en}
@@ -428,8 +462,7 @@ export default async function RaceDetailPage({
         {/* Checkpoints */}
         {race.checkpoints.length > 0 && (
           <section>
-            <SectionLabel>{locale === 'ja' ? '関門' : 'Cutoffs'}</SectionLabel>
-            <SectionTitle>{t('checkpoints')}</SectionTitle>
+            <SectionHeading num="02-a" title={locale === 'ja' ? '関門' : 'Cutoffs'} />
             <Card className="overflow-x-auto">
               <table className="w-full text-sm">
                 <thead>
@@ -462,8 +495,7 @@ export default async function RaceDetailPage({
         {/* Aid Stations */}
         {race.aid_stations.length > 0 && (
           <section>
-            <SectionLabel>{locale === 'ja' ? 'エイド' : 'Aid'}</SectionLabel>
-            <SectionTitle>{t('aidStations')}</SectionTitle>
+            <SectionHeading num="02-b" title={locale === 'ja' ? 'エイドステーション' : 'Aid Stations'} />
             <div className="space-y-2">
               {race.aid_stations.map((aid, i) => (
                 <Card key={i}>
@@ -495,9 +527,8 @@ export default async function RaceDetailPage({
         )}
 
         {/* Entry / Registration */}
-        <section>
-          <SectionLabel>{locale === 'ja' ? 'エントリー' : 'Registration'}</SectionLabel>
-          <SectionTitle>{t('applicationPeriod')}</SectionTitle>
+        <section id="entry" style={{ scrollMarginTop: '3.5rem' }}>
+          <SectionHeading num="03" title={locale === 'ja' ? 'エントリー情報' : 'Registration'} subtitle={locale === 'ja' ? 'Entry' : 'エントリー'} />
           <Card>
             <EntrySection race={race} locale={locale} today={today} />
           </Card>
@@ -506,8 +537,7 @@ export default async function RaceDetailPage({
         {/* Access */}
         {race.access_points.length > 0 && (
           <section>
-            <SectionLabel>{locale === 'ja' ? '交通' : 'Transport'}</SectionLabel>
-            <SectionTitle>{t('access')}</SectionTitle>
+            <SectionHeading num="04" title={locale === 'ja' ? 'アクセス・宿泊' : 'Access & Stay'} subtitle={locale === 'ja' ? 'Access & Stay' : 'アクセス・宿泊'} />
             <div className="space-y-2">
               {race.access_points.map((ap, i) => (
                 <Card key={i}>
@@ -531,8 +561,7 @@ export default async function RaceDetailPage({
         {/* Participation Gift */}
         {race.participation_gifts.length > 0 && (
           <section>
-            <SectionLabel>{locale === 'ja' ? '参加賞' : 'Finisher'}</SectionLabel>
-            <SectionTitle>{t('gift')}</SectionTitle>
+            <SectionHeading num="05" title={locale === 'ja' ? '参加賞' : 'Finisher Gift'} />
             {race.participation_gifts.map((gift, i) => (
               <Card key={i}>
                 <div className="flex flex-wrap gap-2 mb-3">
@@ -564,8 +593,7 @@ export default async function RaceDetailPage({
         {/* Nearby Spots */}
         {race.nearby_spots.length > 0 && (
           <section>
-            <SectionLabel>{locale === 'ja' ? '周辺' : 'Area'}</SectionLabel>
-            <SectionTitle>{t('nearby')}</SectionTitle>
+            <SectionHeading num="06" title={locale === 'ja' ? '近隣スポット' : 'Nearby'} />
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
               {race.nearby_spots.map((spot, i) => {
                 const typeInfo = NEARBY_TYPE[spot.type];
@@ -613,18 +641,16 @@ export default async function RaceDetailPage({
 
         {/* Last Edition Result */}
         {race.result && (
-          <section>
-            <SectionLabel>{locale === 'ja' ? '開催実績' : 'Results'}</SectionLabel>
-            <SectionTitle>{locale === 'ja' ? '前回大会' : 'Last Edition'}</SectionTitle>
+          <section id="last-edition" style={{ scrollMarginTop: '3.5rem' }}>
+            <SectionHeading num="07" title={locale === 'ja' ? '前回の様子' : 'Last Edition'} subtitle={locale === 'ja' ? 'Last Edition' : '前回の様子'} />
             <LastEditionSection race={race} locale={locale} />
           </section>
         )}
 
         {/* Gallery & Voices */}
         {(race.gallery.length > 0 || race.voices.length > 0) && (
-          <section>
-            <SectionLabel>{locale === 'ja' ? 'ギャラリー' : 'Gallery'}</SectionLabel>
-            <SectionTitle>{locale === 'ja' ? '写真・参加者の声' : 'Photos & Voices'}</SectionTitle>
+          <section id="gallery" style={{ scrollMarginTop: '3.5rem' }}>
+            <SectionHeading num="08" title={locale === 'ja' ? '写真・参加者の声' : 'Photos & Voices'} subtitle={locale === 'ja' ? 'Gallery' : 'ギャラリー'} />
             <GallerySection race={race} locale={locale} />
           </section>
         )}
@@ -632,12 +658,11 @@ export default async function RaceDetailPage({
         {/* Past Editions */}
         {(seriesRaces.length > 0 || series) && (
           <section>
-            <SectionLabel>{locale === 'ja' ? 'シリーズ' : 'Series'}</SectionLabel>
-            <SectionTitle>
-              {series
-                ? (locale === 'ja' ? series.name_ja : series.name_en)
-                : (locale === 'ja' ? '過去の大会' : 'Past Editions')}
-            </SectionTitle>
+            <SectionHeading
+              num="09"
+              title={series ? (locale === 'ja' ? series.name_ja : series.name_en) ?? (locale === 'ja' ? '過去の大会' : 'Past Editions') : (locale === 'ja' ? '過去の大会' : 'Past Editions')}
+              subtitle={locale === 'ja' ? 'Series' : 'シリーズ'}
+            />
             {seriesRaces.length === 0 ? (
               <Card>
                 <p className="text-sm" style={{ color: 'var(--color-mid)' }}>
@@ -717,8 +742,7 @@ export default async function RaceDetailPage({
         {/* Weather History */}
         {race.weather_history.length > 0 && (
           <section>
-            <SectionLabel>{locale === 'ja' ? '気象' : 'Weather'}</SectionLabel>
-            <SectionTitle>{t('weather')}</SectionTitle>
+            <SectionHeading num="10" title={locale === 'ja' ? '気象履歴' : 'Weather History'} subtitle={locale === 'ja' ? 'Weather' : '気象'} />
             <Card className="overflow-x-auto">
               <table className="w-full text-sm">
                 <thead>

--- a/src/components/calendar/CalendarView.tsx
+++ b/src/components/calendar/CalendarView.tsx
@@ -125,6 +125,7 @@ export default function CalendarView({
         <YearTimeline
           races={filteredRaces}
           year={year}
+          month={month}
           locale={locale}
           today={today}
         />

--- a/src/components/calendar/YearTimeline.tsx
+++ b/src/components/calendar/YearTimeline.tsx
@@ -6,6 +6,7 @@ import { Link } from '@/i18n/navigation';
 interface YearTimelineProps {
   races: Race[];
   year: number;
+  month: number; // 0-indexed
   locale: Locale;
   today: string;
 }
@@ -13,68 +14,92 @@ interface YearTimelineProps {
 const MONTH_LABELS_JA = ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月'];
 const MONTH_LABELS_EN = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
-function dayOfYear(dateStr: string): number {
-  const d = new Date(dateStr + 'T00:00:00');
-  const start = new Date(d.getFullYear(), 0, 0);
-  const diff = d.getTime() - start.getTime();
-  return Math.floor(diff / 86400000);
-}
+/** 絶対月番号 (year*12 + month0indexed) */
+function absMonth(y: number, m: number) { return y * 12 + m; }
 
-function daysInYear(year: number): number {
-  return (year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0)) ? 366 : 365;
-}
+/** 絶対月番号 → { year, month } */
+function fromAbsMonth(abs: number) { return { year: Math.floor(abs / 12), month: abs % 12 }; }
 
-function monthStartDay(year: number, month: number): number {
-  const d = new Date(year, month, 1);
-  const start = new Date(year, 0, 0);
-  return Math.floor((d.getTime() - start.getTime()) / 86400000);
-}
+/** 月の日数 */
+function daysInMonth(y: number, m: number) { return new Date(y, m + 1, 0).getDate(); }
 
-export default function YearTimeline({ races, year, locale, today }: YearTimelineProps) {
+export default function YearTimeline({ races, year, month, locale, today }: YearTimelineProps) {
   const isJa = locale === 'ja';
   const monthLabels = isJa ? MONTH_LABELS_JA : MONTH_LABELS_EN;
-  const totalDays = daysInYear(year);
 
-  // 対象年の大会のみ
-  const yearRaces = races.filter((r) => r.date.startsWith(String(year)));
+  // 表示ウィンドウ: 選択月-2 から 12ヶ月
+  const windowStart = absMonth(year, month) - 2;
+  const windowEnd   = windowStart + 11; // inclusive
+
+  // ウィンドウ内の全大会（年をまたぐ場合も含む）
+  const windowRaces = races.filter((r) => {
+    const ry = parseInt(r.date.slice(0, 4));
+    const rm = parseInt(r.date.slice(5, 7)) - 1;
+    const abs = absMonth(ry, rm);
+    return abs >= windowStart && abs <= windowEnd;
+  }).sort((a, b) => a.date.localeCompare(b.date));
+
   const raceName = (race: Race) => isJa ? race.name_ja : (race.name_en ?? race.name_ja);
 
   const ROW_H = 28;
   const LABEL_W = 160;
   const CHART_W = 600;
+  const MONTH_W = CHART_W / 12;
   const HEADER_H = 32;
-  const svgHeight = HEADER_H + yearRaces.length * ROW_H + 16;
+  const svgHeight = HEADER_H + windowRaces.length * ROW_H + 16;
 
-  const xForDay = (day: number) => LABEL_W + (day / totalDays) * CHART_W;
+  /** 日付文字列 → SVG x 座標 */
+  function xForDate(dateStr: string): number {
+    const dy = parseInt(dateStr.slice(0, 4));
+    const dm = parseInt(dateStr.slice(5, 7)) - 1;
+    const dd = parseInt(dateStr.slice(8, 10));
+    const slotIdx = absMonth(dy, dm) - windowStart;
+    const fracInMonth = (dd - 1) / daysInMonth(dy, dm);
+    return LABEL_W + (slotIdx + fracInMonth) * MONTH_W;
+  }
 
-  const todayDay = today.startsWith(String(year)) ? dayOfYear(today) : null;
+  // 今日線
+  const todayInWindow = (() => {
+    const ty = parseInt(today.slice(0, 4));
+    const tm = parseInt(today.slice(5, 7)) - 1;
+    const abs = absMonth(ty, tm);
+    if (abs < windowStart || abs > windowEnd) return null;
+    return xForDate(today);
+  })();
 
   return (
-    <div className="overflow-x-auto">
+    <div>
       <svg
         width={LABEL_W + CHART_W}
         height={svgHeight}
         style={{ fontFamily: 'var(--font-dm-sans, sans-serif)', fontSize: 12 }}
       >
-        {/* Month grid lines & labels */}
-        {Array.from({ length: 12 }, (_, m) => {
-          const x = xForDay(monthStartDay(year, m));
+        {/* 月グリッド線・ラベル */}
+        {Array.from({ length: 12 }, (_, i) => {
+          const { year: my, month: mm } = fromAbsMonth(windowStart + i);
+          const x = LABEL_W + i * MONTH_W;
+          const label = monthLabels[mm];
+          // 年をまたぐ場合は年を付記
+          const showYear = i === 0 || mm === 0;
           return (
-            <g key={m}>
+            <g key={i}>
               <line x1={x} y1={HEADER_H} x2={x} y2={svgHeight} stroke="var(--color-border)" strokeWidth={1} />
-              <text x={x + 4} y={HEADER_H - 6} fill="var(--color-mid)" fontSize={10}>
-                {monthLabels[m]}
+              <text x={x + 3} y={HEADER_H - 14} fill="var(--color-light)" fontSize={9}>
+                {showYear ? String(my) : ''}
+              </text>
+              <text x={x + 3} y={HEADER_H - 4} fill="var(--color-mid)" fontSize={10}>
+                {label}
               </text>
             </g>
           );
         })}
 
-        {/* Today line */}
-        {todayDay !== null && (
+        {/* 今日線 */}
+        {todayInWindow !== null && (
           <line
-            x1={xForDay(todayDay)}
+            x1={todayInWindow}
             y1={HEADER_H}
-            x2={xForDay(todayDay)}
+            x2={todayInWindow}
             y2={svgHeight}
             stroke="var(--color-primary)"
             strokeWidth={1.5}
@@ -82,43 +107,33 @@ export default function YearTimeline({ races, year, locale, today }: YearTimelin
           />
         )}
 
-        {/* Race rows */}
-        {yearRaces.map((race, i) => {
+        {/* 大会行 */}
+        {windowRaces.map((race, i) => {
           const y = HEADER_H + i * ROW_H;
-          const raceDay = dayOfYear(race.date);
-          const cx = xForDay(raceDay);
+          const cx = xForDate(race.date);
           const name = raceName(race);
 
           return (
             <g key={race.id}>
-              {/* Entry period band */}
-              {race.entry_start_date && race.entry_end_date &&
-                race.entry_start_date.startsWith(String(year)) && (
-                <rect
-                  x={xForDay(dayOfYear(race.entry_start_date))}
-                  y={y + 10}
-                  width={Math.max(
-                    2,
-                    xForDay(dayOfYear(race.entry_end_date)) - xForDay(dayOfYear(race.entry_start_date))
-                  )}
-                  height={8}
-                  fill="#d1fae5"
-                  rx={2}
-                />
-              )}
+              {/* エントリー期間帯 */}
+              {race.entry_start_date && race.entry_end_date && (() => {
+                const ey = parseInt(race.entry_start_date.slice(0, 4));
+                const em = parseInt(race.entry_start_date.slice(5, 7)) - 1;
+                const eAbs = absMonth(ey, em);
+                if (eAbs < windowStart || eAbs > windowEnd) return null;
+                const x1 = xForDate(race.entry_start_date);
+                const x2 = xForDate(race.entry_end_date);
+                return (
+                  <rect x={x1} y={y + 10} width={Math.max(2, x2 - x1)} height={8} fill="#d1fae5" rx={2} />
+                );
+              })()}
 
-              {/* Race dot */}
+              {/* ドット */}
               <circle cx={cx} cy={y + 14} r={5} fill="var(--color-primary)" />
 
-              {/* Race name label */}
+              {/* 大会名 */}
               <Link href={`/races/${race.id}?from=calendar`}>
-                <text
-                  x={4}
-                  y={y + 18}
-                  fill="var(--color-ink)"
-                  fontSize={11}
-                  style={{ cursor: 'pointer' }}
-                >
+                <text x={4} y={y + 18} fill="var(--color-ink)" fontSize={11} style={{ cursor: 'pointer' }}>
                   {name.length > 20 ? name.slice(0, 19) + '…' : name}
                 </text>
               </Link>

--- a/src/components/course/CourseProfileSection.tsx
+++ b/src/components/course/CourseProfileSection.tsx
@@ -9,9 +9,11 @@ interface Props {
   /** GPXファイル名（例: "nagano-marathon-2026-full.gpx"）またはレースID（拡張子なし）を渡す。拡張子は自動除去 */
   profileKey: string;
   locale: string;
+  /** 指定するとマップの右横に表示するサイドバーコンテンツ */
+  sidebarContent?: React.ReactNode;
 }
 
-export default function CourseProfileSection({ profileKey, locale }: Props) {
+export default function CourseProfileSection({ profileKey, locale, sidebarContent }: Props) {
   const [profile, setProfile] = useState<CourseProfile | null>(null);
   const [error, setError] = useState(false);
 
@@ -45,8 +47,19 @@ export default function CourseProfileSection({ profileKey, locale }: Props) {
 
   return (
     <div className="space-y-3">
-      {/* 地図 */}
-      <CourseMapLoader courseProfile={profile} />
+      {/* 地図（+ オプショナルサイドバー） */}
+      {sidebarContent ? (
+        <div className="flex gap-4 items-start">
+          <div className="flex-1 min-w-0">
+            <CourseMapLoader courseProfile={profile} />
+          </div>
+          <div className="w-52 shrink-0">
+            {sidebarContent}
+          </div>
+        </div>
+      ) : (
+        <CourseMapLoader courseProfile={profile} />
+      )}
 
       {/* 高低差チャート */}
       <ElevationChartLoader data={profile.points} />

--- a/src/components/races/RaceBreadcrumb.tsx
+++ b/src/components/races/RaceBreadcrumb.tsx
@@ -32,23 +32,23 @@ export default function RaceBreadcrumb({ raceName, from, labels }: RaceBreadcrum
     <nav
       className="flex items-center gap-1.5 text-xs mb-6"
       aria-label="breadcrumb"
-      style={{ color: 'var(--color-light)' }}
+      style={{ color: 'var(--color-mid)' }}
     >
-      <Link href="/" className="hover:text-white transition-colors">
+      <Link href="/" className="transition-colors hover:underline" style={{ color: 'var(--color-mid)' }}>
         {labels.home}
       </Link>
 
       {middle && (
         <>
           <span aria-hidden="true">›</span>
-          <Link href={middle.href} onClick={handleBack} className="hover:text-white transition-colors">
+          <Link href={middle.href} onClick={handleBack} className="transition-colors hover:underline" style={{ color: 'var(--color-mid)' }}>
             {middle.label}
           </Link>
         </>
       )}
 
       <span aria-hidden="true">›</span>
-      <span className="text-white truncate max-w-[200px] sm:max-w-xs">{raceName}</span>
+      <span className="truncate max-w-[200px] sm:max-w-xs" style={{ color: 'var(--color-ink)' }}>{raceName}</span>
     </nav>
   );
 }

--- a/src/components/races/RaceRegistrationButtons.tsx
+++ b/src/components/races/RaceRegistrationButtons.tsx
@@ -164,14 +164,14 @@ export default function RaceRegistrationButtons({
   const plannedCat = categories.find((c) => c.id === plannedCatId);
   const hasReminders = reminderPeriodIds.length > 0;
 
-  // ボタン共通スタイル（ダーク背景対応）
+  // ボタン共通スタイル（ライト背景対応）
   const baseBtn = `flex items-center gap-1.5 text-sm font-medium px-4 py-2 rounded-[3px] transition-colors disabled:opacity-40`;
   const inactiveStyle = {
-    border: '1.5px solid rgba(255,255,255,0.4)',
-    color: 'rgba(255,255,255,0.85)',
-    background: 'rgba(255,255,255,0.06)',
+    border: '1.5px solid var(--color-border)',
+    color: 'var(--color-ink2)',
+    background: 'white',
   };
-  const planActiveStyle = { border: '1.5px solid white', color: 'var(--color-ink)', background: 'white' };
+  const planActiveStyle = { border: '1.5px solid var(--color-ink)', color: 'white', background: 'var(--color-ink)' };
   const reminderActiveStyle = { border: '1.5px solid var(--color-primary)', color: 'white', background: 'var(--color-primary)' };
 
   return (
@@ -331,7 +331,7 @@ export default function RaceRegistrationButtons({
 
       {/* 解除時の案内 */}
       {(isPlanning || hasReminders) && (
-        <p className="mt-2 text-xs" style={{ color: 'rgba(255,255,255,0.45)' }}>
+        <p className="mt-2 text-xs" style={{ color: 'var(--color-light)' }}>
           Googleカレンダーへの追加はご自身で保存してください。解除してもカレンダーからは自動削除されません。
         </p>
       )}

--- a/src/components/races/detail/DetailHeader.tsx
+++ b/src/components/races/detail/DetailHeader.tsx
@@ -1,79 +1,208 @@
 import type { Race, Locale } from '@/lib/types';
+import { getMainCategory, getRaceCity, formatDate } from '@/lib/utils';
 
 interface DetailHeaderProps {
   race: Race;
   locale: Locale;
   raceName: string;
+  isEntryOpen?: boolean;
+  isNotYetOpen?: boolean;
+  isPast?: boolean;
+  t?: (key: string) => string;
 }
 
-export default function DetailHeader({ race, locale, raceName }: DetailHeaderProps) {
-  const tagline = locale === 'en' ? race.tagline_en : race.tagline_ja;
-  const bgColor = race.motif_color ?? 'var(--color-primary)';
+function ordinalSuffix(n: number): string {
+  const v = n % 100;
+  if (v >= 11 && v <= 13) return 'TH';
+  switch (v % 10) {
+    case 1: return 'ST';
+    case 2: return 'ND';
+    case 3: return 'RD';
+    default: return 'TH';
+  }
+}
+
+export default function DetailHeader({ race, locale, raceName, isEntryOpen, isNotYetOpen, isPast, t }: DetailHeaderProps) {
+  const taglineJa = race.tagline_ja;
+  const taglineEn = race.tagline_en;
+  const motifBg = race.motif_color ?? 'var(--color-ink)';
+  const mainCat = getMainCategory(race.categories);
+  const startTime = mainCat?.start_time;
+  const city = getRaceCity(race, locale);
+  const dateStr = formatDate(race.date, locale);
 
   return (
-    <div
-      className="relative overflow-hidden"
-      style={{ minHeight: 280, background: bgColor }}
-    >
-      {/* Diagonal stripe overlay */}
-      <div
-        className="absolute inset-0"
-        style={{
-          backgroundImage: 'repeating-linear-gradient(-45deg, transparent 0, transparent 10px, rgba(255,255,255,0.03) 10px, rgba(255,255,255,0.03) 20px)',
-        }}
-      />
+    <div style={{ background: 'var(--color-cream)', borderBottom: '1px solid var(--color-border)' }}>
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 pt-8 pb-6">
 
-      {/* Hero image */}
-      {race.hero_image_url && (
-        // eslint-disable-next-line @next/next/no-img-element
-        <img
-          src={race.hero_image_url}
-          alt={race.hero_caption_ja ?? ''}
-          className="absolute inset-0 w-full h-full object-cover opacity-40"
-        />
-      )}
+        {/* 版数 */}
+        {race.edition != null && (
+          <p
+            className="text-[0.67rem] tracking-[0.18em] uppercase font-mono mb-5"
+            style={{ color: 'var(--color-mid)' }}
+          >
+            第{race.edition}回&nbsp;&nbsp;/&nbsp;&nbsp;{race.edition}{ordinalSuffix(race.edition)}&nbsp;Edition
+          </p>
+        )}
 
-      {/* Bottom gradient */}
-      <div
-        className="absolute inset-0"
-        style={{ background: 'linear-gradient(to top, rgba(0,0,0,0.6) 0%, transparent 60%)' }}
-      />
-
-      {/* Content */}
-      <div className="relative max-w-4xl mx-auto px-4 sm:px-6 pt-10 pb-10 flex flex-col gap-3">
-        {/* Motif + edition row */}
-        <div className="flex items-center gap-3">
-          {race.motif && (
-            <span
-              className="font-mono text-white/50 tracking-[0.2em] text-xs uppercase"
+        {/* タイトルブロック + モチーフバッジ横並び */}
+        <div className="flex items-start gap-4 mb-6">
+          {/* 左: 大会名・サブタイトル・タグライン */}
+          <div className="flex-1 min-w-0">
+            <h1
+              className="font-serif font-bold leading-tight mb-1"
+              style={{
+                fontSize: 'clamp(2.4rem, 6vw, 4rem)',
+                fontWeight: 700,
+                color: 'var(--color-ink)',
+                fontFamily: 'var(--font-noto-serif-jp)',
+              }}
             >
-              {race.motif}
-            </span>
-          )}
-          {race.edition && (
-            <span className="text-white/60 text-sm font-mono">
-              第{race.edition}回
-            </span>
+              {raceName}
+            </h1>
+
+            {race.name_en && (
+              <p
+                className="text-xs tracking-[0.22em] uppercase mb-4"
+                style={{ color: 'var(--color-mid)', fontFamily: 'var(--font-dm-sans)' }}
+              >
+                {race.name_en}
+              </p>
+            )}
+
+            {(taglineJa || taglineEn) && (
+              <div data-testid="tagline">
+                {taglineJa && (
+                  <p className="font-bold text-lg leading-snug" style={{ color: 'var(--color-ink)' }}>
+                    {taglineJa}
+                  </p>
+                )}
+                {taglineEn && (
+                  <p className="text-sm italic mt-0.5" style={{ color: 'var(--color-mid)' }}>
+                    — {taglineEn}
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
+
+          {/* 右: モチーフバッジ（縦長旗） */}
+          {race.motif && (
+            <div
+              className="flex flex-col items-center justify-between shrink-0"
+              style={{
+                background: motifBg,
+                width: '5rem',
+                minHeight: '8rem',
+                paddingTop: '1rem',
+                paddingBottom: '0.85rem',
+              }}
+            >
+              <p
+                className="font-serif text-white text-center"
+                style={{
+                  fontSize: '2.1rem',
+                  letterSpacing: '0.15em',
+                  fontFamily: 'var(--font-noto-serif-jp)',
+                  writingMode: 'vertical-rl',
+                  textOrientation: 'upright',
+                }}
+              >
+                {race.motif}
+              </p>
+              <p
+                className="text-[0.42rem] tracking-[0.22em] uppercase text-white/50 text-center"
+              >
+                {race.motif_romaji ?? ''}
+              </p>
+            </div>
           )}
         </div>
 
-        {/* Race name */}
-        <h1
-          className="text-white font-serif leading-tight"
-          style={{ fontSize: 'clamp(2rem, 5vw, 3.5rem)', fontFamily: 'var(--font-noto-serif-jp)' }}
+        {/* メタ行: 開催日 / スタート / 会場 / 公式サイト */}
+        <div
+          className="flex flex-wrap items-end gap-x-8 gap-y-3 pt-4"
+          style={{ borderTop: '1px solid var(--color-border)' }}
         >
-          {raceName}
-        </h1>
+          <div>
+            <p
+              className="text-[0.58rem] tracking-[0.2em] uppercase font-semibold mb-0.5"
+              style={{ color: 'var(--color-mid)' }}
+            >
+              {locale === 'ja' ? '開催日' : 'Date'}
+            </p>
+            <p className="text-sm font-medium" style={{ color: 'var(--color-ink)' }}>
+              {dateStr}
+            </p>
+          </div>
 
-        {/* Tagline */}
-        {tagline && (
-          <p
-            data-testid="tagline"
-            className="text-white/75 text-base font-light tracking-wide"
-          >
-            {tagline}
-          </p>
-        )}
+          {startTime && (
+            <div>
+              <p
+                className="text-[0.58rem] tracking-[0.2em] uppercase font-semibold mb-0.5"
+                style={{ color: 'var(--color-mid)' }}
+              >
+                {locale === 'ja' ? 'スタート' : 'Start'}
+              </p>
+              <p className="text-sm font-medium" style={{ color: 'var(--color-ink)' }}>
+                {startTime}
+              </p>
+            </div>
+          )}
+
+          <div>
+            <p
+              className="text-[0.58rem] tracking-[0.2em] uppercase font-semibold mb-0.5"
+              style={{ color: 'var(--color-mid)' }}
+            >
+              {locale === 'ja' ? '会場' : 'Venue'}
+            </p>
+            <p className="text-sm font-medium" style={{ color: 'var(--color-ink)' }}>
+              {city}
+            </p>
+          </div>
+
+          {race.official_url && (
+            <a
+              href={race.official_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="ml-auto text-xs font-semibold px-4 py-1.5 rounded-[3px] transition-colors no-underline shrink-0"
+              style={{
+                background: 'var(--color-ink)',
+                color: 'white',
+              }}
+            >
+              {locale === 'ja' ? '公式サイト ↗' : 'Official Site ↗'}
+            </a>
+          )}
+
+          {/* エントリー状態バッジ */}
+          {!isPast && isEntryOpen && t && (
+            <span
+              className="text-xs font-bold px-3 py-1.5 rounded-[3px] tracking-[0.06em] uppercase shrink-0"
+              style={{ background: 'var(--color-primary)', color: 'white' }}
+            >
+              {t('entryOpen')}
+            </span>
+          )}
+          {!isPast && isNotYetOpen && t && (
+            <span
+              className="text-xs font-semibold px-3 py-1.5 rounded-[3px] shrink-0"
+              style={{ background: 'var(--color-cream)', color: 'var(--color-mid)', border: '1px solid var(--color-border)' }}
+            >
+              {t('notYetOpen')}
+            </span>
+          )}
+          {!isPast && race.entry_closed && t && (
+            <span
+              className="text-xs font-semibold px-3 py-1.5 rounded-[3px] shrink-0"
+              style={{ background: 'var(--color-cream)', color: 'var(--color-mid)', border: '1px solid var(--color-border)' }}
+            >
+              {t('entryClosed')}
+            </span>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/components/races/detail/EntrySection.tsx
+++ b/src/components/races/detail/EntrySection.tsx
@@ -10,8 +10,19 @@ interface EntrySectionProps {
 export default function EntrySection({ race, locale, today }: EntrySectionProps) {
   const isPast = race.date < today;
 
+  const receptionLabel = (type: typeof race.reception_type) => {
+    const map: Record<typeof type, { ja: string; en: string }> = {
+      pre_day:  { ja: '前日受付', en: 'Day-before' },
+      race_day: { ja: '当日受付', en: 'Race day' },
+      both:     { ja: '前日・当日受付', en: 'Day-before & Race day' },
+      pre_mail: { ja: '郵送受付', en: 'Mail-in' },
+      none:     { ja: 'なし', en: 'None' },
+    };
+    return map[type] ?? { ja: type, en: type };
+  };
+
   return (
-    <section id="entry">
+    <div>
       {/* 受付終了メッセージ */}
       {race.entry_closed && (
         <p
@@ -126,6 +137,23 @@ export default function EntrySection({ race, locale, today }: EntrySectionProps)
         </div>
       )}
 
+      {/* 受付方法 */}
+      {race.reception_type !== 'none' && (
+        <div className="mb-4">
+          <p className="text-xs mb-1" style={{ color: 'var(--color-mid)' }}>
+            {locale === 'ja' ? '受付方法' : 'Check-in'}
+          </p>
+          <p className="font-medium">
+            {locale === 'ja' ? receptionLabel(race.reception_type).ja : receptionLabel(race.reception_type).en}
+          </p>
+          {(locale === 'ja' ? race.reception_note_ja : race.reception_note_en) && (
+            <p className="text-sm mt-1" style={{ color: 'var(--color-ink2)' }}>
+              {locale === 'ja' ? race.reception_note_ja : race.reception_note_en}
+            </p>
+          )}
+        </div>
+      )}
+
       {/* エントリーリンク */}
       {race.entry_links.length > 0 && (
         <div className="mt-4 flex flex-wrap gap-2">
@@ -156,6 +184,6 @@ export default function EntrySection({ race, locale, today }: EntrySectionProps)
           {locale === 'ja' ? '公式サイト' : 'Official Site'} ↗
         </a>
       )}
-    </section>
+    </div>
   );
 }

--- a/src/components/races/detail/__tests__/DetailHeader.test.tsx
+++ b/src/components/races/detail/__tests__/DetailHeader.test.tsx
@@ -14,7 +14,8 @@ describe('DetailHeader - 基本レンダリング', () => {
   it('en ロケールで英語大会名が表示される', () => {
     const race = makeRace({ name_en: 'Nagano Marathon 2026', date: '2026-04-19' });
     render(<DetailHeader race={race} locale="en" raceName="Nagano Marathon 2026" />);
-    expect(screen.getByText('Nagano Marathon 2026')).toBeInTheDocument();
+    // h1 とサブタイトル両方に表示されるため getAllByText を使用
+    expect(screen.getAllByText('Nagano Marathon 2026').length).toBeGreaterThanOrEqual(1);
   });
 
   it('tagline_ja が表示される', () => {
@@ -26,7 +27,7 @@ describe('DetailHeader - 基本レンダリング', () => {
   it('tagline_en が en ロケールで表示される', () => {
     const race = makeRace({ tagline_en: 'Chase the Cherry Blossoms.', date: '2026-04-19' });
     render(<DetailHeader race={race} locale="en" raceName="Nagano Marathon 2026" />);
-    expect(screen.getByText('Chase the Cherry Blossoms.')).toBeInTheDocument();
+    expect(screen.getByText(/Chase the Cherry Blossoms\./)).toBeInTheDocument();
   });
 
   it('tagline が null のとき何も表示されない', () => {
@@ -53,17 +54,25 @@ describe('DetailHeader - 基本レンダリング', () => {
     expect(screen.getByText('SAKURA')).toBeInTheDocument();
   });
 
-  it('hero_image_url がある場合 img タグが描画される', () => {
-    const race = makeRace({ hero_image_url: '/images/hero.jpg', date: '2026-04-19' });
-    const { container } = render(<DetailHeader race={race} locale="ja" raceName="テスト大会" />);
-    const img = container.querySelector('img');
-    expect(img).not.toBeNull();
-    expect(img?.getAttribute('src')).toBe('/images/hero.jpg');
+  it('開催日がメタ行に表示される', () => {
+    const race = makeRace({ date: '2026-04-19' });
+    render(<DetailHeader race={race} locale="ja" raceName="テスト大会" />);
+    expect(screen.getByText('2026年4月19日')).toBeInTheDocument();
   });
 
-  it('hero_image_url が null のとき img タグが描画されない', () => {
-    const race = makeRace({ hero_image_url: null, date: '2026-04-19' });
-    const { container } = render(<DetailHeader race={race} locale="ja" raceName="テスト大会" />);
-    expect(container.querySelector('img')).toBeNull();
+  it('ordinalSuffix が 1st/2nd/3rd/4th で正しく表示される', () => {
+    const race1 = makeRace({ edition: 1, date: '2026-04-19' });
+    const { unmount: u1 } = render(<DetailHeader race={race1} locale="ja" raceName="テスト大会" />);
+    expect(screen.getByText(/1ST/)).toBeInTheDocument();
+    u1();
+
+    const race2 = makeRace({ edition: 2, date: '2026-04-19' });
+    const { unmount: u2 } = render(<DetailHeader race={race2} locale="ja" raceName="テスト大会" />);
+    expect(screen.getByText(/2ND/)).toBeInTheDocument();
+    u2();
+
+    const race11 = makeRace({ edition: 11, date: '2026-04-19' });
+    render(<DetailHeader race={race11} locale="ja" raceName="テスト大会" />);
+    expect(screen.getByText(/11TH/)).toBeInTheDocument();
   });
 });

--- a/src/data/races/abashiri-marathon-2026.json
+++ b/src/data/races/abashiri-marathon-2026.json
@@ -70,12 +70,16 @@
       "label_en": "General Entry"
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "流氷",
+  "motif_color": "#bfdbfe",
+  "motif_romaji": "Ryuhyo",
+  "tagline_ja": "流氷の大地を駆け抜ける春の42km",
+  "tagline_en": "Run through the land of drift ice in spring",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": []
 }

--- a/src/data/races/abashiri-marathon-2026.json
+++ b/src/data/races/abashiri-marathon-2026.json
@@ -17,7 +17,7 @@
   "entry_capacity": 0,
   "entry_start_date": "2026-04-01",
   "entry_end_date": "2026-07-16",
-  "reception_type": "mail",
+  "reception_type": "pre_mail",
   "reception_note_ja": "",
   "reception_note_en": "",
   "tags": [],

--- a/src/data/races/akita-nairiku-ultra-2026.json
+++ b/src/data/races/akita-nairiku-ultra-2026.json
@@ -91,12 +91,35 @@
       "entry_fee": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "紅葉",
+  "motif_color": "#d4631a",
+  "motif_romaji": "Koyo",
+  "tagline_ja": "秋田内陸の紅葉の回廊を走る100km",
+  "tagline_en": "A 100km journey through autumn foliage corridors",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "秋田内陸縦貫鉄道沿い",
+      "name_en": "Along Akita Nairiku Railway",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "田沢湖高原",
+      "name_en": "Tazawako Highland",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "最大高低差531m",
+      "name_en": "531m elevation difference",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/aomori-sakura-marathon-2026.json
+++ b/src/data/races/aomori-sakura-marathon-2026.json
@@ -110,12 +110,35 @@
       "entry_fee": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "桜",
+  "motif_color": "#f9c1cc",
+  "motif_romaji": "Sakura",
+  "tagline_ja": "桜前線に乗って、青森を走る",
+  "tagline_en": "Run through Aomori on the cherry blossom front",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "八甲田山",
+      "name_en": "Mt. Hakkoda",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "陸奥湾",
+      "name_en": "Mutsu Bay",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "桜並木",
+      "name_en": "cherry blossom trees",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/aomori-sakura-marathon-2026.json
+++ b/src/data/races/aomori-sakura-marathon-2026.json
@@ -17,7 +17,7 @@
   "entry_capacity": 0,
   "entry_start_date": "2025-11-01",
   "entry_end_date": "2026-01-30",
-  "reception_type": "mail",
+  "reception_type": "pre_mail",
   "reception_note_ja": "",
   "reception_note_en": "",
   "tags": [

--- a/src/data/races/asahikawa-half-marathon-2026.json
+++ b/src/data/races/asahikawa-half-marathon-2026.json
@@ -81,12 +81,23 @@
       "entry_fee": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "大雪山",
+  "motif_color": "#dbeafe",
+  "motif_romaji": "Taisetsuzan",
+  "tagline_ja": "大雪山を仰ぎながら旭川の街を駆ける",
+  "tagline_en": "Run through Asahikawa with Mt. Taisetsu in view",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "忠別川沿い",
+      "name_en": "Along Chubetsu River",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/beppu-oita-marathon-2026.json
+++ b/src/data/races/beppu-oita-marathon-2026.json
@@ -109,12 +109,29 @@
       "entry_fee": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "温泉",
+  "motif_color": "#fed7aa",
+  "motif_romaji": "Onsen",
+  "tagline_ja": "湯けむりの街から、大分へ。歴史ある42.195km",
+  "tagline_en": "From the city of hot springs to Oita — a storied 42.195km",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "別府温泉街",
+      "name_en": "Beppu hot spring town",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "別大国道の海岸線",
+      "name_en": "Betsudai coastal road",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/biwako-marathon-2026.json
+++ b/src/data/races/biwako-marathon-2026.json
@@ -17,7 +17,7 @@
   "entry_capacity": 7000,
   "entry_start_date": "2025-08-01",
   "entry_end_date": "2025-10-31",
-  "reception_type": "mail",
+  "reception_type": "pre_mail",
   "reception_note_ja": "",
   "reception_note_en": "",
   "tags": [

--- a/src/data/races/biwako-marathon-2026.json
+++ b/src/data/races/biwako-marathon-2026.json
@@ -98,12 +98,29 @@
       "entry_fee": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "琵琶湖",
+  "motif_color": "#93c5fd",
+  "motif_romaji": "Biwako",
+  "tagline_ja": "日本最大の湖を舞台に、水の都を走る",
+  "tagline_en": "Run along Japan's largest lake",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "琵琶湖畔",
+      "name_en": "Lake Biwa shore",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "比叡山",
+      "name_en": "Mt. Hiei",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/challenge-fuji5lakes-2026.json
+++ b/src/data/races/challenge-fuji5lakes-2026.json
@@ -303,12 +303,53 @@
       "entry_fee": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "富士五湖",
+  "motif_color": "#2563eb",
+  "motif_romaji": "Fuji-Goko",
+  "tagline_ja": "富士五湖を巡る、究極のチャレンジ",
+  "tagline_en": "The ultimate challenge around the five Fuji lakes",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "河口湖畔の桜並木",
+      "name_en": "Cherry blossom-lined Lake Kawaguchi shore",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "西湖からの富士山眺望",
+      "name_en": "Mt. Fuji views from Lake Saiko",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "精進湖",
+      "name_en": "Lake Shoji",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "本栖湖（120kmのみ）",
+      "name_en": "Lake Motosu (120km only)",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "山中湖（100km・120kmのみ）",
+      "name_en": "Lake Yamanaka (100km & 120km only)",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "富士北麓公園（スタート・フィニッシュ）",
+      "name_en": "Fuji Hokuroku Park (start/finish)",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/chiba-aqualine-marathon-2026.json
+++ b/src/data/races/chiba-aqualine-marathon-2026.json
@@ -101,12 +101,35 @@
       "label_en": "Late Entry"
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "海",
+  "motif_color": "#0ea5e9",
+  "motif_romaji": "Umi",
+  "tagline_ja": "東京湾アクアラインを渡る、世界唯一のコース",
+  "tagline_en": "The world-unique course crossing Tokyo Bay Aqua-Line",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "東京湾アクアライン",
+      "name_en": "Tokyo Bay Aqualine",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "海ほたる",
+      "name_en": "Umihotaru PA",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "袖ケ浦の田園地帯",
+      "name_en": "Sodegaura farmlands",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/chiba-aqualine-marathon-2026.json
+++ b/src/data/races/chiba-aqualine-marathon-2026.json
@@ -17,7 +17,7 @@
   "entry_capacity": 0,
   "entry_start_date": "2026-03-22",
   "entry_end_date": "2026-04-12",
-  "reception_type": "mail",
+  "reception_type": "pre_mail",
   "reception_note_ja": "一般枠：3/22〜4/12。アスリート・学生・女性・海外枠：3/22〜5/7。レイトエントリー枠：5/31〜6/8。システム利用料別途。",
   "reception_note_en": "General entry: Mar 22 - Apr 12. Athlete/Student/Women/Overseas entries: Mar 22 - May 7. Late entry: May 31 - Jun 8. System fee applies separately.",
   "tags": [

--- a/src/data/races/ehime-marathon-2026.json
+++ b/src/data/races/ehime-marathon-2026.json
@@ -115,12 +115,29 @@
       "entry_fee": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "みかん",
+  "motif_color": "#f97316",
+  "motif_romaji": "Mikan",
+  "tagline_ja": "蜜柑の香り漂う、瀬戸内の道を走る",
+  "tagline_en": "Run through the Seto Inland citrus country",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "松山城",
+      "name_en": "Matsuyama Castle",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "道後温泉",
+      "name_en": "Dogo Onsen",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/fuji-mountain-race-2026.json
+++ b/src/data/races/fuji-mountain-race-2026.json
@@ -9,15 +9,15 @@
   "prefecture": "19",
   "city_ja": "富士吉田市",
   "city_en": "Fujiyoshida City",
-  "description_ja": "この山の頂には過酷に挑む価値がある",
-  "description_en": "The summit of this mountain is well worth the challenge",
+  "description_ja": "",
+  "description_en": "",
   "official_url": "https://fujimountainrace.city.fujiyoshida.yamanashi.jp/",
   "entry_fee": null,
   "entry_fee_by_category": true,
   "entry_capacity": 0,
   "entry_start_date": "2026-03-28",
   "entry_end_date": "2026-04-06",
-  "reception_type": "mail",
+  "reception_type": "pre_mail",
   "reception_note_ja": "受付不要。事前発送とする。\n申込後の住所変更、その他の変更事項については、必ず事務局へ連絡すること。\n大会当日、ナンバーカード、計測用RSタグを忘れると出走できなくなるので、注意すること。\n（やむを得ず、当日再発行の場合は、別途再発行手数料を徴収する）",
   "reception_note_en": "No on-site registration is required. All materials will be sent in advance.\nPlease be sure to contact the organizing committee regarding any changes to your address or other details after registration.\nPlease note that if you forget your race number or timing chip on the day of the event, you will not be able to participate.\n(If reissuance is unavoidably necessary on the day of the event, a separate reissuance fee will be charged.)",
   "tags": [],
@@ -44,7 +44,8 @@
       "name_ja": "山頂コース",
       "eligibility_ja": "第76回大会、第77回大会、第78回大会のいずれかにおいて五合目関門（五合目ゴール）通過時間が2時間20分以内の実績のある者。又は、第2回富士山クライムランにおいて五合目ゴール時間が2時間以内の実績がある者とする。 過去(第76回、第77回、第78回)の大会の記録についてはこちらからご確認ください。 第2回富士山クライムランの記録についてはこちらからご確認ください。",
       "eligibility_en": "Participants must have completed the 5th Station checkpoint (5th Station finish) in 2 hours and 20 minutes or less in either the 76th, 77th, or 78th edition of the race. Alternatively, participants must have completed the 5th Station finish in 2 hours or less in the 2nd Mount Fuji Climb Run. Please click here to view records from past editions (76th, 77th, and 78th). Please click here to view records from the 2nd Mt. Fuji Climb Run.  Translated with DeepL.com (free version)",
-      "course_gpx_file": "fuji-mountain-race-2026.gpx"
+      "course_gpx_file": "fuji-mountain-race-2026.gpx",
+      "course_highlights": []
     },
     {
       "distance_type": "other",
@@ -56,7 +57,8 @@
       "name_ja": "五合目コース",
       "eligibility_ja": null,
       "eligibility_en": null,
-      "course_gpx_file": "fuji-mountain-race-2026-5gome"
+      "course_gpx_file": "fuji-mountain-race-2026-5gome",
+      "course_highlights": []
     }
   ],
   "aid_stations": [],
@@ -83,16 +85,15 @@
       "url": "https://runnet.jp/parts/2026/386774/entry.html"
     }
   ],
-  "motif": "富士山",
+  "motif": "霊峰",
   "motif_color": "#4b5563",
-  "motif_romaji": "Fujisan",
-  "tagline_ja": "山頂を目指す、日本の頂への挑戦",
-  "tagline_en": "Challenge to the summit — the ultimate mountain race",
+  "motif_romaji": "Reiho",
+  "tagline_ja": "この山の頂には過酷に挑む価値がある",
+  "tagline_en": "The summit of this mountain is well worth the challenge",
   "hero_image_url": null,
   "hero_caption_ja": null,
   "hero_caption_en": null,
   "gallery": [],
   "voices": [],
-  "time_buckets": [],
-  "course_highlights": []
+  "time_buckets": []
 }

--- a/src/data/races/fuji-mountain-race-2026.json
+++ b/src/data/races/fuji-mountain-race-2026.json
@@ -83,12 +83,16 @@
       "url": "https://runnet.jp/parts/2026/386774/entry.html"
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "富士山",
+  "motif_color": "#4b5563",
+  "motif_romaji": "Fujisan",
+  "tagline_ja": "山頂を目指す、日本の頂への挑戦",
+  "tagline_en": "Challenge to the summit — the ultimate mountain race",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": []
 }

--- a/src/data/races/fujisan-marathon-2026.json
+++ b/src/data/races/fujisan-marathon-2026.json
@@ -96,12 +96,35 @@
     "detail_level": "medium"
   },
   "entry_periods": [],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "富士山",
+  "motif_color": "#2a4fa3",
+  "motif_romaji": "Fujisan",
+  "tagline_ja": "霊峰富士を望みながら駆ける、絶景のコース",
+  "tagline_en": "Run with Japan's sacred peak as your guide",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "河口湖",
+      "name_en": "Lake Kawaguchi",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "西湖",
+      "name_en": "Lake Saiko",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "紅葉の富士山",
+      "name_en": "Mt. Fuji with autumn foliage",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/fukuchiyama-marathon-2026.json
+++ b/src/data/races/fukuchiyama-marathon-2026.json
@@ -136,12 +136,29 @@
       "label_en": "Last-minute (no participation gift)"
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "福知山城",
+  "motif_color": "#78350f",
+  "motif_romaji": "Fukuchiyama-jo",
+  "tagline_ja": "城下町・福知山の歴史街道を駆け抜ける",
+  "tagline_en": "Run through the historic castle town of Fukuchiyama",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "由良川沿い",
+      "name_en": "Along Yura River",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "福知山城周辺",
+      "name_en": "near Fukuchiyama Castle",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/fukuchiyama-marathon-2026.json
+++ b/src/data/races/fukuchiyama-marathon-2026.json
@@ -16,15 +16,12 @@
   "entry_fee_by_category": true,
   "entry_capacity": 5400,
   "entry_start_date": "2026-05-01",
-  "entry_end_date": "2026-08-31",
+  "entry_end_date": "2026-05-17",
   "reception_type": "pre_day",
   "reception_note_ja": "",
   "reception_note_en": "",
   "tags": [
-    "歴史ある大会",
-    "タフコース",
-    "川沿い",
-    "京都"
+    "歴史ある大会"
   ],
   "course_gpx_file": null,
   "course_info": {
@@ -43,7 +40,7 @@
       "distance_type": "full",
       "distance_km": 42.195,
       "time_limit_minutes": 360,
-      "start_time": null,
+      "start_time": "",
       "capacity": 5400,
       "entry_fee": 11000,
       "entry_fee_u25": null,
@@ -51,7 +48,11 @@
       "name_en": null,
       "description_ja": null,
       "description_en": null,
-      "waves": null
+      "waves": null,
+      "eligibility_ja": null,
+      "eligibility_en": null,
+      "course_gpx_file": null,
+      "course_highlights": []
     }
   ],
   "aid_stations": [],
@@ -110,7 +111,7 @@
     {
       "start_date": "2026-05-01",
       "end_date": "2026-05-17",
-      "entry_fee": 11000,
+      "entry_fee": 10000,
       "label_ja": "早割",
       "label_en": "Early Bird"
     },
@@ -120,13 +121,6 @@
       "entry_fee": 11000,
       "label_ja": "一般",
       "label_en": "General"
-    },
-    {
-      "start_date": "2026-09-01",
-      "end_date": "2026-09-20",
-      "entry_fee": 11000,
-      "label_ja": "レイト（参加賞なし）",
-      "label_en": "Late (no participation gift)"
     },
     {
       "start_date": "2026-11-01",
@@ -147,18 +141,6 @@
   "gallery": [],
   "voices": [],
   "time_buckets": [],
-  "course_highlights": [
-    {
-      "name_ja": "由良川沿い",
-      "name_en": "Along Yura River",
-      "description_ja": null,
-      "description_en": null
-    },
-    {
-      "name_ja": "福知山城周辺",
-      "name_en": "near Fukuchiyama Castle",
-      "description_ja": null,
-      "description_en": null
-    }
-  ]
+  "entry_closed": false,
+  "entry_links": []
 }

--- a/src/data/races/fukui-sakura-marathon-2026.json
+++ b/src/data/races/fukui-sakura-marathon-2026.json
@@ -122,12 +122,29 @@
       "label_en": "General Entry"
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "桜",
+  "motif_color": "#f9c1cc",
+  "motif_romaji": "Sakura",
+  "tagline_ja": "福井の桜回廊を巡る、春の42km",
+  "tagline_en": "A spring 42km through Fukui's cherry blossom corridors",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "桜並木",
+      "name_en": "Cherry blossom trees",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "足羽川",
+      "name_en": "Asuwa River",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/fukuoka-international-marathon-2026.json
+++ b/src/data/races/fukuoka-international-marathon-2026.json
@@ -89,12 +89,35 @@
     "detail_level": "medium"
   },
   "entry_periods": [],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "博多",
+  "motif_color": "#1e3a5f",
+  "motif_romaji": "Hakata",
+  "tagline_ja": "国際都市・福岡が誇る、世界へ続く道",
+  "tagline_en": "A world-class course in the international city of Fukuoka",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "平和台陸上競技場",
+      "name_en": "Heiwadai Athletics Stadium",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "大濠公園",
+      "name_en": "Ohori Park",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "海の中道方面",
+      "name_en": "Uminonakamichi area",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/fukuoka-marathon-2026.json
+++ b/src/data/races/fukuoka-marathon-2026.json
@@ -125,12 +125,41 @@
       "label_en": ""
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "博多湾",
+  "motif_color": "#0284c7",
+  "motif_romaji": "Hakata-wan",
+  "tagline_ja": "博多の海沿いを走る、秋の風物詩",
+  "tagline_en": "Run along Hakata Bay in autumn",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "天神スタート",
+      "name_en": "Tenjin start",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "博多湾沿い",
+      "name_en": "Hakata Bay coastline",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "玄界灘",
+      "name_en": "Genkai Sea",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "糸島フィニッシュ",
+      "name_en": "Itoshima finish",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/gunma-marathon-2026.json
+++ b/src/data/races/gunma-marathon-2026.json
@@ -115,12 +115,41 @@
       "label_en": ""
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "赤城山",
+  "motif_color": "#166534",
+  "motif_romaji": "Akagi-san",
+  "tagline_ja": "赤城を仰ぎ、前橋の大地を駆ける",
+  "tagline_en": "Run across Maebashi plain with Mt. Akagi in view",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "赤城山",
+      "name_en": "Mt. Akagi",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "榛名山",
+      "name_en": "Mt. Haruna",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "利根川",
+      "name_en": "Tone River",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "正田醤油スタジアム群馬",
+      "name_en": "Shoda Shoyu Stadium Gunma",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/gunma-marathon-2026.json
+++ b/src/data/races/gunma-marathon-2026.json
@@ -17,7 +17,7 @@
   "entry_capacity": 0,
   "entry_start_date": "2026-04-09",
   "entry_end_date": "2026-08-17",
-  "reception_type": "mail",
+  "reception_type": "pre_mail",
   "reception_note_ja": "参加者には、アスリートビブス、計測チップ、参加マニュアル等を申込時の住所に事前に発送します（10月下旬発送予定）。大会前日・当日の受付は行いません。\n\nエントリー締切後の住所変更は、郵便局にて転送手続きをお願いします。\n計測チップは、アスリートビブスに貼り付けてあります。外さずに参加してください。なお、詳細につきましてはアスリートビブスが入ったビニール袋同封の案内をご覧ください。\n大会にエントリー後、出場できなくなった場合のご連絡は不要です。参加賞の受取方法は「参加マニュアル」をご参照ください。",
   "reception_note_en": "Participants will receive their athlete bibs, timing chips, and participation manuals in advance at the address provided during registration (scheduled for late October). There will be no registration on the day before or the day of the event.\n\nFor address changes after the entry deadline, please arrange for mail forwarding at the post office.\n\nThe timing chip is attached to the athlete bib. Please do not remove it during the event. For further details, please refer to the instructions enclosed in the plastic bag containing the athlete bib.\n\nIf you are unable to participate after registering, you do not need to contact us. Please refer to the \"Participation Manual\" for instructions on how to receive your participation prize.",
   "tags": [

--- a/src/data/races/higashine-sakuranbo-marathon-2026.json
+++ b/src/data/races/higashine-sakuranbo-marathon-2026.json
@@ -100,12 +100,29 @@
       "entry_fee": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "さくらんぼ",
+  "motif_color": "#dc2626",
+  "motif_romaji": "Sakuranbo",
+  "tagline_ja": "さくらんぼの里・東根で走る、甘い42km",
+  "tagline_en": "Run 42km in Japan's cherry capital",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "フルーツライン",
+      "name_en": "Fruit Line road",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "神町駐屯地周辺",
+      "name_en": "Kanomachi Garrison area",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/higashinipon-half-marathon-2026.json
+++ b/src/data/races/higashinipon-half-marathon-2026.json
@@ -81,12 +81,29 @@
       "entry_fee": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "桜",
+  "motif_color": "#f9c1cc",
+  "motif_romaji": "Sakura",
+  "tagline_ja": "立川の春を駆け抜ける東日本ハーフ",
+  "tagline_en": "East Japan Half Marathon through spring Tachikawa",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "在日米陸軍相模総合補給廠内",
+      "name_en": "Inside US Army Sagami General Depot",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "フラット周回コース",
+      "name_en": "flat lap course",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/himeji-castle-marathon-2026.json
+++ b/src/data/races/himeji-castle-marathon-2026.json
@@ -96,12 +96,23 @@
       "entry_fee": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "姫路城",
+  "motif_color": "#f8fafc",
+  "motif_romaji": "Himeji-jo",
+  "tagline_ja": "世界遺産・白鷺城を眺めながら走る42.195km",
+  "tagline_en": "Run beneath the White Heron Castle, a World Heritage Site",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "姫路城",
+      "name_en": "Himeji Castle",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/hitachi-seaside-marathon-2026.json
+++ b/src/data/races/hitachi-seaside-marathon-2026.json
@@ -70,12 +70,16 @@
       "image": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "コキア",
+  "motif_color": "#dc2626",
+  "motif_romaji": "Kochiya",
+  "tagline_ja": "海浜公園のコキアが彩る、ひたちの秋",
+  "tagline_en": "Run through Hitachi Seaside Park's autumn kochia fields",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": []
 }

--- a/src/data/races/hitachi-seaside-marathon-2026.json
+++ b/src/data/races/hitachi-seaside-marathon-2026.json
@@ -17,7 +17,7 @@
   "entry_capacity": 0,
   "entry_start_date": "2026-04-13",
   "entry_end_date": "2026-08-31",
-  "reception_type": "mail",
+  "reception_type": "pre_mail",
   "reception_note_ja": "大会当日の受付はありません。10月末（予定）にアスリートビブス・ランナーズチップ等を郵送いたしますので、忘れずにお持ちください",
   "reception_note_en": "There will be no on-site registration on the day of the event. We will mail your race bibs, timing chips, and other items by the end of October (tentative), so please be sure to bring them with you.",
   "tags": [],

--- a/src/data/races/hofu-yomiuri-marathon-2026.json
+++ b/src/data/races/hofu-yomiuri-marathon-2026.json
@@ -89,12 +89,23 @@
     "detail_level": "medium"
   },
   "entry_periods": [],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "防府天満宮",
+  "motif_color": "#92400e",
+  "motif_romaji": "Hofu-Tenmangu",
+  "tagline_ja": "日本最古の天満宮の参道を巡る歴史ある大会",
+  "tagline_en": "Race through the grounds of Japan's oldest Tenmangu shrine",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "防府天満宮付近",
+      "name_en": "Near Hofu Tenmangu Shrine",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/hokkaido-marathon-2026.json
+++ b/src/data/races/hokkaido-marathon-2026.json
@@ -126,12 +126,35 @@
       "entry_fee": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "ライラック",
+  "motif_color": "#8b5cf6",
+  "motif_romaji": "Rairakku",
+  "tagline_ja": "ライラック香る大通公園から、北の大地を走る",
+  "tagline_en": "From the lilac-scented Odori Park across Hokkaido",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "大通公園",
+      "name_en": "Odori Park",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "北海道大学",
+      "name_en": "Hokkaido University",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "豊平川",
+      "name_en": "Toyohira River",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/ibusuki-nanohana-2026.json
+++ b/src/data/races/ibusuki-nanohana-2026.json
@@ -138,12 +138,35 @@
     "detail_level": "full"
   },
   "entry_periods": [],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "菜の花",
+  "motif_color": "#eab308",
+  "motif_romaji": "Nanohana",
+  "tagline_ja": "黄金色の菜の花畑と薩摩の海を巡る42km",
+  "tagline_en": "Run through golden rapeseed fields along the Satsuma sea",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "開聞岳",
+      "name_en": "Mt. Kaimon",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "錦江湾",
+      "name_en": "Kinko Bay",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "菜の花ロード",
+      "name_en": "canola flower road",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/ichinoseki-half-marathon-2026.json
+++ b/src/data/races/ichinoseki-half-marathon-2026.json
@@ -83,12 +83,23 @@
       "entry_fee": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "厳美渓",
+  "motif_color": "#065f46",
+  "motif_romaji": "Genbikei",
+  "tagline_ja": "厳美渓の渓谷美を感じながら走る一関ハーフ",
+  "tagline_en": "Run through the scenic Genbikei gorge in Ichinoseki",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "最大高低差15mのフラットコース",
+      "name_en": "Flat course with only 15m elevation difference",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/iki-ultra-marathon-2026.json
+++ b/src/data/races/iki-ultra-marathon-2026.json
@@ -79,12 +79,16 @@
       "image": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "壱岐の海",
+  "motif_color": "#0891b2",
+  "motif_romaji": "Iki-no-Umi",
+  "tagline_ja": "玄界灘に浮かぶ神秘の島・壱岐を一周する",
+  "tagline_en": "Circle the mystical island of Iki in the Genkai Sea",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": []
 }

--- a/src/data/races/iki-ultra-marathon-2026.json
+++ b/src/data/races/iki-ultra-marathon-2026.json
@@ -17,7 +17,7 @@
   "entry_capacity": 0,
   "entry_start_date": "2026-04-10",
   "entry_end_date": "2026-07-17",
-  "reception_type": "mail",
+  "reception_type": "pre_mail",
   "reception_note_ja": "ゼッケン・計測タグ・参加賞等を事前発送します。前日受付は行いません",
   "reception_note_en": "Race bibs, timing tags, and participation prizes will be sent out in advance. There will be no registration the day before the event.",
   "tags": [

--- a/src/data/races/itabashi-city-marathon-2026.json
+++ b/src/data/races/itabashi-city-marathon-2026.json
@@ -109,12 +109,23 @@
       "entry_fee": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "荒川",
+  "motif_color": "#6b7280",
+  "motif_romaji": "Arakawa",
+  "tagline_ja": "荒川河川敷を駆ける、春の板橋シティマラソン",
+  "tagline_en": "Run the Arakawa riverside in spring",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "荒川河川敷",
+      "name_en": "Arakawa Riverbank",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/iwaki-sunshine-marathon-2026.json
+++ b/src/data/races/iwaki-sunshine-marathon-2026.json
@@ -123,12 +123,23 @@
       "entry_fee": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "太平洋",
+  "motif_color": "#0369a1",
+  "motif_romaji": "Taiheiyo",
+  "tagline_ja": "太平洋の輝きとともに、いわきの海岸を走る",
+  "tagline_en": "Run along Iwaki's Pacific coast in sunshine",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "太平洋沿岸",
+      "name_en": "Pacific coastline",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/iwate-morioka-city-marathon-2026.json
+++ b/src/data/races/iwate-morioka-city-marathon-2026.json
@@ -70,12 +70,16 @@
       "image": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "岩手山",
+  "motif_color": "#374151",
+  "motif_romaji": "Iwate-san",
+  "tagline_ja": "南部片富士・岩手山を望み、盛岡の街を駆ける",
+  "tagline_en": "Run through Morioka with Mt. Iwate towering above",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": []
 }

--- a/src/data/races/iwate-oshu-kirameki-marathon-2026.json
+++ b/src/data/races/iwate-oshu-kirameki-marathon-2026.json
@@ -106,12 +106,16 @@
       "entry_fee": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "平泉",
+  "motif_color": "#854d0e",
+  "motif_romaji": "Hiraizumi",
+  "tagline_ja": "世界遺産・平泉の黄金文化を感じながら走る",
+  "tagline_en": "Run through Hiraizumi, the Golden City of World Heritage",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": []
 }

--- a/src/data/races/kagawa-marathon-2026.json
+++ b/src/data/races/kagawa-marathon-2026.json
@@ -102,12 +102,23 @@
       "entry_fee": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "瀬戸内海",
+  "motif_color": "#0284c7",
+  "motif_romaji": "Setonaikai",
+  "tagline_ja": "瀬戸内の穏やかな海を見渡しながら走る42km",
+  "tagline_en": "Run along the serene shores of the Seto Inland Sea",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "瀬戸内海",
+      "name_en": "Seto Inland Sea",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/kagoshima-marathon-2026.json
+++ b/src/data/races/kagoshima-marathon-2026.json
@@ -111,12 +111,29 @@
       "entry_fee": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "桜島",
+  "motif_color": "#991b1b",
+  "motif_romaji": "Sakura-jima",
+  "tagline_ja": "活火山・桜島を望む、薩摩の海岸を走る",
+  "tagline_en": "Run along Kagoshima Bay with the volcanic Sakurajima in view",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "桜島",
+      "name_en": "Sakurajima",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "錦江湾",
+      "name_en": "Kinko Bay",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/kaikyo-marathon-2026.json
+++ b/src/data/races/kaikyo-marathon-2026.json
@@ -125,12 +125,35 @@
       "label_en": ""
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "関門海峡",
+  "motif_color": "#1e40af",
+  "motif_romaji": "Kanmon-Kaikyo",
+  "tagline_ja": "本州と九州をつなぐ、関門海峡を渡る",
+  "tagline_en": "Cross the Kanmon Strait connecting Honshu and Kyushu",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "関門海峡",
+      "name_en": "Kanmon Strait",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "関門大橋",
+      "name_en": "Kanmon Bridge",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "巌流島",
+      "name_en": "Ganryujima Island",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/kanazawa-marathon-2026.json
+++ b/src/data/races/kanazawa-marathon-2026.json
@@ -126,12 +126,35 @@
       "label_en": ""
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "兼六園",
+  "motif_color": "#14532d",
+  "motif_romaji": "Kenroku-en",
+  "tagline_ja": "加賀百万石の城下町・金沢を駆ける",
+  "tagline_en": "Run through Kanazawa, the castle town of one million koku",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "兼六園",
+      "name_en": "Kenroku-en Garden",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "金沢城",
+      "name_en": "Kanazawa Castle",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "ひがし茶屋街付近",
+      "name_en": "Higashi Chaya District area",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/kasumigaura-marathon-2026.json
+++ b/src/data/races/kasumigaura-marathon-2026.json
@@ -119,12 +119,23 @@
       "entry_fee": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "霞ヶ浦",
+  "motif_color": "#7dd3fc",
+  "motif_romaji": "Kasumigaura",
+  "tagline_ja": "日本第2位の湖・霞ヶ浦のほとりを走る",
+  "tagline_en": "Run along the shores of Lake Kasumigaura, Japan's 2nd largest lake",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "霞ヶ浦湖畔",
+      "name_en": "Lake Kasumigaura shore",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/katsuta-marathon-2026.json
+++ b/src/data/races/katsuta-marathon-2026.json
@@ -121,12 +121,16 @@
       "entry_fee": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "百里",
+  "motif_color": "#4b5563",
+  "motif_romaji": "Hyakuri",
+  "tagline_ja": "常陸の大地を駆け抜ける、勝田全国マラソン",
+  "tagline_en": "Run across the Hitachi plains at Katsuta",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": []
 }

--- a/src/data/races/kitakyushu-marathon-2026.json
+++ b/src/data/races/kitakyushu-marathon-2026.json
@@ -108,12 +108,29 @@
       "entry_fee": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "洞海湾",
+  "motif_color": "#1d4ed8",
+  "motif_romaji": "Dokai-wan",
+  "tagline_ja": "北九州の海と工場夜景の街を走る",
+  "tagline_en": "Run through Kitakyushu's industrial waterfront",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "小倉市街地",
+      "name_en": "Kokura city center",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "関門海峡",
+      "name_en": "Kanmon Strait",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/kix-senshu-marathon-2026.json
+++ b/src/data/races/kix-senshu-marathon-2026.json
@@ -101,12 +101,23 @@
       "entry_fee": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "大阪湾",
+  "motif_color": "#0ea5e9",
+  "motif_romaji": "Osaka-wan",
+  "tagline_ja": "関西国際空港を望む、泉州の海岸を駆ける",
+  "tagline_en": "Run the Senshu coast with Kansai International Airport in view",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "泉州の海岸沿い",
+      "name_en": "Senshu coastline",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/kobe-marathon-2026.json
+++ b/src/data/races/kobe-marathon-2026.json
@@ -128,12 +128,35 @@
       "label_en": ""
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "異人館",
+  "motif_color": "#b91c1c",
+  "motif_romaji": "Ijin-kan",
+  "tagline_ja": "港町・神戸の異国情緒あふれる街を走る",
+  "tagline_en": "Run through the exotic port city of Kobe",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "明石海峡大橋",
+      "name_en": "Akashi Kaikyo Bridge",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "ポートアイランド",
+      "name_en": "Port Island",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "ハーバーランド",
+      "name_en": "Harborland",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/kochi-ryoma-marathon-2026.json
+++ b/src/data/races/kochi-ryoma-marathon-2026.json
@@ -114,12 +114,35 @@
       "entry_fee": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "坂本龍馬",
+  "motif_color": "#1a3a1a",
+  "motif_romaji": "Ryoma",
+  "tagline_ja": "龍馬の志を胸に、土佐の大地を駆け抜ける",
+  "tagline_en": "Run the Tosa plains with the spirit of Ryoma",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "太平洋",
+      "name_en": "Pacific Ocean",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "浦戸大橋",
+      "name_en": "Urado Bridge",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "桂浜方面",
+      "name_en": "Katsurahama area",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/kumamoto-castle-marathon-2026.json
+++ b/src/data/races/kumamoto-castle-marathon-2026.json
@@ -113,12 +113,23 @@
       "entry_fee": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "熊本城",
+  "motif_color": "#1c1917",
+  "motif_romaji": "Kumamoto-jo",
+  "tagline_ja": "不落の名城・熊本城をめぐる感動の42km",
+  "tagline_en": "42km around the legendary Kumamoto Castle",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "熊本城",
+      "name_en": "Kumamoto Castle",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/kyoto-marathon-2026.json
+++ b/src/data/races/kyoto-marathon-2026.json
@@ -125,12 +125,47 @@
       "entry_fee": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "大文字山",
+  "motif_color": "#7f1d1d",
+  "motif_romaji": "Daimonji-yama",
+  "tagline_ja": "千年の古都・京都の世界遺産をめぐる",
+  "tagline_en": "Run through Kyoto's thousand years of world heritage",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "嵐山",
+      "name_en": "Arashiyama",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "金閣寺付近",
+      "name_en": "near Kinkaku-ji",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "今出川通",
+      "name_en": "Imadegawa-dori",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "銀閣寺付近",
+      "name_en": "near Ginkaku-ji",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "平安神宮",
+      "name_en": "Heian Shrine",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/mie-matsusaka-marathon-2026.json
+++ b/src/data/races/mie-matsusaka-marathon-2026.json
@@ -93,12 +93,23 @@
     "detail_level": "medium"
   },
   "entry_periods": [],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "松阪牛",
+  "motif_color": "#7f1d1d",
+  "motif_romaji": "Matsusaka-gyu",
+  "tagline_ja": "松阪牛の里・松阪を走る、美食ランナーの聖地",
+  "tagline_en": "Run through Matsusaka, home of Japan's finest beef",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "松阪の城下町",
+      "name_en": "Matsusaka castle town",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/mito-komon-manyu-marathon-2026.json
+++ b/src/data/races/mito-komon-manyu-marathon-2026.json
@@ -111,12 +111,29 @@
       "url": "https://runnet.jp/entry/runtes/user/pc/competitionDetailAction.do?raceId=387694&div=1"
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "水戸黄門",
+  "motif_color": "#1c1917",
+  "motif_romaji": "Mito-Komon",
+  "tagline_ja": "助さん格さんも驚く、水戸を駆ける42km",
+  "tagline_en": "Run through Mito as legends of the Komon await",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "偕楽園",
+      "name_en": "Kairakuen Garden",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "千波湖",
+      "name_en": "Lake Senba",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/mito-komon-manyu-marathon-2026.json
+++ b/src/data/races/mito-komon-manyu-marathon-2026.json
@@ -17,7 +17,7 @@
   "entry_capacity": 0,
   "entry_start_date": "2026-04-16",
   "entry_end_date": "2026-06-30",
-  "reception_type": "mail",
+  "reception_type": "pre_mail",
   "reception_note_ja": "",
   "reception_note_en": "",
   "tags": [

--- a/src/data/races/mtfuji-climb-run-2026.json
+++ b/src/data/races/mtfuji-climb-run-2026.json
@@ -69,12 +69,16 @@
       "image": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "富士山頂",
+  "motif_color": "#1e3a8a",
+  "motif_romaji": "Fujisan-cho",
+  "tagline_ja": "霊峰富士の頂へ、山岳レースの最高峰",
+  "tagline_en": "Climb to the summit of Mt. Fuji — the ultimate trail race",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": []
 }

--- a/src/data/races/nagano-marathon-2026.json
+++ b/src/data/races/nagano-marathon-2026.json
@@ -307,12 +307,53 @@
       "entry_fee": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "善光寺",
+  "motif_color": "#78350f",
+  "motif_romaji": "Zenko-ji",
+  "tagline_ja": "長野オリンピックの遺産を巡る、信濃の春",
+  "tagline_en": "Run through Nagano's Olympic legacy in spring Shinano",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "善光寺表参道",
+      "name_en": "Zenkoji approach road",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "エムウェーブ（2026年は工事のためコース変更あり）",
+      "name_en": "M-Wave (course change in 2026 due to construction)",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "ビッグハット",
+      "name_en": "Big Hat",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "五輪大橋",
+      "name_en": "Olympic Bridge",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "ホワイトリング",
+      "name_en": "White Ring",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "長野オリンピックスタジアム（フィニッシュ）",
+      "name_en": "Nagano Olympic Stadium (finish)",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/nagoya-womens-marathon-2026.json
+++ b/src/data/races/nagoya-womens-marathon-2026.json
@@ -106,12 +106,29 @@
     "detail_level": "medium"
   },
   "entry_periods": [],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "名古屋城",
+  "motif_color": "#c2410c",
+  "motif_romaji": "Nagoya-jo",
+  "tagline_ja": "女性ランナーの憧れ、名古屋の街を駆ける42km",
+  "tagline_en": "The women's marathon destination — run through Nagoya",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "名古屋ドーム（バンテリンドーム ナゴヤ）",
+      "name_en": "Nagoya Dome (Vantelin Dome Nagoya)",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "名古屋城付近",
+      "name_en": "near Nagoya Castle",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/naha-marathon-2026.json
+++ b/src/data/races/naha-marathon-2026.json
@@ -105,12 +105,35 @@
     "detail_level": "medium"
   },
   "entry_periods": [],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "ハイビスカス",
+  "motif_color": "#dc2626",
+  "motif_romaji": "Haibisukasu",
+  "tagline_ja": "南国の陽光と笑顔溢れる、那覇の42km",
+  "tagline_en": "Run through tropical Naha with sunshine and smiles",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "国際通り",
+      "name_en": "Kokusai Street",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "那覇市街",
+      "name_en": "Naha city",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "沖縄の風景",
+      "name_en": "Okinawan scenery",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/nara-marathon-2026.json
+++ b/src/data/races/nara-marathon-2026.json
@@ -107,12 +107,41 @@
     "detail_level": "medium"
   },
   "entry_periods": [],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "奈良の鹿",
+  "motif_color": "#92400e",
+  "motif_romaji": "Nara-no-Shika",
+  "tagline_ja": "奈良の鹿と世界遺産が待つ、古都の42km",
+  "tagline_en": "Run through the ancient capital of Nara alongside sacred deer",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "東大寺",
+      "name_en": "Todai-ji",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "春日大社",
+      "name_en": "Kasuga Shrine",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "平城宮跡",
+      "name_en": "Heijo Palace ruins",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "奈良公園",
+      "name_en": "Nara Park",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/niigata-city-marathon-2026.json
+++ b/src/data/races/niigata-city-marathon-2026.json
@@ -70,12 +70,16 @@
       "image": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "信濃川",
+  "motif_color": "#0369a1",
+  "motif_romaji": "Shinano-gawa",
+  "tagline_ja": "日本一の大河・信濃川が流れる、米どころを走る",
+  "tagline_en": "Run along the Shinano River, Japan's longest",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": []
 }

--- a/src/data/races/nishio-marathon-2026.json
+++ b/src/data/races/nishio-marathon-2026.json
@@ -89,12 +89,16 @@
     "detail_level": "medium"
   },
   "entry_periods": [],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "抹茶",
+  "motif_color": "#4d7c0f",
+  "motif_romaji": "Matcha",
+  "tagline_ja": "日本有数の抹茶の産地・西尾を巡る42km",
+  "tagline_en": "Run through Nishio, one of Japan's top matcha-producing cities",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": []
 }

--- a/src/data/races/okayama-marathon-2026.json
+++ b/src/data/races/okayama-marathon-2026.json
@@ -101,12 +101,29 @@
       "entry_fee": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "桃",
+  "motif_color": "#f9a8d4",
+  "motif_romaji": "Momo",
+  "tagline_ja": "桃太郎の里・岡山を、晴れの国で走る",
+  "tagline_en": "Run through Okayama, the sunny land of Momotaro",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "岡山城",
+      "name_en": "Okayama Castle",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "後楽園",
+      "name_en": "Korakuen Garden",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/okushinano100-2026.json
+++ b/src/data/races/okushinano100-2026.json
@@ -98,12 +98,29 @@
       "entry_fee": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "北アルプス",
+  "motif_color": "#1e40af",
+  "motif_romaji": "Kita-Arupusu",
+  "tagline_ja": "北アルプスの麓・奥信濃を走る100km",
+  "tagline_en": "100km through the foothills of the Northern Alps",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "奥信濃の山岳トレイル",
+      "name_en": "Mountain trails of Okushinano",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "木島平村〜飯山市周辺",
+      "name_en": "Kijimadaira to Iiyama area",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/osaka-marathon-2026.json
+++ b/src/data/races/osaka-marathon-2026.json
@@ -119,12 +119,41 @@
     "detail_level": "medium"
   },
   "entry_periods": [],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "大阪城",
+  "motif_color": "#92400e",
+  "motif_romaji": "Osaka-jo",
+  "tagline_ja": "笑いと活気溢れる、天下の台所・大阪を走る",
+  "tagline_en": "Run through Osaka, the nation's kitchen of energy",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "大阪城",
+      "name_en": "Osaka Castle",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "御堂筋",
+      "name_en": "Midosuji",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "通天閣",
+      "name_en": "Tsutenkaku",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "中之島",
+      "name_en": "Nakanoshima",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/osaka-yodo-river-citizens-marathon-2026.json
+++ b/src/data/races/osaka-yodo-river-citizens-marathon-2026.json
@@ -17,7 +17,7 @@
   "entry_capacity": 0,
   "entry_start_date": "2026-04-17",
   "entry_end_date": "2026-09-27",
-  "reception_type": "mail",
+  "reception_type": "pre_mail",
   "reception_note_ja": "",
   "reception_note_en": "",
   "tags": [],

--- a/src/data/races/osaka-yodo-river-citizens-marathon-2026.json
+++ b/src/data/races/osaka-yodo-river-citizens-marathon-2026.json
@@ -86,12 +86,16 @@
       "image": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "淀川",
+  "motif_color": "#0284c7",
+  "motif_romaji": "Yodogawa",
+  "tagline_ja": "淀川の流れに沿って、大阪の街を走る",
+  "tagline_en": "Run along the Yodo River through Osaka",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": []
 }

--- a/src/data/races/osj-ontake100-2026.json
+++ b/src/data/races/osj-ontake100-2026.json
@@ -82,12 +82,29 @@
       "entry_fee": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "御嶽山",
+  "motif_color": "#1c1917",
+  "motif_romaji": "Ontake-san",
+  "tagline_ja": "霊峰・御嶽山の麓を巡る、100kmの山岳路",
+  "tagline_en": "100km through the sacred slopes of Mt. Ontake",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "御嶽山麓国有林",
+      "name_en": "National forest at Mt. Ontake base",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "特別開放区域",
+      "name_en": "specially opened restricted area",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/sado-toki-marathon-2026.json
+++ b/src/data/races/sado-toki-marathon-2026.json
@@ -112,12 +112,23 @@
       "entry_fee": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "朱鷺",
+  "motif_color": "#fb7185",
+  "motif_romaji": "Toki",
+  "tagline_ja": "朱鷺舞う離島・佐渡で走る、自然豊かな42km",
+  "tagline_en": "Run the island of Sado where the endangered crested ibis soars",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "佐渡島の自然",
+      "name_en": "Nature of Sado Island",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/sado-toki-marathon-2026.json
+++ b/src/data/races/sado-toki-marathon-2026.json
@@ -17,7 +17,7 @@
   "entry_capacity": 0,
   "entry_start_date": "2025-12-01",
   "entry_end_date": "2026-03-22",
-  "reception_type": "mail",
+  "reception_type": "pre_mail",
   "reception_note_ja": "",
   "reception_note_en": "",
   "tags": [

--- a/src/data/races/saga-sakura-marathon-2026.json
+++ b/src/data/races/saga-sakura-marathon-2026.json
@@ -91,12 +91,29 @@
     "detail_level": "medium"
   },
   "entry_periods": [],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "桜",
+  "motif_color": "#f9c1cc",
+  "motif_romaji": "Sakura",
+  "tagline_ja": "佐賀城址の桜を愛でながら走る、春の42km",
+  "tagline_en": "Run beneath cherry blossoms at Saga Castle in spring",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "桜並木",
+      "name_en": "Cherry blossom trees",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "佐賀平野",
+      "name_en": "Saga Plain",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/saitama-marathon-2026.json
+++ b/src/data/races/saitama-marathon-2026.json
@@ -81,12 +81,16 @@
     "detail_level": "medium"
   },
   "entry_periods": [],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "荒川",
+  "motif_color": "#0369a1",
+  "motif_romaji": "Arakawa",
+  "tagline_ja": "荒川の雄大な流れとともに走る、さいたまの42km",
+  "tagline_en": "Run along the vast Arakawa River through Saitama",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": []
 }

--- a/src/data/races/shiga-kogen100-2026.json
+++ b/src/data/races/shiga-kogen100-2026.json
@@ -89,12 +89,16 @@
       "image": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "高原",
+  "motif_color": "#166534",
+  "motif_romaji": "Kogen",
+  "tagline_ja": "志賀高原の雄大な自然の中を走る100kmトレイル",
+  "tagline_en": "100km trail through the majestic nature of Shiga Kogen",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": []
 }

--- a/src/data/races/shimada-oigawa-marathon-2026.json
+++ b/src/data/races/shimada-oigawa-marathon-2026.json
@@ -17,7 +17,7 @@
   "entry_capacity": 0,
   "entry_start_date": "2026-05-01",
   "entry_end_date": "2026-06-30",
-  "reception_type": "mail",
+  "reception_type": "pre_mail",
   "reception_note_ja": "",
   "reception_note_en": "",
   "tags": [],

--- a/src/data/races/shimada-oigawa-marathon-2026.json
+++ b/src/data/races/shimada-oigawa-marathon-2026.json
@@ -78,12 +78,16 @@
       "image": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "大井川",
+  "motif_color": "#15803d",
+  "motif_romaji": "Oi-gawa",
+  "tagline_ja": "南アルプスから流れる大井川沿いを走る42km",
+  "tagline_en": "Run along the Oi River flowing down from the Southern Alps",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": []
 }

--- a/src/data/races/shinetsu5mountains-trail-100-2026.json
+++ b/src/data/races/shinetsu5mountains-trail-100-2026.json
@@ -81,12 +81,16 @@
       "image": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "信越五岳",
+  "motif_color": "#065f46",
+  "motif_romaji": "Shin-etsu-Gogaku",
+  "tagline_ja": "信越の五つの山を巡る、100マイルの挑戦",
+  "tagline_en": "A 100-mile challenge through five peaks of the Shin-Etsu mountains",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": []
 }

--- a/src/data/races/shizuoka-marathon-2026.json
+++ b/src/data/races/shizuoka-marathon-2026.json
@@ -93,12 +93,29 @@
     "detail_level": "medium"
   },
   "entry_periods": [],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "富士山",
+  "motif_color": "#2a4fa3",
+  "motif_romaji": "Fujisan",
+  "tagline_ja": "富士山を正面に望む、海岸線の42km",
+  "tagline_en": "Run the coastline with Mt. Fuji straight ahead",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "駿河湾",
+      "name_en": "Suruga Bay",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "富士山",
+      "name_en": "Mt. Fuji",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/shonan-international-marathon-2026.json
+++ b/src/data/races/shonan-international-marathon-2026.json
@@ -110,12 +110,35 @@
       "label_en": ""
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "湘南の海",
+  "motif_color": "#0ea5e9",
+  "motif_romaji": "Shonan-no-Umi",
+  "tagline_ja": "湘南の海風を感じながら走る、江ノ島から湘南へ",
+  "tagline_en": "Run the Shonan coast from Enoshima with ocean breezes",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "湘南海岸",
+      "name_en": "Shonan coast",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "江の島",
+      "name_en": "Enoshima",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "富士山",
+      "name_en": "Mt. Fuji",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/shonan-international-marathon-2026.json
+++ b/src/data/races/shonan-international-marathon-2026.json
@@ -17,7 +17,7 @@
   "entry_capacity": null,
   "entry_start_date": "2026-04-04",
   "entry_end_date": "2026-09-09",
-  "reception_type": "mail",
+  "reception_type": "pre_mail",
   "reception_note_ja": "計測タグは、ナンバーカードとともに事前に参加者へ発送します（事前のランナー受付はありません）。",
   "reception_note_en": "Timing tags will be sent to participants in advance along with their race numbers (there is no pre-race runner registration).",
   "tags": [

--- a/src/data/races/soja-kibiji-marathon-2026.json
+++ b/src/data/races/soja-kibiji-marathon-2026.json
@@ -101,12 +101,35 @@
       "label_en": ""
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "吉備路",
+  "motif_color": "#854d0e",
+  "motif_romaji": "Kibiji",
+  "tagline_ja": "吉備路の古代ロマンを感じながら走る42km",
+  "tagline_en": "Run the ancient Kibiji road through Soja's historic landscape",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "備中国分寺五重塔",
+      "name_en": "Bitchu Kokubunji five-story pagoda",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "古墳群",
+      "name_en": "burial mounds",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "吉備路",
+      "name_en": "Kibiji",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/soja-kibiji-marathon-2026.json
+++ b/src/data/races/soja-kibiji-marathon-2026.json
@@ -17,7 +17,7 @@
   "entry_capacity": null,
   "entry_start_date": "2025-10-01",
   "entry_end_date": "2026-01-03",
-  "reception_type": "mail",
+  "reception_type": "pre_mail",
   "reception_note_ja": "すべての種目でナンバーカードを事前に発送させていただきます。\nそのため受付はございません。",
   "reception_note_en": "Number cards for all events will be sent out in advance.\n\nTherefore, there is no registration required.",
   "tags": [

--- a/src/data/races/tamba-sasayama-abc-marathon-2026.json
+++ b/src/data/races/tamba-sasayama-abc-marathon-2026.json
@@ -94,12 +94,29 @@
     "detail_level": "medium"
   },
   "entry_periods": [],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "城下町",
+  "motif_color": "#1c1917",
+  "motif_romaji": "Jokamachi",
+  "tagline_ja": "丹波篠山・城下町の風情漂う黒豆の里を走る",
+  "tagline_en": "Run through the castle town of Tamba Sasayama, home of black soybeans",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "篠山城跡",
+      "name_en": "Sasayama Castle ruins",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "田園風景",
+      "name_en": "rural landscape",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/tateyama-wakashio-2026.json
+++ b/src/data/races/tateyama-wakashio-2026.json
@@ -104,12 +104,23 @@
     "detail_level": "medium"
   },
   "entry_periods": [],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "若潮",
+  "motif_color": "#0369a1",
+  "motif_romaji": "Wakashio",
+  "tagline_ja": "太平洋に面した館山の若潮を感じながら走る",
+  "tagline_en": "Run Tateyama's Pacific coast on the fresh tides of spring",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "房総の海岸線",
+      "name_en": "Boso coastline",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/tazawako-marathon-2026.json
+++ b/src/data/races/tazawako-marathon-2026.json
@@ -75,12 +75,16 @@
       "entry_fee": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "田沢湖",
+  "motif_color": "#1e40af",
+  "motif_romaji": "Tazawako",
+  "tagline_ja": "日本最深の湖・田沢湖を一望しながら走る",
+  "tagline_en": "Run overlooking Lake Tazawa, Japan's deepest lake",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": []
 }

--- a/src/data/races/tazawako-marathon-2026.json
+++ b/src/data/races/tazawako-marathon-2026.json
@@ -17,7 +17,7 @@
   "entry_capacity": 0,
   "entry_start_date": "2026-04-01",
   "entry_end_date": "2026-05-27",
-  "reception_type": "mail",
+  "reception_type": "pre_mail",
   "reception_note_ja": "",
   "reception_note_en": "",
   "tags": [],

--- a/src/data/races/tokushima-marathon-2026.json
+++ b/src/data/races/tokushima-marathon-2026.json
@@ -89,12 +89,23 @@
     "detail_level": "medium"
   },
   "entry_periods": [],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "阿波おどり",
+  "motif_color": "#ea580c",
+  "motif_romaji": "Awa-Odori",
+  "tagline_ja": "踊る阿呆に走る阿呆！阿波の国を駆け抜ける",
+  "tagline_en": "Run the land of Awa dance — the spirit of Tokushima",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "吉野川",
+      "name_en": "Yoshino River",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/tokyo-marathon-2026.json
+++ b/src/data/races/tokyo-marathon-2026.json
@@ -150,12 +150,53 @@
       "label_en": "General Entry"
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "東京の街",
+  "motif_color": "#1e293b",
+  "motif_romaji": "Tokyo-no-Machi",
+  "tagline_ja": "世界6大メジャーの一つ、東京の街を駆け抜ける",
+  "tagline_en": "Race through Tokyo — one of the six World Marathon Majors",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "東京都庁",
+      "name_en": "Tokyo Metropolitan Government",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "皇居",
+      "name_en": "Imperial Palace",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "浅草雷門",
+      "name_en": "Asakusa Kaminarimon",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "銀座",
+      "name_en": "Ginza",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "東京タワー",
+      "name_en": "Tokyo Tower",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "東京駅丸の内",
+      "name_en": "Tokyo Station Marunouchi",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/tokyo-marathon-2027.json
+++ b/src/data/races/tokyo-marathon-2027.json
@@ -150,12 +150,53 @@
       "label_en": "General Entry"
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "東京の街",
+  "motif_color": "#1e293b",
+  "motif_romaji": "Tokyo-no-Machi",
+  "tagline_ja": "世界6大メジャーの一つ、東京の街を駆け抜ける",
+  "tagline_en": "Race through Tokyo — one of the six World Marathon Majors",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "東京都庁",
+      "name_en": "Tokyo Metropolitan Government",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "皇居",
+      "name_en": "Imperial Palace",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "浅草雷門",
+      "name_en": "Asakusa Kaminarimon",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "銀座",
+      "name_en": "Ginza",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "東京タワー",
+      "name_en": "Tokyo Tower",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "東京駅丸の内",
+      "name_en": "Tokyo Station Marunouchi",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/tomisato-suikaroad-2026.json
+++ b/src/data/races/tomisato-suikaroad-2026.json
@@ -12,12 +12,12 @@
   "description_ja": "スイカの一大産地・千葉県富里市で毎年6月に開催される人気大会。エイドステーションでスイカを食べながら走れる名物大会。コース沿いのスイカ畑が広がる田園風景の中、7kmと10kmで競う。マイカップ給水対応。",
   "description_en": "A popular race held every June in Tomisato City, Chiba, the top watermelon-producing area in Japan. Famous for eating watermelon at aid stations while running. Race through scenic watermelon fields in 7km and 10km distances. Supports personal cup hydration.",
   "official_url": "https://tomisato-suikaroad.jp/",
-  "entry_fee": 0,
+  "entry_fee": null,
   "entry_fee_by_category": true,
   "entry_capacity": 0,
   "entry_start_date": "2026-02-22",
   "entry_end_date": "2026-04-04",
-  "reception_type": "same_day",
+  "reception_type": "race_day",
   "reception_note_ja": "雨天決行。スポーツエントリー（インターネット）で申込。先着順。",
   "reception_note_en": "Held rain or shine. Entry via Sports Entry (online). First-come, first-served.",
   "tags": [
@@ -46,7 +46,12 @@
       "entry_fee": 6500,
       "capacity": 1500,
       "time_limit_minutes": 70,
-      "start_time": "09:15"
+      "start_time": "09:15",
+      "name_ja": null,
+      "eligibility_ja": null,
+      "eligibility_en": null,
+      "course_gpx_file": null,
+      "course_highlights": []
     },
     {
       "distance_type": "other",
@@ -54,7 +59,12 @@
       "entry_fee": 6500,
       "capacity": 5100,
       "time_limit_minutes": 90,
-      "start_time": "10:00"
+      "start_time": "10:00",
+      "name_ja": null,
+      "eligibility_ja": null,
+      "eligibility_en": null,
+      "course_gpx_file": null,
+      "course_highlights": []
     }
   ],
   "aid_stations": [],
@@ -84,16 +94,16 @@
   },
   "entry_periods": [
     {
-      "label_ja": "一般エントリー",
-      "label_en": "General Entry",
       "start_date": "2026-02-22",
       "end_date": "2026-04-04",
-      "entry_fee": null
+      "entry_fee": null,
+      "label_ja": "一般エントリー",
+      "label_en": "General Entry"
     }
   ],
-  "motif": "スイカ",
+  "motif": "給スイカ所",
   "motif_color": "#16a34a",
-  "motif_romaji": "Suika",
+  "motif_romaji": "KyuSuika",
   "tagline_ja": "日本一のスイカの産地・富里を走る、夏の風物詩",
   "tagline_en": "Run Japan's watermelon capital — a midsummer tradition",
   "hero_image_url": null,
@@ -102,12 +112,11 @@
   "gallery": [],
   "voices": [],
   "time_buckets": [],
-  "course_highlights": [
+  "entry_closed": false,
+  "entry_links": [
     {
-      "name_ja": "スイカ畑の田園風景",
-      "name_en": "Scenic watermelon fields",
-      "description_ja": null,
-      "description_en": null
+      "site_name": "SPORT ENTRY",
+      "url": "https://www.sportsentry.ne.jp/event/t/104032"
     }
   ]
 }

--- a/src/data/races/tomisato-suikaroad-2026.json
+++ b/src/data/races/tomisato-suikaroad-2026.json
@@ -91,12 +91,23 @@
       "entry_fee": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "スイカ",
+  "motif_color": "#16a34a",
+  "motif_romaji": "Suika",
+  "tagline_ja": "日本一のスイカの産地・富里を走る、夏の風物詩",
+  "tagline_en": "Run Japan's watermelon capital — a midsummer tradition",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "スイカ畑の田園風景",
+      "name_en": "Scenic watermelon fields",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/tottori-marathon-2026.json
+++ b/src/data/races/tottori-marathon-2026.json
@@ -101,12 +101,29 @@
       "entry_fee": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "砂丘",
+  "motif_color": "#d4a853",
+  "motif_romaji": "Sakyu",
+  "tagline_ja": "日本最大の砂丘を望む、山陰の大地を走る",
+  "tagline_en": "Run the San-in coast with Japan's great sand dunes in view",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "鳥取砂丘付近",
+      "name_en": "Near Tottori Sand Dunes",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "日本海",
+      "name_en": "Sea of Japan",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/toyako-marathon-2026.json
+++ b/src/data/races/toyako-marathon-2026.json
@@ -112,12 +112,29 @@
       "entry_fee": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "洞爺湖",
+  "motif_color": "#0369a1",
+  "motif_romaji": "Toyako",
+  "tagline_ja": "洞爺湖の湖畔を巡る、北海道の爽快42km",
+  "tagline_en": "Circle the shores of Lake Toya in refreshing Hokkaido",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "洞爺湖",
+      "name_en": "Lake Toya",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "羊蹄山",
+      "name_en": "Mt. Yotei",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/toyama-marathon-2026.json
+++ b/src/data/races/toyama-marathon-2026.json
@@ -113,12 +113,35 @@
       "label_en": "General Entry"
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "立山連峰",
+  "motif_color": "#1e3a8a",
+  "motif_romaji": "Tateyama-Rempo",
+  "tagline_ja": "立山連峰と富山湾を望む、360度の絶景コース",
+  "tagline_en": "Run with panoramic views of the Tateyama Range and Toyama Bay",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "立山連峰",
+      "name_en": "Tateyama Mountains",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "新湊大橋",
+      "name_en": "Shinminato Bridge",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "富山湾",
+      "name_en": "Toyama Bay",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/tsukuba-marathon-2026.json
+++ b/src/data/races/tsukuba-marathon-2026.json
@@ -95,12 +95,23 @@
     "detail_level": "medium"
   },
   "entry_periods": [],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "筑波山",
+  "motif_color": "#374151",
+  "motif_romaji": "Tsukuba-san",
+  "tagline_ja": "西の富士、東の筑波。科学の街を快走する",
+  "tagline_en": "Run through the science city with Mt. Tsukuba as your landmark",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "筑波研究学園都市",
+      "name_en": "Tsukuba Science City",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/wakkanai-peace-marathon-2026.json
+++ b/src/data/races/wakkanai-peace-marathon-2026.json
@@ -114,12 +114,35 @@
       "label_en": ""
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "宗谷岬",
+  "motif_color": "#0c4a6e",
+  "motif_romaji": "Soya-Misaki",
+  "tagline_ja": "日本最北端・宗谷岬を目指す平和の42km",
+  "tagline_en": "Run toward Cape Soya, Japan's northernmost point",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "稚内港北防波堤ドーム",
+      "name_en": "Wakkanai Port Northern Breakwater Dome",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "日本海",
+      "name_en": "Sea of Japan",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "宗谷岬方面の眺望",
+      "name_en": "views toward Cape Soya",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/data/races/yokohama-marathon-2026.json
+++ b/src/data/races/yokohama-marathon-2026.json
@@ -114,12 +114,41 @@
       "entry_fee": null
     }
   ],
-  "motif": null,
-  "motif_color": null,
-  "motif_romaji": null,
-  "tagline_ja": null,
-  "tagline_en": null,
+  "motif": "港",
+  "motif_color": "#0e4f8a",
+  "motif_romaji": "Minato",
+  "tagline_ja": "開港の街・横浜の海と丘を駆け抜ける",
+  "tagline_en": "Run through Yokohama's historic port city of sea and hills",
   "hero_image_url": null,
   "hero_caption_ja": null,
-  "hero_caption_en": null
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [
+    {
+      "name_ja": "みなとみらい",
+      "name_en": "Minato Mirai",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "赤レンガ倉庫",
+      "name_en": "Red Brick Warehouse",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "首都高速湾岸線",
+      "name_en": "Bayshore Expressway",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "山下公園",
+      "name_en": "Yamashita Park",
+      "description_ja": null,
+      "description_en": null
+    }
+  ]
 }

--- a/src/lib/__tests__/fixtures.ts
+++ b/src/lib/__tests__/fixtures.ts
@@ -51,7 +51,6 @@ export function makeRace(overrides: Partial<Race> = {}): Race {
     gallery: [],
     voices: [],
     time_buckets: [],
-    course_highlights: [],
     motif: null,
     motif_color: null,
     motif_romaji: null,
@@ -68,6 +67,7 @@ export function makeRace(overrides: Partial<Race> = {}): Race {
 
 export function makeCategory(overrides: Partial<RaceCategory> = {}): RaceCategory {
   return {
+    id: 1,
     distance_type: 'full',
     distance_km: 42.195,
     time_limit_minutes: 360,
@@ -83,6 +83,7 @@ export function makeCategory(overrides: Partial<RaceCategory> = {}): RaceCategor
     eligibility_en: null,
     course_gpx_file: null,
     waves: null,
+    course_highlights: [],
     ...overrides,
   };
 }
@@ -151,6 +152,7 @@ export function makeCourseHighlight(overrides: Partial<RaceCourseHighlight> = {}
   return {
     id: 1,
     race_id: 'test-race-2026',
+    category_id: null,
     km: 21.0,
     name_ja: '折り返し地点',
     name_en: 'Turnaround Point',

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -30,7 +30,7 @@ type NearbySpotRow = typeof schema.nearby_spots.$inferSelect;
 type WeatherRow = typeof schema.weather_history.$inferSelect;
 type GiftRow = typeof schema.participation_gifts.$inferSelect;
 
-function rowToCategory(row: CategoryRow): RaceCategory {
+function rowToCategory(row: CategoryRow, highlights: CourseHighlightRow[] = []): RaceCategory {
   return {
     id: row.id,
     distance_type: row.distance_type as RaceCategory["distance_type"],
@@ -48,6 +48,7 @@ function rowToCategory(row: CategoryRow): RaceCategory {
     eligibility_en: row.eligibility_en ?? null,
     course_gpx_file: row.course_gpx_file ?? null,
     waves: parseJson<Wave[] | null>(row.waves, null),
+    course_highlights: highlights.map(rowToCourseHighlight),
   };
 }
 
@@ -201,6 +202,7 @@ function rowToCourseHighlight(row: CourseHighlightRow): RaceCourseHighlight {
   return {
     id: row.id,
     race_id: row.race_id,
+    category_id: row.category_id ?? null,
     km: row.km,
     name_ja: row.name_ja,
     name_en: row.name_en ?? null,
@@ -265,7 +267,18 @@ function assembleRace(
     tags: parseJson<string[]>(row.tags, []),
     course_gpx_file: row.course_gpx_file ?? null,
     course_info,
-    categories: categories.map(rowToCategory),
+    categories: (() => {
+      // category_id 指定あり → そのカテゴリへ、null → メインカテゴリ（先頭）へ振り分け
+      const mainCatId = categories.length > 0 ? categories[0].id : null;
+      const byCat = new Map<number, CourseHighlightRow[]>();
+      for (const h of courseHighlightRows) {
+        const targetId = h.category_id ?? mainCatId;
+        if (targetId == null) continue;
+        if (!byCat.has(targetId)) byCat.set(targetId, []);
+        byCat.get(targetId)!.push(h);
+      }
+      return categories.map(row => rowToCategory(row, byCat.get(row.id) ?? []));
+    })(),
     aid_stations: aidStations.map(rowToAidStation),
     checkpoints: checkpointRows.map(rowToCheckpoint),
     access_points: accessPointRows.map(rowToAccessPoint),
@@ -278,7 +291,6 @@ function assembleRace(
     gallery:           galleryRows.map(rowToGallery),
     voices:            voiceRows.map(rowToVoice),
     time_buckets:      timeBucketRows.map(rowToTimeBucket),
-    course_highlights: courseHighlightRows.map(rowToCourseHighlight),
     motif:           row.motif ?? null,
     motif_color:     row.motif_color ?? null,
     motif_romaji:    row.motif_romaji ?? null,
@@ -555,6 +567,28 @@ export async function getAdminRaces(): Promise<{ id: string; name_ja: string; da
     .from(schema.races)
     .orderBy(asc(schema.races.date));
   return rows;
+}
+
+/** 全登録大会数 */
+export async function getTotalRaceCount(): Promise<number> {
+  const db = getDatabase();
+  const rows = await db.select({ count: sql<number>`count(*)` }).from(schema.races);
+  return rows[0]?.count ?? 0;
+}
+
+/** 現在エントリー受付中の大会数 */
+export async function getOpenEntryCount(): Promise<number> {
+  const db = getDatabase();
+  const today = new Date().toISOString().split("T")[0];
+  const rows = await db.select({ count: sql<number>`count(*)` }).from(schema.races).where(
+    sql`EXISTS (
+      SELECT 1 FROM race_entry_periods rep
+      WHERE rep.race_id = ${schema.races.id}
+        AND rep.start_date <= ${today}
+        AND rep.end_date >= ${today}
+    )`
+  );
+  return rows[0]?.count ?? 0;
 }
 
 export async function getGiftCategoryById(id: string): Promise<GiftCategory | null> {

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -407,14 +407,15 @@ export const race_time_buckets = sqliteTable("race_time_buckets", {
 // ==================
 
 export const race_course_highlights = sqliteTable("race_course_highlights", {
-  id:         integer("id").primaryKey({ autoIncrement: true }),
-  race_id:    text("race_id").notNull().references(() => races.id, { onDelete: "cascade" }),
-  km:         real("km").notNull(),
-  name_ja:    text("name_ja").notNull(),
-  name_en:    text("name_en"),
-  note_ja:    text("note_ja"),
-  note_en:    text("note_en"),
-  sort_order: integer("sort_order").notNull().default(0),
+  id:          integer("id").primaryKey({ autoIncrement: true }),
+  race_id:     text("race_id").notNull().references(() => races.id, { onDelete: "cascade" }),
+  category_id: integer("category_id").references(() => race_categories.id, { onDelete: "cascade" }),
+  km:          real("km"),
+  name_ja:     text("name_ja").notNull(),
+  name_en:     text("name_en"),
+  note_ja:     text("note_ja"),
+  note_en:     text("note_en"),
+  sort_order:  integer("sort_order").notNull().default(0),
 }, (t) => [
   index("race_course_highlights_race_id_idx").on(t.race_id),
 ]);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -52,7 +52,6 @@ export interface Race {
   gallery: RaceGallery[];
   voices: RaceVoice[];
   time_buckets: RaceTimeBucket[];
-  course_highlights: RaceCourseHighlight[];
   // Phase 2: ビジュアル拡張フィールド
   motif: string | null;
   motif_color: string | null;
@@ -105,6 +104,7 @@ export interface RaceCategory {
   eligibility_en: string | null;
   course_gpx_file: string | null;
   waves: Wave[] | null;
+  course_highlights: RaceCourseHighlight[];
 }
 
 // ==================
@@ -297,7 +297,8 @@ export interface RaceTimeBucket {
 export interface RaceCourseHighlight {
   id: number;
   race_id: string;
-  km: number;
+  category_id: number | null;
+  km: number | null;
   name_ja: string;
   name_en: string | null;
   note_ja: string | null;

--- a/tools/admin/app.js
+++ b/tools/admin/app.js
@@ -211,11 +211,10 @@ function populateForm(r) {
   setVal('f-hero_caption_ja', r.hero_caption_ja ?? '');
   setVal('f-hero_caption_en', r.hero_caption_en ?? '');
 
-  // Phase 3: ギャラリー / 声 / タイム分布 / コース見どころ
+  // Phase 3: ギャラリー / 声 / タイム分布
   renderGallery(r.gallery ?? []);
   renderVoices(r.voices ?? []);
   renderTimeBuckets(r.time_buckets ?? []);
-  renderCourseHighlights(r.course_highlights ?? []);
 
   // 画像
   loadImagePreview(r.id);
@@ -298,16 +297,10 @@ function collectTimeBuckets() {
 }
 document.getElementById('btn-add-time-bucket').addEventListener('click', () => addTimeBucketRow());
 
-// ── コース見どころ ───────────────────────────────────────────────
-function renderCourseHighlights(items) {
-  const c = document.getElementById('course-highlights-container');
-  c.innerHTML = '';
-  items.forEach(ch => addCourseHighlightRow(ch));
-}
-function addCourseHighlightRow(ch = {}) {
-  const c = document.getElementById('course-highlights-container');
+// ── カテゴリ内コース見どころ ─────────────────────────────────────
+function addHighlightRowToContainer(container, ch = {}) {
   const row = document.createElement('div');
-  row.className = 'dynamic-row';
+  row.className = 'dynamic-row ch-row';
   row.innerHTML = `
     <input type="number" class="ch-km" placeholder="地点(km)" step="0.1" min="0" value="${ch.km ?? ''}" />
     <input type="text" class="ch-name-ja" placeholder="スポット名（日本語）" value="${(ch.name_ja ?? '').replace(/"/g, '&quot;')}" />
@@ -316,18 +309,17 @@ function addCourseHighlightRow(ch = {}) {
     <input type="text" class="ch-note-en" placeholder="Note (English)" value="${(ch.note_en ?? '').replace(/"/g, '&quot;')}" />
     <button type="button" class="btn-remove" title="削除">×</button>`;
   row.querySelector('.btn-remove').addEventListener('click', () => row.remove());
-  c.appendChild(row);
+  container.appendChild(row);
 }
-function collectCourseHighlights() {
-  return [...document.querySelectorAll('#course-highlights-container .dynamic-row')].map(row => ({
-    km: parseFloat(row.querySelector('.ch-km').value) || 0,
+function collectCategoryHighlights(catRow) {
+  return [...catRow.querySelectorAll('.cat-highlights-container .ch-row')].map(row => ({
+    km: parseFloat(row.querySelector('.ch-km').value) || null,
     name_ja: row.querySelector('.ch-name-ja').value.trim(),
     name_en: row.querySelector('.ch-name-en').value.trim() || null,
     note_ja: row.querySelector('.ch-note-ja').value.trim() || null,
     note_en: row.querySelector('.ch-note-en').value.trim() || null,
   })).filter(ch => ch.name_ja);
 }
-document.getElementById('btn-add-course-highlight').addEventListener('click', () => addCourseHighlightRow());
 
 function setVal(id, val) {
   const el = document.getElementById(id);
@@ -516,12 +508,23 @@ function addCategoryRow(cat = {}, index) {
       <input type="text" class="cat-gpx-file" value="${(cat.course_gpx_file ?? '').replace(/"/g, '&quot;')}" placeholder="例: nagano-marathon-2026-full.gpx" />
       <p class="field-hint">ファイルは <code>public/gpx/</code> に配置し、保存後に <code>npm run course:generate</code> を実行してください。</p>
     </div>
+    <div class="field full">
+      <label>コース見どころ</label>
+      <div class="cat-highlights-container"></div>
+      <button type="button" class="btn btn-secondary btn-add-highlight">+ 見どころを追加</button>
+    </div>
   `;
   row.querySelector('.btn-remove-cat').addEventListener('click', () => {
     row.remove();
     markDirty();
   });
   row.querySelectorAll('input, select, textarea').forEach(el => el.addEventListener('change', markDirty));
+  const highlightsContainer = row.querySelector('.cat-highlights-container');
+  (cat.course_highlights ?? []).forEach(ch => addHighlightRowToContainer(highlightsContainer, ch));
+  row.querySelector('.btn-add-highlight').addEventListener('click', () => {
+    addHighlightRowToContainer(highlightsContainer);
+    markDirty();
+  });
   container.appendChild(row);
 }
 
@@ -883,6 +886,7 @@ function buildRaceData() {
     eligibility_ja: row.querySelector('.cat-eligibility-ja')?.value.trim() || null,
     eligibility_en: row.querySelector('.cat-eligibility-en')?.value.trim() || null,
     course_gpx_file: row.querySelector('.cat-gpx-file')?.value.trim() || null,
+    course_highlights: collectCategoryHighlights(row),
   }));
 
   // タグ収集
@@ -892,8 +896,10 @@ function buildRaceData() {
   const entryPeriods = collectEntryPeriods();
   const firstPeriod = entryPeriods[0] ?? null;
 
+  // eslint-disable-next-line no-unused-vars
+  const { course_highlights: _raceHighlights, ...restCurrentRace } = currentRace ?? {};
   return {
-    ...currentRace,
+    ...restCurrentRace,
     entry_fee: null,
     entry_fee_by_category: true,
     name_ja: getVal('f-name_ja'),
@@ -935,7 +941,6 @@ function buildRaceData() {
     gallery: collectGallery(),
     voices: collectVoices(),
     time_buckets: collectTimeBuckets(),
-    course_highlights: collectCourseHighlights(),
   };
 }
 

--- a/tools/admin/index.html
+++ b/tools/admin/index.html
@@ -169,8 +169,9 @@
                 <label>受付方法</label>
                 <select id="f-reception_type">
                   <option value="pre_day">前日受付</option>
-                  <option value="same_day">当日受付</option>
-                  <option value="mail">郵送</option>
+                  <option value="race_day">当日受付</option>
+                  <option value="both">前日・当日受付</option>
+                  <option value="pre_mail">郵送受付</option>
                   <option value="none">なし</option>
                 </select>
               </div>
@@ -304,13 +305,6 @@
             <h2 class="section-title">タイム分布</h2>
             <div id="time-buckets-container"></div>
             <button type="button" class="btn btn-secondary" id="btn-add-time-bucket">+ バケットを追加</button>
-          </section>
-
-          <!-- コース見どころ (Phase 3) -->
-          <section class="form-section">
-            <h2 class="section-title">コース見どころ</h2>
-            <div id="course-highlights-container"></div>
-            <button type="button" class="btn btn-secondary" id="btn-add-course-highlight">+ 見どころを追加</button>
           </section>
 
         </div><!-- /form-body -->


### PR DESCRIPTION
## 概要

Phase 2/3 フィールドのデータ充填に加え、詳細ページのデザイン刷新・各種UX改善を含む。

## スキーマ・データ構造

- `race_course_highlights.km` を nullable 化（マイグレーション 0006）
- `race_course_highlights` に `category_id` FK を追加（マイグレーション 0007）
- `RaceCategory` に `course_highlights` を追加、`Race` から削除（カテゴリ別ハイライト構造）
- `reception_type` の旧値 (`mail` / `same_day`) を正規値 (`pre_mail` / `race_day`) に一括修正（16件）

## 大会詳細ページ

- `DetailHeader` 全面刷新（モチーフバッジ縦書き・版次表示・メタ行）
- セクション番号化 (01–10)・`SectionHeading` コンポーネント
- Section 01: スタットグリッド（Distance / Time Limit / Capacity / Fee / Elevation）
- Section 02: コース地図とハイライトの横並びレイアウト（`CourseProfileSection` に `sidebarContent` prop 追加）
- `EntrySection` に受付方法・受付メモ表示を追加
- アンカーリンクに `scroll-margin-top` を追加・`last-edition` / `gallery` セクションに `id` 属性を追加
- `RaceBreadcrumb` / `RaceRegistrationButtons` の文字色をクリーム背景向けに修正

## ホームページ

- 掲載大会数を DB 総登録件数に変更（`getTotalRaceCount()`）
- 受付中大会数を統計に追加（`getOpenEntryCount()`）

## カレンダー

- 年間ビュー: 選択月-2 から12ヶ月ウィンドウ表示（年またぎ対応）
- 今月に戻るボタンを追加（現在月以外の時のみ表示）

## 管理ツール

- `course_highlights` 入力をカテゴリ別に変更
- `reception_type` 選択肢を正規値に修正・`both`（前日・当日受付）を追加

## テスト

- `fixtures.ts`: `makeRace` / `makeCategory` / `makeCourseHighlight` を新スキーマに合わせて更新
- `DetailHeader.test.tsx`: ヒーロー画像テスト削除・メタ行テスト追加

## Checklist

- [x] ビルド成功 (`npm run build`)
- [x] ローカル DB シード適用済み (`npm run db:seed-races:local`)
- [x] マイグレーション適用済み (`npm run db:migrate:local`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)