### PR TITLE
feat: モチーフバッジの文字色を背景色から自動算出

### DIFF
--- a/src/components/races/detail/DetailHeader.tsx
+++ b/src/components/races/detail/DetailHeader.tsx
@@ -1,5 +1,5 @@
 import type { Race, Locale } from '@/lib/types';
-import { getMainCategory, getRaceCity, formatDate } from '@/lib/utils';
+import { getMainCategory, getRaceCity, formatDate, getContrastColor } from '@/lib/utils';
 
 interface DetailHeaderProps {
   race: Race;
@@ -26,6 +26,7 @@ export default function DetailHeader({ race, locale, raceName, isEntryOpen, isNo
   const taglineJa = race.tagline_ja;
   const taglineEn = race.tagline_en;
   const motifBg = race.motif_color ?? 'var(--color-ink)';
+  const motifTextColor = race.motif_color ? getContrastColor(race.motif_color) : '#ffffff';
   const mainCat = getMainCategory(race.categories);
   const startTime = mainCat?.start_time;
   const city = getRaceCity(race, locale);
@@ -99,19 +100,21 @@ export default function DetailHeader({ race, locale, raceName, isEntryOpen, isNo
               }}
             >
               <p
-                className="font-serif text-white text-center"
+                className="font-serif text-center"
                 style={{
                   fontSize: '2.1rem',
                   letterSpacing: '0.15em',
                   fontFamily: 'var(--font-noto-serif-jp)',
                   writingMode: 'vertical-rl',
                   textOrientation: 'upright',
+                  color: motifTextColor,
                 }}
               >
                 {race.motif}
               </p>
               <p
-                className="text-[0.42rem] tracking-[0.22em] uppercase text-white/50 text-center"
+                className="text-[0.42rem] tracking-[0.22em] uppercase text-center"
+                style={{ color: motifTextColor, opacity: 0.5 }}
               >
                 {race.motif_romaji ?? ''}
               </p>

--- a/src/data/races/tokyo-legacy-half-2026.json
+++ b/src/data/races/tokyo-legacy-half-2026.json
@@ -1,0 +1,98 @@
+{
+  "id": "tokyo-legacy-half-2026",
+  "name_ja": "東京レガシーハーフマラソン",
+  "name_en": "Tokyo Legacy Half ",
+  "full_name_ja": "東京レガシーハーフマラソン2026",
+  "full_name_en": "Tokyo Legacy Half 2026",
+  "edition": null,
+  "date": "2026-10-18",
+  "prefecture": "13",
+  "city_ja": "新宿区霞ヶ丘町",
+  "city_en": "Kasumigaoka-cho, Shinjuku Ward",
+  "description_ja": "",
+  "description_en": "",
+  "official_url": "https://legacyhalf.tokyo/",
+  "entry_fee": null,
+  "entry_fee_by_category": true,
+  "entry_capacity": 0,
+  "entry_start_date": "2026-05-18",
+  "entry_end_date": "2026-05-25",
+  "reception_type": "pre_day",
+  "reception_note_ja": "期間\n2026年10月16日(金)　11時00分～20時30分\n2026年10月17日(土)　10時00分～19時30分\n※ 上記受付期間内に、必ずランナー本人が受付を行ってください。\n※ 大会当日【10月18日(日)】は、ランナー受付を行いません。\n会場\nMUFGスタジアム(国立競技場)：東京都新宿区霞ヶ丘町10-1",
+  "reception_note_en": "Dates and Times\nFriday, October 16, 2026: 11:00 AM – 8:30 PM\nSaturday, October 17, 2026: 10:00 AM – 7:30 PM\n* Runners must check in in person during the above registration period.\n* There will be no runner registration on the day of the event [Sunday, October 18].\nVenue\nMUFG Stadium (National Stadium): 10-1 Kasumigaoka-cho, Shinjuku-ku, Tokyo",
+  "tags": [],
+  "course_gpx_file": null,
+  "course_info": {
+    "max_elevation_m": null,
+    "min_elevation_m": null,
+    "elevation_diff_m": null,
+    "surface": "road",
+    "certification": [],
+    "highlights_ja": "",
+    "highlights_en": "",
+    "notes_ja": "",
+    "notes_en": ""
+  },
+  "categories": [
+    {
+      "distance_type": "half",
+      "distance_km": 21.0975,
+      "entry_fee": 13200,
+      "capacity": 18000,
+      "time_limit_minutes": 180,
+      "start_time": "08:05",
+      "name_ja": null,
+      "eligibility_ja": "大会当日満18歳以上で以下の条件にあてはまる者で、主催者が出場を認めた者。\n※主催者が実施するイベント等による出走権付与者を含みます。\n一般の部：2時間40分以内に完走できる男子・女子・ノンバイナリー。\n障がい者の部：2時間40分以内に完走できる男子・女子・ノンバイナリー。\n※ 障がいのある方で単独走行が困難な方はガイドランナーを1名つけることができます。(盲導犬等の伴走は不可とします。)\n障がい者(車いす)の部：レース仕様車でハーフマラソンを1時間40分以内に完走できる男子・女子・ノンバイナリー。\n学生チームの部：2時間40分以内に完走できる学生(国内のみ)。\n※ 1チーム7名～10名とします。\n※ ランナー受付時に学生証の提示が必須となります。\n※ 障がいのある方で単独走行が困難な方はガイドランナーを1名つけることができます。(盲導犬等の伴走は不可とします。)\n準エリートの部\n国内\n2026年度日本陸上競技連盟登録競技者である男子・女子。\n2024年5月1日から2026年4月30日までの公認記録またはワールドアスレティックスラベルロードレース公式記録で下記参加基準に達する男子・女子。\n　　男子：ハーフマラソン1時間14分00秒以内\n　　女子：ハーフマラソン1時間40分00秒以内\n海外\n2024年5月1日から2026年4月30日までのワールドアスレティックスラベルロードレース公式記録で下記参加基準に達する男子・女子。\n　　男子：ハーフマラソン1時間14分00秒以内\n　　女子：ハーフマラソン1時間40分00秒以内\n※ 障がいのある方で単独走行が困難な方はガイドランナーを1名つけることができます。(盲導犬等の伴走は不可とします。)\nエリートの部\n2026年度日本陸上競技連盟登録競技者で、別途定める参加基準に達する男子・女子。\n招待選手(主催者または日本陸上競技連盟が推薦する国内・海外の男子・女子)。\nパラアスリートの部\n2026年度日本パラスポーツ協会に加盟するパラ陸上競技団体登録競技者で、大会当日までに有効な競技クラスを有し、別途定める参加基準に達する男子・女子。\n招待選手(主催者または日本パラスポーツ協会に加盟するパラ陸上競技団体が推薦する国内・海外の男子・女子)。\n実施クラス：\n①視覚障がいT11/T12、上肢障がいT45/T46、車いすT53/T54\n②上記以外でIPC(国際パラリンピック委員会)のカテゴリーにあるすべてのクラス",
+      "eligibility_en": "Participants must be at least 18 years of age on the day of the event, meet the following criteria, and have been approved by the organizers.\n*This includes individuals who have been granted entry through events organized by the organizers.\nGeneral Division: Men, women, and non-binary individuals capable of completing the race within 2 hours and 40 minutes.\nDisabled Division: Men, women, and non-binary individuals capable of completing the race within 2 hours and 40 minutes.\n* Participants with disabilities who have difficulty running independently may be accompanied by one guide runner. (Assistance from guide dogs or similar animals is not permitted.)\nDisabled (Wheelchair) Division: Men, women, and non-binary individuals who can complete the half marathon in a race-spec wheelchair within 1 hour and 40 minutes.\nStudent Team Division: Students (domestic only) who can complete the race within 2 hours and 40 minutes.\n* Teams must consist of 7 to 10 members.\n* A student ID must be presented at runner registration.\n* Participants with disabilities who have difficulty running independently may be accompanied by one guide runner. (Guide dogs and other assistance animals are not permitted.)\nSemi-Elite Division* Participants with disabilities who have difficulty running independently may be accompanied by one guide runner. (Guide dogs and other assistance animals are not permitted.)\nDomestic\nMen and women registered with the Japan Association of Athletics Federations for the 2026 season.\nMen and women who meet the following participation criteria based on certified records or official World Athletics Label Road Race records from May 1, 2024, to April 30, 2026.\n　　Men: Half marathon in 1 hour 14 minutes 00 seconds or less\n　　Women: Half marathon in 1 hour 40 minutes 00 seconds or less\nInternational\nMen and women who meet the following participation standards based on official World Athletics Label Road Race records from May 1, 2024, to April 30, 2026.\n　　Men: Half marathon in 1 hour 14 minutes 00 seconds or faster\n　　Women: Half marathon in 1 hour 40 minutes 00 seconds or faster\nElite Division\nMen and women who are registered athletes with the Japan Association of Athletics Federations for the 2026 season and meet the separately specified participation criteria.\nInvited Athletes (men and women from Japan and overseas recommended by the organizer or the Japan Association of Athletics Federations).\nPara-Athletes Division\nMen and women who are registered athletes with a para-athletics organization affiliated with the Japan Para Sports Association for the 2026 season, hold a valid competition class by the day of the event, and meet the separately specified participation criteria.\nInvited Athletes (men and women from Japan and overseas recommended by the organizer or a para-athletics organization affiliated with the Japan Para Sports Association).\nCompetition Classes:\n① Visual Impairment T11/T12, Upper Limb Impairment T45/T46, Wheelchair T53/T54\n② All classes falling under the IPC (International Paralympic Committee) categories other than those listed above\n\nTranslated with DeepL.com (free version)",
+      "course_gpx_file": null,
+      "course_highlights": []
+    }
+  ],
+  "aid_stations": [],
+  "checkpoints": [],
+  "access_points": [],
+  "nearby_spots": [],
+  "result": null,
+  "created_at": "2026-05-14T14:47:07.523Z",
+  "updated_at": "2026-05-14T14:47:07.523Z",
+  "entry_periods": [
+    {
+      "start_date": "2026-05-18",
+      "end_date": "2026-05-25",
+      "entry_fee": null,
+      "label_ja": "ジャパンプレミアハーフ優先エントリー",
+      "label_en": ""
+    },
+    {
+      "start_date": "2026-05-26",
+      "end_date": "2026-06-09",
+      "entry_fee": null,
+      "label_ja": "一般エントリー",
+      "label_en": ""
+    }
+  ],
+  "entry_closed": false,
+  "entry_links": [],
+  "participation_gifts": [
+    {
+      "gift_categories": [
+        "medal",
+        "goods"
+      ],
+      "description_ja": "",
+      "description_en": "",
+      "image": null
+    }
+  ],
+  "motif": "遺産",
+  "motif_romaji": "Legacy",
+  "motif_color": "#F8F8FF",
+  "tagline_ja": "感動や文化を次世代へ引き継ぐ",
+  "tagline_en": "Passing on inspiration and culture to the next generation",
+  "hero_image_url": null,
+  "hero_caption_ja": null,
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": []
+}

--- a/src/lib/__tests__/utils.format.test.ts
+++ b/src/lib/__tests__/utils.format.test.ts
@@ -15,6 +15,7 @@ import {
   filterToSearchParams,
   searchParamsToFilter,
   emptyFilter,
+  getContrastColor,
 } from '../utils';
 import { makeRace, makeCategory } from './fixtures';
 
@@ -294,5 +295,35 @@ describe('searchParamsToFilter', () => {
     const filter = searchParamsToFilter({ month: '4', pref: '01' });
     expect(filter.month).toBe(4);
     expect(filter.prefecture).toBe('01');
+  });
+});
+
+describe('getContrastColor', () => {
+  it('明るい背景（#F8F8FF）は暗色テキストを返す', () => {
+    expect(getContrastColor('#F8F8FF')).toBe('#1a1a1a');
+  });
+
+  it('暗い背景（#1a1a1a）は白テキストを返す', () => {
+    expect(getContrastColor('#1a1a1a')).toBe('#ffffff');
+  });
+
+  it('黒（#000000）は白テキストを返す', () => {
+    expect(getContrastColor('#000000')).toBe('#ffffff');
+  });
+
+  it('白（#ffffff）は暗色テキストを返す', () => {
+    expect(getContrastColor('#ffffff')).toBe('#1a1a1a');
+  });
+
+  it('中間色（#808080）は暗色テキストを返す', () => {
+    expect(getContrastColor('#808080')).toBe('#1a1a1a');
+  });
+
+  it('3桁表記（#FFF）も正しく処理される', () => {
+    expect(getContrastColor('#FFF')).toBe('#1a1a1a');
+  });
+
+  it('不正な値は白テキストにフォールバックする', () => {
+    expect(getContrastColor('#ZZZZZZ')).toBe('#ffffff');
   });
 });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -369,3 +369,37 @@ export function searchParamsToFilter(params: URLSearchParams | Record<string, st
 export function cn(...classes: (string | undefined | false | null)[]): string {
   return classes.filter(Boolean).join(' ');
 }
+
+// ==================
+// Color contrast
+// ==================
+
+/**
+ * 16進数カラーコードに対して読みやすいテキスト色（白 or 暗色）を返す。
+ * WCAG 2.1 相対輝度を使って判定する。
+ * @param hex - "#RRGGBB" または "#RGB" 形式
+ * @returns 背景が暗い → "#ffffff"、背景が明るい → "#1a1a1a"
+ */
+export function getContrastColor(hex: string): string {
+  const clean = hex.replace('#', '');
+  const full = clean.length === 3
+    ? clean.split('').map((c) => c + c).join('')
+    : clean;
+
+  const r = parseInt(full.slice(0, 2), 16);
+  const g = parseInt(full.slice(2, 4), 16);
+  const b = parseInt(full.slice(4, 6), 16);
+
+  if (isNaN(r) || isNaN(g) || isNaN(b)) return '#ffffff';
+
+  // sRGB → 線形輝度（WCAG 2.1）
+  const toLinear = (v: number) => {
+    const s = v / 255;
+    return s <= 0.04045 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+
+  const L = 0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b);
+
+  // 輝度 0.179 を閾値に（白との対比比率 ~4.5:1 相当）
+  return L > 0.179 ? '#1a1a1a' : '#ffffff';
+}


### PR DESCRIPTION
## Summary

- モチーフカラーが明るい色（`#F8F8FF` 等）のとき、文字色がハードコード `white` のままで読めない問題を修正
- WCAG 2.1 相対輝度に基づく `getContrastColor()` を `utils.ts` に追加
- `DetailHeader.tsx` のモチーフテキスト色を `text-white` ハードコード → `motifTextColor` 変数に変更

## 動作

| motif_color | テキスト色 |
|---|---|
| 暗い色 (`#c0392b`, `#1a1a1a` 等) | `#ffffff` (白) |
| 明るい色 (`#F8F8FF`, `#ffffff` 等) | `#1a1a1a` (暗色) |
| `null` (デフォルト `var(--color-ink)`) | `#ffffff` (白) |

## Test plan

- [ ] `npx vitest run src/lib/__tests__/utils.format.test.ts` でテスト (7ケース) がパスすること
- [ ] 東京レガシーハーフ（`motif_color: "#F8F8FF"`）でモチーフ文字が黒で読めること
- [ ] 既存の暗色モチーフ大会でモチーフ文字が白のままであること

🤖 Generated with [Claude Code](https://claude.com/claude-code)