### PR TITLE
fix: race_course_highlights FK修正・シード順序修正・新レース追加

### DIFF
--- a/docs/er-diagram.drawio
+++ b/docs/er-diagram.drawio
@@ -1,13 +1,13 @@
 <mxfile host="app.diagrams.net" version="24.0.0">
   <diagram name="KroteRun ER図" id="er-diagram">
-    <mxGraphModel dx="1422" dy="762" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1654" pageHeight="1169" math="0" shadow="0">
+    <mxGraphModel dx="1422" dy="762" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1860" pageHeight="2300" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
 
         <!-- ===== races ===== -->
         <mxCell id="races_title" value="races" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;fontSize=14;fillColor=#dae8fc;strokeColor=#6c8ebf;" vertex="1" parent="1">
-          <mxGeometry x="560" y="40" width="300" height="570" as="geometry" />
+          <mxGeometry x="560" y="40" width="300" height="900" as="geometry" />
         </mxCell>
         <mxCell id="races_r0" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=1;" vertex="1" parent="races_title">
           <mxGeometry y="30" width="300" height="30" as="geometry" />
@@ -18,318 +18,938 @@
         <mxCell id="races_r0_v" value="id (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r0">
           <mxGeometry x="40" width="260" height="30" as="geometry" />
         </mxCell>
-
         <mxCell id="races_r1" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="races_title">
           <mxGeometry y="60" width="300" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="races_r1_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r1">
+        <mxCell id="races_r1_k" value="FK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=2;overflow=hidden;" vertex="1" parent="races_r1">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="races_r1_v" value="name_ja (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r1">
+        <mxCell id="races_r1_v" value="series_id (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r1">
           <mxGeometry x="40" width="260" height="30" as="geometry" />
         </mxCell>
-
         <mxCell id="races_r2" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="races_title">
           <mxGeometry y="90" width="300" height="30" as="geometry" />
         </mxCell>
         <mxCell id="races_r2_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r2">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="races_r2_v" value="name_en (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r2">
+        <mxCell id="races_r2_v" value="name_ja (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r2">
           <mxGeometry x="40" width="260" height="30" as="geometry" />
         </mxCell>
-
         <mxCell id="races_r3" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="races_title">
           <mxGeometry y="120" width="300" height="30" as="geometry" />
         </mxCell>
         <mxCell id="races_r3_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r3">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="races_r3_v" value="date (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r3">
+        <mxCell id="races_r3_v" value="name_en (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r3">
           <mxGeometry x="40" width="260" height="30" as="geometry" />
         </mxCell>
-
         <mxCell id="races_r4" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="races_title">
           <mxGeometry y="150" width="300" height="30" as="geometry" />
         </mxCell>
         <mxCell id="races_r4_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r4">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="races_r4_v" value="prefecture (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r4">
+        <mxCell id="races_r4_v" value="full_name_ja / full_name_en (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r4">
           <mxGeometry x="40" width="260" height="30" as="geometry" />
         </mxCell>
-
         <mxCell id="races_r5" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="races_title">
           <mxGeometry y="180" width="300" height="30" as="geometry" />
         </mxCell>
         <mxCell id="races_r5_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r5">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="races_r5_v" value="city_ja / city_en (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r5">
+        <mxCell id="races_r5_v" value="edition (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r5">
           <mxGeometry x="40" width="260" height="30" as="geometry" />
         </mxCell>
-
         <mxCell id="races_r6" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="races_title">
           <mxGeometry y="210" width="300" height="30" as="geometry" />
         </mxCell>
         <mxCell id="races_r6_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r6">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="races_r6_v" value="description_ja / _en (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r6">
+        <mxCell id="races_r6_v" value="date (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r6">
           <mxGeometry x="40" width="260" height="30" as="geometry" />
         </mxCell>
-
         <mxCell id="races_r7" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="races_title">
           <mxGeometry y="240" width="300" height="30" as="geometry" />
         </mxCell>
         <mxCell id="races_r7_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r7">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="races_r7_v" value="official_url (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r7">
+        <mxCell id="races_r7_v" value="prefecture (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r7">
           <mxGeometry x="40" width="260" height="30" as="geometry" />
         </mxCell>
-
         <mxCell id="races_r8" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="races_title">
           <mxGeometry y="270" width="300" height="30" as="geometry" />
         </mxCell>
         <mxCell id="races_r8_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r8">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="races_r8_v" value="entry_fee (INT) / entry_capacity (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r8">
+        <mxCell id="races_r8_v" value="city_ja / city_en (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r8">
           <mxGeometry x="40" width="260" height="30" as="geometry" />
         </mxCell>
-
         <mxCell id="races_r9" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="races_title">
           <mxGeometry y="300" width="300" height="30" as="geometry" />
         </mxCell>
         <mxCell id="races_r9_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r9">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="races_r9_v" value="entry_start_date / end_date (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r9">
+        <mxCell id="races_r9_v" value="description_ja / _en (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r9">
           <mxGeometry x="40" width="260" height="30" as="geometry" />
         </mxCell>
-
         <mxCell id="races_r10" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="races_title">
           <mxGeometry y="330" width="300" height="30" as="geometry" />
         </mxCell>
         <mxCell id="races_r10_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r10">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="races_r10_v" value="reception_type (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r10">
+        <mxCell id="races_r10_v" value="official_url (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r10">
           <mxGeometry x="40" width="260" height="30" as="geometry" />
         </mxCell>
-
         <mxCell id="races_r11" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="races_title">
           <mxGeometry y="360" width="300" height="30" as="geometry" />
         </mxCell>
         <mxCell id="races_r11_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r11">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="races_r11_v" value="tags (TEXT/JSON)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r11">
+        <mxCell id="races_r11_v" value="entry_fee (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r11">
           <mxGeometry x="40" width="260" height="30" as="geometry" />
         </mxCell>
-
         <mxCell id="races_r12" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="races_title">
           <mxGeometry y="390" width="300" height="30" as="geometry" />
         </mxCell>
         <mxCell id="races_r12_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r12">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="races_r12_v" value="course_* (REAL/TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r12">
+        <mxCell id="races_r12_v" value="entry_fee_by_category (BOOL)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r12">
           <mxGeometry x="40" width="260" height="30" as="geometry" />
         </mxCell>
-
         <mxCell id="races_r13" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="races_title">
           <mxGeometry y="420" width="300" height="30" as="geometry" />
         </mxCell>
         <mxCell id="races_r13_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r13">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="races_r13_v" value="course_gpx_file (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r13">
+        <mxCell id="races_r13_v" value="entry_capacity (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r13">
           <mxGeometry x="40" width="260" height="30" as="geometry" />
         </mxCell>
-
         <mxCell id="races_r14" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="races_title">
           <mxGeometry y="450" width="300" height="30" as="geometry" />
         </mxCell>
         <mxCell id="races_r14_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r14">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="races_r14_v" value="created_at / updated_at (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r14">
+        <mxCell id="races_r14_v" value="entry_start_date / entry_end_date (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r14">
           <mxGeometry x="40" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r15" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="races_title">
+          <mxGeometry y="480" width="300" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r15_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r15">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r15_v" value="entry_closed (BOOL)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r15">
+          <mxGeometry x="40" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r16" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="races_title">
+          <mxGeometry y="510" width="300" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r16_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r16">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r16_v" value="reception_type (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r16">
+          <mxGeometry x="40" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r17" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="races_title">
+          <mxGeometry y="540" width="300" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r17_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r17">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r17_v" value="reception_note_ja / _en (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r17">
+          <mxGeometry x="40" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r18" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="races_title">
+          <mxGeometry y="570" width="300" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r18_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r18">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r18_v" value="tags (TEXT/JSON)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r18">
+          <mxGeometry x="40" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r19" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="races_title">
+          <mxGeometry y="600" width="300" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r19_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r19">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r19_v" value="course_gpx_file (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r19">
+          <mxGeometry x="40" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r20" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="races_title">
+          <mxGeometry y="630" width="300" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r20_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r20">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r20_v" value="course_max/min_elevation_m / diff (REAL)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r20">
+          <mxGeometry x="40" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r21" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="races_title">
+          <mxGeometry y="660" width="300" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r21_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r21">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r21_v" value="course_surface (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r21">
+          <mxGeometry x="40" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r22" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="races_title">
+          <mxGeometry y="690" width="300" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r22_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r22">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r22_v" value="course_certification (TEXT/JSON)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r22">
+          <mxGeometry x="40" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r23" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="races_title">
+          <mxGeometry y="720" width="300" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r23_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r23">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r23_v" value="course_highlights_ja / _en (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r23">
+          <mxGeometry x="40" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r24" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="races_title">
+          <mxGeometry y="750" width="300" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r24_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r24">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r24_v" value="course_notes_ja / _en (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r24">
+          <mxGeometry x="40" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r25" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="races_title">
+          <mxGeometry y="780" width="300" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r25_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r25">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r25_v" value="motif / motif_color / motif_romaji (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r25">
+          <mxGeometry x="40" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r26" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="races_title">
+          <mxGeometry y="810" width="300" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r26_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r26">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r26_v" value="tagline_ja / tagline_en (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r26">
+          <mxGeometry x="40" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r27" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="races_title">
+          <mxGeometry y="840" width="300" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r27_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r27">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r27_v" value="hero_image_url / hero_caption_ja / _en (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r27">
+          <mxGeometry x="40" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r28" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="races_title">
+          <mxGeometry y="870" width="300" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r28_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r28">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="races_r28_v" value="created_at / updated_at (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="races_r28">
+          <mxGeometry x="40" width="260" height="30" as="geometry" />
+        </mxCell>
+
+        <!-- ===== race_series ===== -->
+        <mxCell id="rseries_title" value="race_series" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;fontSize=14;fillColor=#dae8fc;strokeColor=#6c8ebf;" vertex="1" parent="1">
+          <mxGeometry x="40" y="40" width="260" height="150" as="geometry" />
+        </mxCell>
+        <mxCell id="rseries_r0" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=1;" vertex="1" parent="rseries_title">
+          <mxGeometry y="30" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rseries_r0_k" value="PK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=1;overflow=hidden;" vertex="1" parent="rseries_r0">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rseries_r0_v" value="id (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rseries_r0">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rseries_r1" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rseries_title">
+          <mxGeometry y="60" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rseries_r1_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rseries_r1">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rseries_r1_v" value="name_ja / name_en (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rseries_r1">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rseries_r2" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rseries_title">
+          <mxGeometry y="90" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rseries_r2_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rseries_r2">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rseries_r2_v" value="first_held_year (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rseries_r2">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rseries_r3" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rseries_title">
+          <mxGeometry y="120" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rseries_r3_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rseries_r3">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rseries_r3_v" value="website_url (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rseries_r3">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
         </mxCell>
 
         <!-- ===== race_categories ===== -->
         <mxCell id="rcat_title" value="race_categories" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;fontSize=14;fillColor=#d5e8d4;strokeColor=#82b366;" vertex="1" parent="1">
-          <mxGeometry x="60" y="40" width="280" height="300" as="geometry" />
+          <mxGeometry x="40" y="220" width="260" height="450" as="geometry" />
         </mxCell>
         <mxCell id="rcat_r0" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=1;" vertex="1" parent="rcat_title">
-          <mxGeometry y="30" width="280" height="30" as="geometry" />
+          <mxGeometry y="30" width="260" height="30" as="geometry" />
         </mxCell>
         <mxCell id="rcat_r0_k" value="PK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=1;overflow=hidden;" vertex="1" parent="rcat_r0">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
         <mxCell id="rcat_r0_v" value="id (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rcat_r0">
-          <mxGeometry x="40" width="240" height="30" as="geometry" />
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
         </mxCell>
         <mxCell id="rcat_r1" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rcat_title">
-          <mxGeometry y="60" width="280" height="30" as="geometry" />
+          <mxGeometry y="60" width="260" height="30" as="geometry" />
         </mxCell>
         <mxCell id="rcat_r1_k" value="FK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=2;overflow=hidden;" vertex="1" parent="rcat_r1">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
         <mxCell id="rcat_r1_v" value="race_id (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rcat_r1">
-          <mxGeometry x="40" width="240" height="30" as="geometry" />
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
         </mxCell>
         <mxCell id="rcat_r2" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rcat_title">
-          <mxGeometry y="90" width="280" height="30" as="geometry" />
+          <mxGeometry y="90" width="260" height="30" as="geometry" />
         </mxCell>
         <mxCell id="rcat_r2_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rcat_r2">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
         <mxCell id="rcat_r2_v" value="distance_type (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rcat_r2">
-          <mxGeometry x="40" width="240" height="30" as="geometry" />
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
         </mxCell>
         <mxCell id="rcat_r3" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rcat_title">
-          <mxGeometry y="120" width="280" height="30" as="geometry" />
+          <mxGeometry y="120" width="260" height="30" as="geometry" />
         </mxCell>
         <mxCell id="rcat_r3_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rcat_r3">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
         <mxCell id="rcat_r3_v" value="distance_km (REAL)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rcat_r3">
-          <mxGeometry x="40" width="240" height="30" as="geometry" />
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
         </mxCell>
         <mxCell id="rcat_r4" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rcat_title">
-          <mxGeometry y="150" width="280" height="30" as="geometry" />
+          <mxGeometry y="150" width="260" height="30" as="geometry" />
         </mxCell>
         <mxCell id="rcat_r4_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rcat_r4">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
         <mxCell id="rcat_r4_v" value="time_limit_minutes (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rcat_r4">
-          <mxGeometry x="40" width="240" height="30" as="geometry" />
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
         </mxCell>
         <mxCell id="rcat_r5" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rcat_title">
-          <mxGeometry y="180" width="280" height="30" as="geometry" />
+          <mxGeometry y="180" width="260" height="30" as="geometry" />
         </mxCell>
         <mxCell id="rcat_r5_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rcat_r5">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="rcat_r5_v" value="entry_fee / entry_fee_u25 (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rcat_r5">
-          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        <mxCell id="rcat_r5_v" value="start_time (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rcat_r5">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
         </mxCell>
         <mxCell id="rcat_r6" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rcat_title">
-          <mxGeometry y="210" width="280" height="30" as="geometry" />
+          <mxGeometry y="210" width="260" height="30" as="geometry" />
         </mxCell>
         <mxCell id="rcat_r6_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rcat_r6">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="rcat_r6_v" value="waves (TEXT/JSON)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rcat_r6">
-          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        <mxCell id="rcat_r6_v" value="capacity (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rcat_r6">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
         </mxCell>
         <mxCell id="rcat_r7" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rcat_title">
-          <mxGeometry y="240" width="280" height="30" as="geometry" />
+          <mxGeometry y="240" width="260" height="30" as="geometry" />
         </mxCell>
         <mxCell id="rcat_r7_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rcat_r7">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="rcat_r7_v" value="name_ja / name_en (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rcat_r7">
-          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        <mxCell id="rcat_r7_v" value="entry_fee / entry_fee_u25 (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rcat_r7">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rcat_r8" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rcat_title">
+          <mxGeometry y="270" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rcat_r8_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rcat_r8">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rcat_r8_v" value="name_ja / name_en (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rcat_r8">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rcat_r9" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rcat_title">
+          <mxGeometry y="300" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rcat_r9_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rcat_r9">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rcat_r9_v" value="description_ja / _en (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rcat_r9">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rcat_r10" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rcat_title">
+          <mxGeometry y="330" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rcat_r10_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rcat_r10">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rcat_r10_v" value="eligibility_ja / _en (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rcat_r10">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rcat_r11" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rcat_title">
+          <mxGeometry y="360" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rcat_r11_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rcat_r11">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rcat_r11_v" value="course_gpx_file (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rcat_r11">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rcat_r12" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rcat_title">
+          <mxGeometry y="390" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rcat_r12_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rcat_r12">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rcat_r12_v" value="waves (TEXT/JSON)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rcat_r12">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rcat_r13" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rcat_title">
+          <mxGeometry y="420" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rcat_r13_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rcat_r13">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rcat_r13_v" value="sort_order (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rcat_r13">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
         </mxCell>
 
         <!-- ===== aid_stations ===== -->
         <mxCell id="aid_title" value="aid_stations" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;fontSize=14;fillColor=#d5e8d4;strokeColor=#82b366;" vertex="1" parent="1">
-          <mxGeometry x="60" y="400" width="280" height="180" as="geometry" />
+          <mxGeometry x="40" y="700" width="260" height="180" as="geometry" />
         </mxCell>
         <mxCell id="aid_r0" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=1;" vertex="1" parent="aid_title">
-          <mxGeometry y="30" width="280" height="30" as="geometry" />
+          <mxGeometry y="30" width="260" height="30" as="geometry" />
         </mxCell>
         <mxCell id="aid_r0_k" value="PK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=1;overflow=hidden;" vertex="1" parent="aid_r0">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
         <mxCell id="aid_r0_v" value="id (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="aid_r0">
-          <mxGeometry x="40" width="240" height="30" as="geometry" />
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
         </mxCell>
         <mxCell id="aid_r1" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="aid_title">
-          <mxGeometry y="60" width="280" height="30" as="geometry" />
+          <mxGeometry y="60" width="260" height="30" as="geometry" />
         </mxCell>
         <mxCell id="aid_r1_k" value="FK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=2;overflow=hidden;" vertex="1" parent="aid_r1">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
         <mxCell id="aid_r1_v" value="race_id (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="aid_r1">
-          <mxGeometry x="40" width="240" height="30" as="geometry" />
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
         </mxCell>
         <mxCell id="aid_r2" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="aid_title">
-          <mxGeometry y="90" width="280" height="30" as="geometry" />
+          <mxGeometry y="90" width="260" height="30" as="geometry" />
         </mxCell>
         <mxCell id="aid_r2_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="aid_r2">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
         <mxCell id="aid_r2_v" value="distance_km (REAL)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="aid_r2">
-          <mxGeometry x="40" width="240" height="30" as="geometry" />
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
         </mxCell>
         <mxCell id="aid_r3" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="aid_title">
-          <mxGeometry y="120" width="280" height="30" as="geometry" />
+          <mxGeometry y="120" width="260" height="30" as="geometry" />
         </mxCell>
         <mxCell id="aid_r3_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="aid_r3">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
         <mxCell id="aid_r3_v" value="offerings_ja / _en (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="aid_r3">
-          <mxGeometry x="40" width="240" height="30" as="geometry" />
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
         </mxCell>
         <mxCell id="aid_r4" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="aid_title">
-          <mxGeometry y="150" width="280" height="30" as="geometry" />
+          <mxGeometry y="150" width="260" height="30" as="geometry" />
         </mxCell>
         <mxCell id="aid_r4_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="aid_r4">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
         <mxCell id="aid_r4_v" value="is_featured (BOOL)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="aid_r4">
-          <mxGeometry x="40" width="240" height="30" as="geometry" />
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
         </mxCell>
 
         <!-- ===== checkpoints ===== -->
         <mxCell id="chk_title" value="checkpoints" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;fontSize=14;fillColor=#d5e8d4;strokeColor=#82b366;" vertex="1" parent="1">
-          <mxGeometry x="60" y="640" width="280" height="150" as="geometry" />
+          <mxGeometry x="40" y="910" width="260" height="150" as="geometry" />
         </mxCell>
         <mxCell id="chk_r0" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=1;" vertex="1" parent="chk_title">
-          <mxGeometry y="30" width="280" height="30" as="geometry" />
+          <mxGeometry y="30" width="260" height="30" as="geometry" />
         </mxCell>
         <mxCell id="chk_r0_k" value="PK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=1;overflow=hidden;" vertex="1" parent="chk_r0">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
         <mxCell id="chk_r0_v" value="id (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="chk_r0">
-          <mxGeometry x="40" width="240" height="30" as="geometry" />
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
         </mxCell>
         <mxCell id="chk_r1" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="chk_title">
-          <mxGeometry y="60" width="280" height="30" as="geometry" />
+          <mxGeometry y="60" width="260" height="30" as="geometry" />
         </mxCell>
         <mxCell id="chk_r1_k" value="FK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=2;overflow=hidden;" vertex="1" parent="chk_r1">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
         <mxCell id="chk_r1_v" value="race_id (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="chk_r1">
-          <mxGeometry x="40" width="240" height="30" as="geometry" />
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
         </mxCell>
         <mxCell id="chk_r2" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="chk_title">
-          <mxGeometry y="90" width="280" height="30" as="geometry" />
+          <mxGeometry y="90" width="260" height="30" as="geometry" />
         </mxCell>
         <mxCell id="chk_r2_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="chk_r2">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
         <mxCell id="chk_r2_v" value="distance_km (REAL)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="chk_r2">
-          <mxGeometry x="40" width="240" height="30" as="geometry" />
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
         </mxCell>
         <mxCell id="chk_r3" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="chk_title">
-          <mxGeometry y="120" width="280" height="30" as="geometry" />
+          <mxGeometry y="120" width="260" height="30" as="geometry" />
         </mxCell>
         <mxCell id="chk_r3_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="chk_r3">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
         <mxCell id="chk_r3_v" value="closing_time (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="chk_r3">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
+        </mxCell>
+
+        <!-- ===== participation_gifts ===== -->
+        <mxCell id="pgift_title" value="participation_gifts" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;fontSize=14;fillColor=#d5e8d4;strokeColor=#82b366;" vertex="1" parent="1">
+          <mxGeometry x="40" y="1090" width="260" height="210" as="geometry" />
+        </mxCell>
+        <mxCell id="pgift_r0" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=1;" vertex="1" parent="pgift_title">
+          <mxGeometry y="30" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="pgift_r0_k" value="PK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=1;overflow=hidden;" vertex="1" parent="pgift_r0">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="pgift_r0_v" value="id (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="pgift_r0">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="pgift_r1" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="pgift_title">
+          <mxGeometry y="60" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="pgift_r1_k" value="FK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=2;overflow=hidden;" vertex="1" parent="pgift_r1">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="pgift_r1_v" value="race_id (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="pgift_r1">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="pgift_r2" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="pgift_title">
+          <mxGeometry y="90" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="pgift_r2_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="pgift_r2">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="pgift_r2_v" value="gift_categories (TEXT/JSON)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="pgift_r2">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="pgift_r3" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="pgift_title">
+          <mxGeometry y="120" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="pgift_r3_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="pgift_r3">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="pgift_r3_v" value="description_ja / _en (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="pgift_r3">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="pgift_r4" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="pgift_title">
+          <mxGeometry y="150" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="pgift_r4_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="pgift_r4">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="pgift_r4_v" value="image (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="pgift_r4">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="pgift_r5" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="pgift_title">
+          <mxGeometry y="180" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="pgift_r5_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="pgift_r5">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="pgift_r5_v" value="sort_order (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="pgift_r5">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
+        </mxCell>
+
+        <!-- ===== race_course_highlights ===== -->
+        <mxCell id="rch_title" value="race_course_highlights" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;fontSize=14;fillColor=#d5e8d4;strokeColor=#82b366;" vertex="1" parent="1">
+          <mxGeometry x="900" y="40" width="280" height="270" as="geometry" />
+        </mxCell>
+        <mxCell id="rch_r0" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=1;" vertex="1" parent="rch_title">
+          <mxGeometry y="30" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rch_r0_k" value="PK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=1;overflow=hidden;" vertex="1" parent="rch_r0">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rch_r0_v" value="id (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rch_r0">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rch_r1" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rch_title">
+          <mxGeometry y="60" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rch_r1_k" value="FK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=2;overflow=hidden;" vertex="1" parent="rch_r1">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rch_r1_v" value="race_id (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rch_r1">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rch_r2" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rch_title">
+          <mxGeometry y="90" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rch_r2_k" value="FK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=2;overflow=hidden;" vertex="1" parent="rch_r2">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rch_r2_v" value="category_id (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rch_r2">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rch_r3" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rch_title">
+          <mxGeometry y="120" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rch_r3_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rch_r3">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rch_r3_v" value="km (REAL)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rch_r3">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rch_r4" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rch_title">
+          <mxGeometry y="150" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rch_r4_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rch_r4">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rch_r4_v" value="name_ja (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rch_r4">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rch_r5" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rch_title">
+          <mxGeometry y="180" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rch_r5_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rch_r5">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rch_r5_v" value="name_en (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rch_r5">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rch_r6" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rch_title">
+          <mxGeometry y="210" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rch_r6_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rch_r6">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rch_r6_v" value="note_ja / note_en (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rch_r6">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rch_r7" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rch_title">
+          <mxGeometry y="240" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rch_r7_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rch_r7">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rch_r7_v" value="sort_order (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rch_r7">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+
+        <!-- ===== race_entry_periods ===== -->
+        <mxCell id="rperiod_title" value="race_entry_periods" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;fontSize=14;fillColor=#d5e8d4;strokeColor=#82b366;" vertex="1" parent="1">
+          <mxGeometry x="900" y="340" width="280" height="240" as="geometry" />
+        </mxCell>
+        <mxCell id="rperiod_r0" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=1;" vertex="1" parent="rperiod_title">
+          <mxGeometry y="30" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rperiod_r0_k" value="PK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=1;overflow=hidden;" vertex="1" parent="rperiod_r0">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rperiod_r0_v" value="id (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rperiod_r0">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rperiod_r1" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rperiod_title">
+          <mxGeometry y="60" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rperiod_r1_k" value="FK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=2;overflow=hidden;" vertex="1" parent="rperiod_r1">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rperiod_r1_v" value="race_id (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rperiod_r1">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rperiod_r2" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rperiod_title">
+          <mxGeometry y="90" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rperiod_r2_k" value="FK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=2;overflow=hidden;" vertex="1" parent="rperiod_r2">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rperiod_r2_v" value="category_id (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rperiod_r2">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rperiod_r3" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rperiod_title">
+          <mxGeometry y="120" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rperiod_r3_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rperiod_r3">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rperiod_r3_v" value="label_ja / label_en (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rperiod_r3">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rperiod_r4" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rperiod_title">
+          <mxGeometry y="150" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rperiod_r4_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rperiod_r4">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rperiod_r4_v" value="start_date / end_date (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rperiod_r4">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rperiod_r5" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rperiod_title">
+          <mxGeometry y="180" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rperiod_r5_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rperiod_r5">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rperiod_r5_v" value="entry_fee (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rperiod_r5">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rperiod_r6" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rperiod_title">
+          <mxGeometry y="210" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rperiod_r6_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rperiod_r6">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rperiod_r6_v" value="sort_order (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rperiod_r6">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+
+        <!-- ===== race_entry_links ===== -->
+        <mxCell id="relink_title" value="race_entry_links" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;fontSize=14;fillColor=#d5e8d4;strokeColor=#82b366;" vertex="1" parent="1">
+          <mxGeometry x="900" y="610" width="280" height="180" as="geometry" />
+        </mxCell>
+        <mxCell id="relink_r0" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=1;" vertex="1" parent="relink_title">
+          <mxGeometry y="30" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="relink_r0_k" value="PK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=1;overflow=hidden;" vertex="1" parent="relink_r0">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="relink_r0_v" value="id (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="relink_r0">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="relink_r1" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="relink_title">
+          <mxGeometry y="60" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="relink_r1_k" value="FK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=2;overflow=hidden;" vertex="1" parent="relink_r1">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="relink_r1_v" value="race_id (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="relink_r1">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="relink_r2" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="relink_title">
+          <mxGeometry y="90" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="relink_r2_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="relink_r2">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="relink_r2_v" value="site_name (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="relink_r2">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="relink_r3" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="relink_title">
+          <mxGeometry y="120" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="relink_r3_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="relink_r3">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="relink_r3_v" value="url (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="relink_r3">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="relink_r4" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="relink_title">
+          <mxGeometry y="150" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="relink_r4_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="relink_r4">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="relink_r4_v" value="sort_order (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="relink_r4">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+
+        <!-- ===== race_gallery ===== -->
+        <mxCell id="rgal_title" value="race_gallery" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;fontSize=14;fillColor=#d5e8d4;strokeColor=#82b366;" vertex="1" parent="1">
+          <mxGeometry x="900" y="820" width="280" height="180" as="geometry" />
+        </mxCell>
+        <mxCell id="rgal_r0" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=1;" vertex="1" parent="rgal_title">
+          <mxGeometry y="30" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rgal_r0_k" value="PK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=1;overflow=hidden;" vertex="1" parent="rgal_r0">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rgal_r0_v" value="id (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rgal_r0">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rgal_r1" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rgal_title">
+          <mxGeometry y="60" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rgal_r1_k" value="FK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=2;overflow=hidden;" vertex="1" parent="rgal_r1">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rgal_r1_v" value="race_id (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rgal_r1">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rgal_r2" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rgal_title">
+          <mxGeometry y="90" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rgal_r2_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rgal_r2">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rgal_r2_v" value="src (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rgal_r2">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rgal_r3" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rgal_title">
+          <mxGeometry y="120" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rgal_r3_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rgal_r3">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rgal_r3_v" value="caption_ja / caption_en (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rgal_r3">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rgal_r4" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rgal_title">
+          <mxGeometry y="150" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rgal_r4_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rgal_r4">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rgal_r4_v" value="sort_order (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rgal_r4">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+
+        <!-- ===== race_voices ===== -->
+        <mxCell id="rvoices_title" value="race_voices" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;fontSize=14;fillColor=#d5e8d4;strokeColor=#82b366;" vertex="1" parent="1">
+          <mxGeometry x="900" y="1030" width="280" height="210" as="geometry" />
+        </mxCell>
+        <mxCell id="rvoices_r0" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=1;" vertex="1" parent="rvoices_title">
+          <mxGeometry y="30" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rvoices_r0_k" value="PK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=1;overflow=hidden;" vertex="1" parent="rvoices_r0">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rvoices_r0_v" value="id (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rvoices_r0">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rvoices_r1" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rvoices_title">
+          <mxGeometry y="60" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rvoices_r1_k" value="FK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=2;overflow=hidden;" vertex="1" parent="rvoices_r1">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rvoices_r1_v" value="race_id (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rvoices_r1">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rvoices_r2" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rvoices_title">
+          <mxGeometry y="90" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rvoices_r2_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rvoices_r2">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rvoices_r2_v" value="quote_ja (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rvoices_r2">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rvoices_r3" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rvoices_title">
+          <mxGeometry y="120" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rvoices_r3_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rvoices_r3">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rvoices_r3_v" value="author (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rvoices_r3">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rvoices_r4" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rvoices_title">
+          <mxGeometry y="150" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rvoices_r4_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rvoices_r4">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rvoices_r4_v" value="quote_en (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rvoices_r4">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rvoices_r5" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rvoices_title">
+          <mxGeometry y="180" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rvoices_r5_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rvoices_r5">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rvoices_r5_v" value="sort_order (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rvoices_r5">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+
+        <!-- ===== race_time_buckets ===== -->
+        <mxCell id="rtb_title" value="race_time_buckets" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;fontSize=14;fillColor=#d5e8d4;strokeColor=#82b366;" vertex="1" parent="1">
+          <mxGeometry x="900" y="1270" width="280" height="180" as="geometry" />
+        </mxCell>
+        <mxCell id="rtb_r0" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=1;" vertex="1" parent="rtb_title">
+          <mxGeometry y="30" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rtb_r0_k" value="PK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=1;overflow=hidden;" vertex="1" parent="rtb_r0">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rtb_r0_v" value="id (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rtb_r0">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rtb_r1" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rtb_title">
+          <mxGeometry y="60" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rtb_r1_k" value="FK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=2;overflow=hidden;" vertex="1" parent="rtb_r1">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rtb_r1_v" value="race_id (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rtb_r1">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rtb_r2" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rtb_title">
+          <mxGeometry y="90" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rtb_r2_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rtb_r2">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rtb_r2_v" value="bucket (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rtb_r2">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rtb_r3" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rtb_title">
+          <mxGeometry y="120" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rtb_r3_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rtb_r3">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rtb_r3_v" value="pct (REAL)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rtb_r3">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rtb_r4" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="rtb_title">
+          <mxGeometry y="150" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rtb_r4_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rtb_r4">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="rtb_r4_v" value="sort_order (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="rtb_r4">
           <mxGeometry x="40" width="240" height="30" as="geometry" />
         </mxCell>
 
         <!-- ===== access_points ===== -->
         <mxCell id="acc_title" value="access_points" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;fontSize=14;fillColor=#d5e8d4;strokeColor=#82b366;" vertex="1" parent="1">
-          <mxGeometry x="980" y="40" width="280" height="240" as="geometry" />
+          <mxGeometry x="1220" y="40" width="280" height="240" as="geometry" />
         </mxCell>
         <mxCell id="acc_r0" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=1;" vertex="1" parent="acc_title">
           <mxGeometry y="30" width="280" height="30" as="geometry" />
@@ -355,7 +975,7 @@
         <mxCell id="acc_r2_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="acc_r2">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="acc_r2_v" value="station_name_ja / _en (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="acc_r2">
+        <mxCell id="acc_r2_v" value="station_name_ja / station_name_en (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="acc_r2">
           <mxGeometry x="40" width="240" height="30" as="geometry" />
         </mxCell>
         <mxCell id="acc_r3" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="acc_title">
@@ -382,13 +1002,22 @@
         <mxCell id="acc_r5_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="acc_r5">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="acc_r5_v" value="sort_order (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="acc_r5">
+        <mxCell id="acc_r5_v" value="station_code / sort_order (TEXT/INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="acc_r5">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="acc_r6" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="acc_title">
+          <mxGeometry y="210" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="acc_r6_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="acc_r6">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="acc_r6_v" value="(placeholder)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;fontSize=1;" vertex="1" parent="acc_r6">
           <mxGeometry x="40" width="240" height="30" as="geometry" />
         </mxCell>
 
         <!-- ===== nearby_spots ===== -->
         <mxCell id="spot_title" value="nearby_spots" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;fontSize=14;fillColor=#d5e8d4;strokeColor=#82b366;" vertex="1" parent="1">
-          <mxGeometry x="980" y="340" width="280" height="240" as="geometry" />
+          <mxGeometry x="1220" y="310" width="280" height="240" as="geometry" />
         </mxCell>
         <mxCell id="spot_r0" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=1;" vertex="1" parent="spot_title">
           <mxGeometry y="30" width="280" height="30" as="geometry" />
@@ -432,7 +1061,7 @@
         <mxCell id="spot_r4_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="spot_r4">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="spot_r4_v" value="latitude / longitude (REAL)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="spot_r4">
+        <mxCell id="spot_r4_v" value="description_ja / _en (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="spot_r4">
           <mxGeometry x="40" width="240" height="30" as="geometry" />
         </mxCell>
         <mxCell id="spot_r5" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="spot_title">
@@ -444,10 +1073,19 @@
         <mxCell id="spot_r5_v" value="url / distance_from_venue (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="spot_r5">
           <mxGeometry x="40" width="240" height="30" as="geometry" />
         </mxCell>
+        <mxCell id="spot_r6" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="spot_title">
+          <mxGeometry y="210" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="spot_r6_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="spot_r6">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="spot_r6_v" value="latitude / longitude (REAL)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="spot_r6">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
 
         <!-- ===== weather_history ===== -->
         <mxCell id="wth_title" value="weather_history" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;fontSize=14;fillColor=#d5e8d4;strokeColor=#82b366;" vertex="1" parent="1">
-          <mxGeometry x="980" y="640" width="280" height="240" as="geometry" />
+          <mxGeometry x="1220" y="580" width="280" height="210" as="geometry" />
         </mxCell>
         <mxCell id="wth_r0" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=1;" vertex="1" parent="wth_title">
           <mxGeometry y="30" width="280" height="30" as="geometry" />
@@ -504,68 +1142,553 @@
           <mxGeometry x="40" width="240" height="30" as="geometry" />
         </mxCell>
 
-        <!-- ===== participation_gifts ===== -->
-        <mxCell id="gift_title" value="participation_gifts" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;fontSize=14;fillColor=#d5e8d4;strokeColor=#82b366;" vertex="1" parent="1">
-          <mxGeometry x="60" y="860" width="280" height="210" as="geometry" />
+        <!-- ===== race_results ===== -->
+        <mxCell id="result_title" value="race_results" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;fontSize=14;fillColor=#d5e8d4;strokeColor=#82b366;" vertex="1" parent="1">
+          <mxGeometry x="1220" y="820" width="280" height="300" as="geometry" />
         </mxCell>
-        <mxCell id="gift_r0" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=1;" vertex="1" parent="gift_title">
+        <mxCell id="result_r0" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=1;" vertex="1" parent="result_title">
           <mxGeometry y="30" width="280" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="gift_r0_k" value="PK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=1;overflow=hidden;" vertex="1" parent="gift_r0">
+        <mxCell id="result_r0_k" value="PK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=1;overflow=hidden;" vertex="1" parent="result_r0">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="gift_r0_v" value="id (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="gift_r0">
+        <mxCell id="result_r0_v" value="id (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="result_r0">
           <mxGeometry x="40" width="240" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="gift_r1" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="gift_title">
+        <mxCell id="result_r1" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="result_title">
           <mxGeometry y="60" width="280" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="gift_r1_k" value="FK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=2;overflow=hidden;" vertex="1" parent="gift_r1">
+        <mxCell id="result_r1_k" value="FK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=2;overflow=hidden;" vertex="1" parent="result_r1">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="gift_r1_v" value="race_id (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="gift_r1">
+        <mxCell id="result_r1_v" value="race_id (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="result_r1">
           <mxGeometry x="40" width="240" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="gift_r2" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="gift_title">
+        <mxCell id="result_r2" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="result_title">
           <mxGeometry y="90" width="280" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="gift_r2_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="gift_r2">
+        <mxCell id="result_r2_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="result_r2">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="gift_r2_v" value="gift_categories (TEXT/JSON)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="gift_r2">
+        <mxCell id="result_r2_v" value="participants_count / finishers_count (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="result_r2">
           <mxGeometry x="40" width="240" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="gift_r3" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="gift_title">
+        <mxCell id="result_r3" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="result_title">
           <mxGeometry y="120" width="280" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="gift_r3_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="gift_r3">
+        <mxCell id="result_r3_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="result_r3">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="gift_r3_v" value="description_ja / _en (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="gift_r3">
+        <mxCell id="result_r3_v" value="finisher_rate_pct (REAL)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="result_r3">
           <mxGeometry x="40" width="240" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="gift_r4" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="gift_title">
+        <mxCell id="result_r4" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="result_title">
           <mxGeometry y="150" width="280" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="gift_r4_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="gift_r4">
+        <mxCell id="result_r4_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="result_r4">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="gift_r4_v" value="image (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="gift_r4">
+        <mxCell id="result_r4_v" value="weather_condition_ja / _en (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="result_r4">
           <mxGeometry x="40" width="240" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="gift_r5" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="gift_title">
+        <mxCell id="result_r5" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="result_title">
           <mxGeometry y="180" width="280" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="gift_r5_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="gift_r5">
+        <mxCell id="result_r5_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="result_r5">
           <mxGeometry width="40" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="gift_r5_v" value="sort_order (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="gift_r5">
+        <mxCell id="result_r5_v" value="temperature_c / max_temp_c / min_temp_c (REAL)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="result_r5">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="result_r6" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="result_title">
+          <mxGeometry y="210" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="result_r6_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="result_r6">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="result_r6_v" value="wind_speed_ms / humidity_pct (REAL)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="result_r6">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="result_r7" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="result_title">
+          <mxGeometry y="240" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="result_r7_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="result_r7">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="result_r7_v" value="notes_ja / notes_en (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="result_r7">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="result_r8" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="result_title">
+          <mxGeometry y="270" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="result_r8_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="result_r8">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="result_r8_v" value="avg_time (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="result_r8">
           <mxGeometry x="40" width="240" height="30" as="geometry" />
         </mxCell>
 
-        <!-- ===== gift_categories (master) ===== -->
-        <mxCell id="gcat_title" value="gift_categories（マスタ）" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;fontSize=14;fillColor=#fff2cc;strokeColor=#d6b656;" vertex="1" parent="1">
-          <mxGeometry x="440" y="940" width="260" height="150" as="geometry" />
+        <!-- ===== user_races ===== -->
+        <mxCell id="uraces_title" value="user_races" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;fontSize=14;fillColor=#e1d5e7;strokeColor=#9673a6;" vertex="1" parent="1">
+          <mxGeometry x="1220" y="1150" width="280" height="240" as="geometry" />
+        </mxCell>
+        <mxCell id="uraces_r0" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=1;" vertex="1" parent="uraces_title">
+          <mxGeometry y="30" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="uraces_r0_k" value="PK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=1;overflow=hidden;" vertex="1" parent="uraces_r0">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="uraces_r0_v" value="id (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="uraces_r0">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="uraces_r1" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="uraces_title">
+          <mxGeometry y="60" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="uraces_r1_k" value="FK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=2;overflow=hidden;" vertex="1" parent="uraces_r1">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="uraces_r1_v" value="user_id (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="uraces_r1">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="uraces_r2" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="uraces_title">
+          <mxGeometry y="90" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="uraces_r2_k" value="FK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=2;overflow=hidden;" vertex="1" parent="uraces_r2">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="uraces_r2_v" value="race_id (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="uraces_r2">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="uraces_r3" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="uraces_title">
+          <mxGeometry y="120" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="uraces_r3_k" value="FK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=2;overflow=hidden;" vertex="1" parent="uraces_r3">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="uraces_r3_v" value="planning_category_id (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="uraces_r3">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="uraces_r4" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="uraces_title">
+          <mxGeometry y="150" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="uraces_r4_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="uraces_r4">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="uraces_r4_v" value="is_planning (BOOL)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="uraces_r4">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="uraces_r5" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="uraces_title">
+          <mxGeometry y="180" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="uraces_r5_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="uraces_r5">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="uraces_r5_v" value="entry_reminder_period_ids (TEXT/JSON)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="uraces_r5">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="uraces_r6" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="uraces_title">
+          <mxGeometry y="210" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="uraces_r6_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="uraces_r6">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="uraces_r6_v" value="created_at / updated_at (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="uraces_r6">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+
+        <!-- ===== user (Better Auth) ===== -->
+        <mxCell id="user_title" value="user" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;fontSize=14;fillColor=#ffe6cc;strokeColor=#d6b656;" vertex="1" parent="1">
+          <mxGeometry x="40" y="1560" width="260" height="240" as="geometry" />
+        </mxCell>
+        <mxCell id="user_r0" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=1;" vertex="1" parent="user_title">
+          <mxGeometry y="30" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="user_r0_k" value="PK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=1;overflow=hidden;" vertex="1" parent="user_r0">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="user_r0_v" value="id (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="user_r0">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="user_r1" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="user_title">
+          <mxGeometry y="60" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="user_r1_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="user_r1">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="user_r1_v" value="name (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="user_r1">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="user_r2" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="user_title">
+          <mxGeometry y="90" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="user_r2_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="user_r2">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="user_r2_v" value="email (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="user_r2">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="user_r3" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="user_title">
+          <mxGeometry y="120" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="user_r3_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="user_r3">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="user_r3_v" value="emailVerified (BOOL)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="user_r3">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="user_r4" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="user_title">
+          <mxGeometry y="150" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="user_r4_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="user_r4">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="user_r4_v" value="image (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="user_r4">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="user_r5" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="user_title">
+          <mxGeometry y="180" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="user_r5_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="user_r5">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="user_r5_v" value="createdAt / updatedAt (INT/timestamp)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="user_r5">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
+        </mxCell>
+
+        <!-- ===== session ===== -->
+        <mxCell id="session_title" value="session" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;fontSize=14;fillColor=#ffe6cc;strokeColor=#d6b656;" vertex="1" parent="1">
+          <mxGeometry x="340" y="1560" width="280" height="210" as="geometry" />
+        </mxCell>
+        <mxCell id="session_r0" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=1;" vertex="1" parent="session_title">
+          <mxGeometry y="30" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="session_r0_k" value="PK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=1;overflow=hidden;" vertex="1" parent="session_r0">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="session_r0_v" value="id (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="session_r0">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="session_r1" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="session_title">
+          <mxGeometry y="60" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="session_r1_k" value="FK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=2;overflow=hidden;" vertex="1" parent="session_r1">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="session_r1_v" value="userId (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="session_r1">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="session_r2" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="session_title">
+          <mxGeometry y="90" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="session_r2_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="session_r2">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="session_r2_v" value="expiresAt (INT/timestamp)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="session_r2">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="session_r3" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="session_title">
+          <mxGeometry y="120" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="session_r3_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="session_r3">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="session_r3_v" value="token (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="session_r3">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="session_r4" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="session_title">
+          <mxGeometry y="150" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="session_r4_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="session_r4">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="session_r4_v" value="createdAt / updatedAt (INT/timestamp)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="session_r4">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="session_r5" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="session_title">
+          <mxGeometry y="180" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="session_r5_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="session_r5">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="session_r5_v" value="ipAddress / userAgent (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="session_r5">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+
+        <!-- ===== account ===== -->
+        <mxCell id="account_title" value="account" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;fontSize=14;fillColor=#ffe6cc;strokeColor=#d6b656;" vertex="1" parent="1">
+          <mxGeometry x="660" y="1560" width="280" height="270" as="geometry" />
+        </mxCell>
+        <mxCell id="account_r0" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=1;" vertex="1" parent="account_title">
+          <mxGeometry y="30" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="account_r0_k" value="PK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=1;overflow=hidden;" vertex="1" parent="account_r0">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="account_r0_v" value="id (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="account_r0">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="account_r1" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="account_title">
+          <mxGeometry y="60" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="account_r1_k" value="FK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=2;overflow=hidden;" vertex="1" parent="account_r1">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="account_r1_v" value="userId (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="account_r1">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="account_r2" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="account_title">
+          <mxGeometry y="90" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="account_r2_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="account_r2">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="account_r2_v" value="accountId / providerId (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="account_r2">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="account_r3" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="account_title">
+          <mxGeometry y="120" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="account_r3_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="account_r3">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="account_r3_v" value="accessToken / refreshToken / idToken (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="account_r3">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="account_r4" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="account_title">
+          <mxGeometry y="150" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="account_r4_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="account_r4">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="account_r4_v" value="accessTokenExpiresAt / refreshTokenExpiresAt (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="account_r4">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="account_r5" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="account_title">
+          <mxGeometry y="180" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="account_r5_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="account_r5">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="account_r5_v" value="scope / password (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="account_r5">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="account_r6" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="account_title">
+          <mxGeometry y="210" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="account_r6_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="account_r6">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="account_r6_v" value="createdAt / updatedAt (INT/timestamp)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="account_r6">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+
+        <!-- ===== passkey ===== -->
+        <mxCell id="passkey_title" value="passkey" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;fontSize=14;fillColor=#ffe6cc;strokeColor=#d6b656;" vertex="1" parent="1">
+          <mxGeometry x="980" y="1560" width="280" height="300" as="geometry" />
+        </mxCell>
+        <mxCell id="passkey_r0" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=1;" vertex="1" parent="passkey_title">
+          <mxGeometry y="30" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="passkey_r0_k" value="PK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=1;overflow=hidden;" vertex="1" parent="passkey_r0">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="passkey_r0_v" value="id (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="passkey_r0">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="passkey_r1" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="passkey_title">
+          <mxGeometry y="60" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="passkey_r1_k" value="FK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=2;overflow=hidden;" vertex="1" parent="passkey_r1">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="passkey_r1_v" value="userId (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="passkey_r1">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="passkey_r2" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="passkey_title">
+          <mxGeometry y="90" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="passkey_r2_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="passkey_r2">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="passkey_r2_v" value="name (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="passkey_r2">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="passkey_r3" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="passkey_title">
+          <mxGeometry y="120" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="passkey_r3_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="passkey_r3">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="passkey_r3_v" value="publicKey (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="passkey_r3">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="passkey_r4" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="passkey_title">
+          <mxGeometry y="150" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="passkey_r4_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="passkey_r4">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="passkey_r4_v" value="webAuthnUserID (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="passkey_r4">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="passkey_r5" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="passkey_title">
+          <mxGeometry y="180" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="passkey_r5_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="passkey_r5">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="passkey_r5_v" value="counter (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="passkey_r5">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="passkey_r6" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="passkey_title">
+          <mxGeometry y="210" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="passkey_r6_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="passkey_r6">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="passkey_r6_v" value="deviceType / backedUp (TEXT/BOOL)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="passkey_r6">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="passkey_r7" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="passkey_title">
+          <mxGeometry y="240" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="passkey_r7_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="passkey_r7">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="passkey_r7_v" value="transports / createdAt (TEXT/INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="passkey_r7">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+
+        <!-- ===== verification ===== -->
+        <mxCell id="verif_title" value="verification" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;fontSize=14;fillColor=#ffe6cc;strokeColor=#d6b656;" vertex="1" parent="1">
+          <mxGeometry x="1300" y="1560" width="280" height="180" as="geometry" />
+        </mxCell>
+        <mxCell id="verif_r0" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=1;" vertex="1" parent="verif_title">
+          <mxGeometry y="30" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="verif_r0_k" value="PK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=1;overflow=hidden;" vertex="1" parent="verif_r0">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="verif_r0_v" value="id (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="verif_r0">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="verif_r1" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="verif_title">
+          <mxGeometry y="60" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="verif_r1_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="verif_r1">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="verif_r1_v" value="identifier (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="verif_r1">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="verif_r2" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="verif_title">
+          <mxGeometry y="90" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="verif_r2_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="verif_r2">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="verif_r2_v" value="value (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="verif_r2">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="verif_r3" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="verif_title">
+          <mxGeometry y="120" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="verif_r3_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="verif_r3">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="verif_r3_v" value="expiresAt (INT/timestamp)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="verif_r3">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="verif_r4" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="verif_title">
+          <mxGeometry y="150" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="verif_r4_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="verif_r4">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="verif_r4_v" value="createdAt / updatedAt (INT/timestamp)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="verif_r4">
+          <mxGeometry x="40" width="240" height="30" as="geometry" />
+        </mxCell>
+
+        <!-- ===== contact_submissions ===== -->
+        <mxCell id="contact_title" value="contact_submissions" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;fontSize=14;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="1">
+          <mxGeometry x="40" y="1830" width="260" height="270" as="geometry" />
+        </mxCell>
+        <mxCell id="contact_r0" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=1;" vertex="1" parent="contact_title">
+          <mxGeometry y="30" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="contact_r0_k" value="PK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=1;overflow=hidden;" vertex="1" parent="contact_r0">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="contact_r0_v" value="id (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="contact_r0">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="contact_r1" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="contact_title">
+          <mxGeometry y="60" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="contact_r1_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="contact_r1">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="contact_r1_v" value="name (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="contact_r1">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="contact_r2" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="contact_title">
+          <mxGeometry y="90" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="contact_r2_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="contact_r2">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="contact_r2_v" value="email (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="contact_r2">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="contact_r3" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="contact_title">
+          <mxGeometry y="120" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="contact_r3_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="contact_r3">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="contact_r3_v" value="category (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="contact_r3">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="contact_r4" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="contact_title">
+          <mxGeometry y="150" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="contact_r4_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="contact_r4">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="contact_r4_v" value="message (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="contact_r4">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="contact_r5" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="contact_title">
+          <mxGeometry y="180" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="contact_r5_k" value="FK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=2;overflow=hidden;" vertex="1" parent="contact_r5">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="contact_r5_v" value="user_id (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="contact_r5">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="contact_r6" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="contact_title">
+          <mxGeometry y="210" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="contact_r6_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="contact_r6">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="contact_r6_v" value="status (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="contact_r6">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="contact_r7" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="contact_title">
+          <mxGeometry y="240" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="contact_r7_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="contact_r7">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="contact_r7_v" value="created_at (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="contact_r7">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
+        </mxCell>
+
+        <!-- ===== gift_categories ===== -->
+        <mxCell id="gcat_title" value="gift_categories" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;fontSize=14;fillColor=#f5f5f5;strokeColor=#666666;" vertex="1" parent="1">
+          <mxGeometry x="1540" y="40" width="260" height="120" as="geometry" />
         </mxCell>
         <mxCell id="gcat_r0" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=1;" vertex="1" parent="gcat_title">
           <mxGeometry y="30" width="260" height="30" as="geometry" />
@@ -595,9 +1718,9 @@
           <mxGeometry x="40" width="220" height="30" as="geometry" />
         </mxCell>
 
-        <!-- ===== prefectures (master) ===== -->
-        <mxCell id="pref_title" value="prefectures（マスタ）" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;fontSize=14;fillColor=#fff2cc;strokeColor=#d6b656;" vertex="1" parent="1">
-          <mxGeometry x="760" y="940" width="260" height="210" as="geometry" />
+        <!-- ===== prefectures ===== -->
+        <mxCell id="pref_title" value="prefectures" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;fontSize=14;fillColor=#f5f5f5;strokeColor=#666666;" vertex="1" parent="1">
+          <mxGeometry x="1540" y="190" width="260" height="150" as="geometry" />
         </mxCell>
         <mxCell id="pref_r0" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=1;" vertex="1" parent="pref_title">
           <mxGeometry y="30" width="260" height="30" as="geometry" />
@@ -636,164 +1759,125 @@
           <mxGeometry x="40" width="220" height="30" as="geometry" />
         </mxCell>
 
-        <!-- ===== race_series (master) ===== -->
-        <mxCell id="series_title" value="race_series" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;fontSize=14;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="1">
-          <mxGeometry x="1100" y="40" width="280" height="180" as="geometry" />
-        </mxCell>
-        <mxCell id="series_r0" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=1;" vertex="1" parent="series_title">
-          <mxGeometry y="30" width="280" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="series_r0_k" value="PK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=1;overflow=hidden;" vertex="1" parent="series_r0">
-          <mxGeometry width="40" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="series_r0_v" value="id (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="series_r0">
-          <mxGeometry x="40" width="240" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="series_r1" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="series_title">
-          <mxGeometry y="60" width="280" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="series_r1_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="series_r1">
-          <mxGeometry width="40" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="series_r1_v" value="name_ja / name_en (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="series_r1">
-          <mxGeometry x="40" width="240" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="series_r2" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="series_title">
-          <mxGeometry y="90" width="280" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="series_r2_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="series_r2">
-          <mxGeometry width="40" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="series_r2_v" value="first_held_year (INT, null)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="series_r2">
-          <mxGeometry x="40" width="240" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="series_r3" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="series_title">
-          <mxGeometry y="120" width="280" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="series_r3_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="series_r3">
-          <mxGeometry width="40" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="series_r3_v" value="website_url (TEXT, null)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="series_r3">
-          <mxGeometry x="40" width="240" height="30" as="geometry" />
-        </mxCell>
-
-        <!-- ===== race_results ===== -->
-        <mxCell id="result_title" value="race_results" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;fontSize=14;fillColor=#d5e8d4;strokeColor=#82b366;" vertex="1" parent="1">
-          <mxGeometry x="1100" y="280" width="280" height="420" as="geometry" />
-        </mxCell>
-        <mxCell id="result_r0" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=1;" vertex="1" parent="result_title">
-          <mxGeometry y="30" width="280" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="result_r0_k" value="PK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=1;overflow=hidden;" vertex="1" parent="result_r0">
-          <mxGeometry width="40" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="result_r0_v" value="id (INT, autoincrement)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="result_r0">
-          <mxGeometry x="40" width="240" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="result_r1" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="result_title">
-          <mxGeometry y="60" width="280" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="result_r1_k" value="FK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=2;overflow=hidden;" vertex="1" parent="result_r1">
-          <mxGeometry width="40" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="result_r1_v" value="race_id (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="result_r1">
-          <mxGeometry x="40" width="240" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="result_r2" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="result_title">
-          <mxGeometry y="90" width="280" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="result_r2_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="result_r2">
-          <mxGeometry width="40" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="result_r2_v" value="participants_count (INT, null)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="result_r2">
-          <mxGeometry x="40" width="240" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="result_r3" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="result_title">
-          <mxGeometry y="120" width="280" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="result_r3_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="result_r3">
-          <mxGeometry width="40" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="result_r3_v" value="finishers_count (INT, null)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="result_r3">
-          <mxGeometry x="40" width="240" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="result_r4" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="result_title">
-          <mxGeometry y="150" width="280" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="result_r4_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="result_r4">
-          <mxGeometry width="40" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="result_r4_v" value="finisher_rate_pct (REAL, null)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="result_r4">
-          <mxGeometry x="40" width="240" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="result_r5" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="result_title">
-          <mxGeometry y="180" width="280" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="result_r5_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="result_r5">
-          <mxGeometry width="40" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="result_r5_v" value="weather_condition_ja / _en (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="result_r5">
-          <mxGeometry x="40" width="240" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="result_r6" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="result_title">
-          <mxGeometry y="210" width="280" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="result_r6_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="result_r6">
-          <mxGeometry width="40" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="result_r6_v" value="temperature_c / max_temp_c / min_temp_c (REAL, null)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="result_r6">
-          <mxGeometry x="40" width="240" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="result_r7" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="result_title">
-          <mxGeometry y="240" width="280" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="result_r7_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="result_r7">
-          <mxGeometry width="40" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="result_r7_v" value="wind_speed_ms / humidity_pct (REAL, null)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="result_r7">
-          <mxGeometry x="40" width="240" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="result_r8" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="result_title">
-          <mxGeometry y="270" width="280" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="result_r8_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="result_r8">
-          <mxGeometry width="40" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="result_r8_v" value="notes_ja / notes_en (TEXT, null)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="result_r8">
-          <mxGeometry x="40" width="240" height="30" as="geometry" />
-        </mxCell>
-
         <!-- ===== Relations ===== -->
-        <!-- races 1 - N race_categories -->
-        <mxCell id="rel_rcat" style="edgeStyle=entityRelationEdgeStyle;endArrow=ERmanyToOne;startArrow=ERmanyToOne;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="rcat_r1" target="races_r0" parent="1">
+
+        <!-- races.series_id → race_series.id -->
+        <mxCell id="rel_rseries" style="edgeStyle=entityRelationEdgeStyle;endArrow=ERmanyToOne;startArrow=ERmanyToOne;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="races_r1" target="rseries_r0" parent="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <!-- races 1 - N aid_stations -->
-        <mxCell id="rel_aid" style="edgeStyle=entityRelationEdgeStyle;endArrow=ERmanyToOne;startArrow=ERmanyToOne;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="aid_r1" target="races_r0" parent="1">
+
+        <!-- race_categories.race_id → races.id -->
+        <mxCell id="rel_rcat_races" style="edgeStyle=entityRelationEdgeStyle;endArrow=ERmanyToOne;startArrow=ERmanyToOne;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="rcat_r0" target="races_r0" parent="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <!-- races 1 - N checkpoints -->
-        <mxCell id="rel_chk" style="edgeStyle=entityRelationEdgeStyle;endArrow=ERmanyToOne;startArrow=ERmanyToOne;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="chk_r1" target="races_r0" parent="1">
+
+        <!-- race_course_highlights.race_id → races.id -->
+        <mxCell id="rel_rch_races" style="edgeStyle=entityRelationEdgeStyle;endArrow=ERmanyToOne;startArrow=ERmanyToOne;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="rch_r0" target="races_r0" parent="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <!-- races 1 - N participation_gifts -->
-        <mxCell id="rel_gift" style="edgeStyle=entityRelationEdgeStyle;endArrow=ERmanyToOne;startArrow=ERmanyToOne;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="gift_r1" target="races_r0" parent="1">
+
+        <!-- race_course_highlights.category_id → race_categories.id -->
+        <mxCell id="rel_rch_rcat" style="edgeStyle=entityRelationEdgeStyle;endArrow=ERmanyToOne;startArrow=ERmanyToOne;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="rch_r1" target="rcat_r0" parent="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <!-- races 1 - N access_points -->
-        <mxCell id="rel_acc" style="edgeStyle=entityRelationEdgeStyle;endArrow=ERmanyToOne;startArrow=ERmanyToOne;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="acc_r1" target="races_r0" parent="1">
+
+        <!-- race_entry_periods.race_id → races.id -->
+        <mxCell id="rel_rep_races" style="edgeStyle=entityRelationEdgeStyle;endArrow=ERmanyToOne;startArrow=ERmanyToOne;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="rep_r0" target="races_r0" parent="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <!-- races 1 - N nearby_spots -->
-        <mxCell id="rel_spot" style="edgeStyle=entityRelationEdgeStyle;endArrow=ERmanyToOne;startArrow=ERmanyToOne;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="spot_r1" target="races_r0" parent="1">
+
+        <!-- race_entry_periods.category_id → race_categories.id -->
+        <mxCell id="rel_rep_rcat" style="edgeStyle=entityRelationEdgeStyle;endArrow=ERmanyToOne;startArrow=ERmanyToOne;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="rep_r1" target="rcat_r0" parent="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <!-- races 1 - N weather_history -->
-        <mxCell id="rel_wth" style="edgeStyle=entityRelationEdgeStyle;endArrow=ERmanyToOne;startArrow=ERmanyToOne;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="wth_r1" target="races_r0" parent="1">
+
+        <!-- race_entry_links.race_id → races.id -->
+        <mxCell id="rel_rel_races" style="edgeStyle=entityRelationEdgeStyle;endArrow=ERmanyToOne;startArrow=ERmanyToOne;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="rel_r0" target="races_r0" parent="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <!-- races 1 - 1 race_results -->
-        <mxCell id="rel_result" style="edgeStyle=entityRelationEdgeStyle;endArrow=ERone;startArrow=ERone;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="result_r1" target="races_r0" parent="1">
+
+        <!-- aid_stations.race_id → races.id -->
+        <mxCell id="rel_aid_races" style="edgeStyle=entityRelationEdgeStyle;endArrow=ERmanyToOne;startArrow=ERmanyToOne;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="aid_r0" target="races_r0" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- checkpoints.race_id → races.id -->
+        <mxCell id="rel_chk_races" style="edgeStyle=entityRelationEdgeStyle;endArrow=ERmanyToOne;startArrow=ERmanyToOne;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="chk_r0" target="races_r0" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- participation_gifts.race_id → races.id -->
+        <mxCell id="rel_pgift_races" style="edgeStyle=entityRelationEdgeStyle;endArrow=ERmanyToOne;startArrow=ERmanyToOne;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="pgift_r0" target="races_r0" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- access_points.race_id → races.id -->
+        <mxCell id="rel_ap_races" style="edgeStyle=entityRelationEdgeStyle;endArrow=ERmanyToOne;startArrow=ERmanyToOne;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="ap_r0" target="races_r0" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- nearby_spots.race_id → races.id -->
+        <mxCell id="rel_ns_races" style="edgeStyle=entityRelationEdgeStyle;endArrow=ERmanyToOne;startArrow=ERmanyToOne;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="ns_r0" target="races_r0" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- weather_history.race_id → races.id -->
+        <mxCell id="rel_wh_races" style="edgeStyle=entityRelationEdgeStyle;endArrow=ERmanyToOne;startArrow=ERmanyToOne;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="wh_r0" target="races_r0" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- race_results.race_id → races.id (1:1) -->
+        <mxCell id="rel_rres_races" style="edgeStyle=entityRelationEdgeStyle;endArrow=ERone;startArrow=ERone;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="rres_r0" target="races_r0" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- race_gallery.race_id → races.id -->
+        <mxCell id="rel_rgal_races" style="edgeStyle=entityRelationEdgeStyle;endArrow=ERmanyToOne;startArrow=ERmanyToOne;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="rgal_r0" target="races_r0" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- race_voices.race_id → races.id -->
+        <mxCell id="rel_rvoice_races" style="edgeStyle=entityRelationEdgeStyle;endArrow=ERmanyToOne;startArrow=ERmanyToOne;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="rvoice_r0" target="races_r0" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- race_time_buckets.race_id → races.id -->
+        <mxCell id="rel_rtb_races" style="edgeStyle=entityRelationEdgeStyle;endArrow=ERmanyToOne;startArrow=ERmanyToOne;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="rtb_r0" target="races_r0" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- user_races.race_id → races.id -->
+        <mxCell id="rel_ur_races" style="edgeStyle=entityRelationEdgeStyle;endArrow=ERmanyToOne;startArrow=ERmanyToOne;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="ur_r0" target="races_r0" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- user_races.user_id → user.id -->
+        <mxCell id="rel_ur_user" style="edgeStyle=entityRelationEdgeStyle;endArrow=ERmanyToOne;startArrow=ERmanyToOne;" edge="1" source="ur_r1" target="user_r0" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- user_races.planning_category_id → race_categories.id -->
+        <mxCell id="rel_ur_rcat" style="edgeStyle=entityRelationEdgeStyle;endArrow=ERmanyToOne;startArrow=ERmanyToOne;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="ur_r2" target="rcat_r0" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- session.userId → user.id -->
+        <mxCell id="rel_sess_user" style="edgeStyle=entityRelationEdgeStyle;endArrow=ERmanyToOne;startArrow=ERmanyToOne;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="sess_r0" target="user_r0" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- account.userId → user.id -->
+        <mxCell id="rel_acct_user" style="edgeStyle=entityRelationEdgeStyle;endArrow=ERmanyToOne;startArrow=ERmanyToOne;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="acct_r0" target="user_r0" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- passkey.userId → user.id -->
+        <mxCell id="rel_pk_user" style="edgeStyle=entityRelationEdgeStyle;endArrow=ERmanyToOne;startArrow=ERmanyToOne;" edge="1" source="pk_r0" target="user_r0" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- contact_submissions.user_id → user.id -->
+        <mxCell id="rel_cs_user" style="edgeStyle=entityRelationEdgeStyle;endArrow=ERmanyToOne;startArrow=ERmanyToOne;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="cs_r1" target="user_r0" parent="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -373,7 +373,8 @@ ER図は `docs/er-diagram.drawio` で管理しています。[draw.io](https://a
 |---|---|---|---|---|
 | id | integer | NO | autoincrement | PK |
 | race_id | text | NO | — | FK → races.id（CASCADE） |
-| km | real | NO | — | 地点（km） |
+| category_id | integer | YES | — | FK → race_categories.id（CASCADE） |
+| km | real | YES | — | 地点（km） |
 | name_ja | text | NO | — | スポット名（日本語） |
 | name_en | text | YES | — | スポット名（英語） |
 | note_ja | text | YES | — | 説明（日本語） |
@@ -399,3 +400,5 @@ ER図は `docs/er-diagram.drawio` で管理しています。[draw.io](https://a
 | `migrations/0008_phase2_motif_hero.sql` | races に motif/motif_color/motif_romaji/tagline_ja/tagline_en/hero_image_url/hero_caption_ja/hero_caption_en を追加、race_results に avg_time を追加（Issue #42 Design Phase 2） |
 | `migrations/0009_phase3_gallery_voices.sql` | race_gallery / race_voices / race_time_buckets / race_course_highlights テーブルを追加（Issue #43 Design Phase 3） |
 | `migrations/0008_stormy_reavers.sql` | race_voices に quote_en カラムを追加（英語対応） |
+| `migrations/0007_yielding_obadiah_stane.sql` | race_course_highlights に category_id カラムを追加（FK ON DELETE 句なし ← 0010 で修正） |
+| `migrations/0010_fix_course_highlights_fk.sql` | race_course_highlights.category_id FK を ON DELETE CASCADE に修正（schema.ts との整合） |

--- a/docs/update-history.md
+++ b/docs/update-history.md
@@ -594,3 +594,20 @@
 - `src/app/api/user/races/[raceId]/__tests__/route.test.ts`: `GET/PATCH/DELETE /api/user/races/[raceId]` の upsert ロジック・parseIds・DELETE テストを追加（closes #59）
 - `src/components/mypage/__tests__/UserRaceList.test.tsx`: セッション状態・データ表示・getCatLabel・raceMap フォールバックのテストを追加（closes #60）
 - `src/components/races/__tests__/RaceBreadcrumb.test.tsx`: from props のバリアント・aria-label・router.back() のテストを追加（closes #61）
+
+## 2026-05-16 FK修正・シード修正・新レース追加
+
+### FK制約修正
+- `migrations/0010_fix_course_highlights_fk.sql`: `race_course_highlights.category_id → race_categories.id` の FK を ON DELETE CASCADE に修正（`0007_yielding_obadiah_stane.sql` で ON DELETE 句が欠落していた schema.ts との不整合を解消）
+
+### シード生成スクリプト修正 (`scripts/generate-seed-races.js`)
+- 子テーブルの DELETE を `INSERT OR REPLACE INTO races` より**先に**実行するよう順序変更（race_course_highlights の NO ACTION FK によるカスケード削除エラーを回避）
+- カテゴリレベルの `race_course_highlights` INSERT で `last_insert_rowid()` → サブクエリ `(SELECT id FROM race_categories WHERE race_id=... AND distance_type=... ORDER BY id DESC LIMIT 1)` に変更（複数ハイライト挿入時に `last_insert_rowid()` が上書きされ FK 違反になる問題を修正）
+
+### 新レース追加
+- `src/data/races/sapporo-marathon-2026.json`: 札幌マラソン 2026 を追加
+- `src/data/races/tokyo-legacy-half-2026.json`: 東京レガシーハーフマラソン 2026 を追加（既存ファイル）
+- `migrations/seed-races-all.sql`: 上記2件を含む 78 件分を再生成
+
+### ドキュメント更新
+- `docs/schema.md`: `race_course_highlights` テーブルに `category_id` カラムを追記、マイグレーション履歴に `0010` を追加

--- a/docs/update-history.md
+++ b/docs/update-history.md
@@ -611,3 +611,4 @@
 
 ### ドキュメント更新
 - `docs/schema.md`: `race_course_highlights` テーブルに `category_id` カラムを追記、マイグレーション履歴に `0010` を追加
+- `docs/er-diagram.drawio`: 全テーブル・全カラム・全FK関係を反映して全面再作成（旧版は多数のテーブル・カラムが欠落していた）

--- a/migrations/0010_fix_course_highlights_fk.sql
+++ b/migrations/0010_fix_course_highlights_fk.sql
@@ -1,0 +1,24 @@
+-- race_course_highlights.category_id FK を ON DELETE CASCADE に修正
+-- schema.ts では onDelete: "cascade" と定義しているが、
+-- 0007_yielding_obadiah_stane.sql が ALTER TABLE で追加した際に ON DELETE 句が欠落していた。
+-- SQLite は ALTER TABLE ... DROP CONSTRAINT が使えないためテーブル再作成で対応する。
+
+CREATE TABLE `race_course_highlights_new` (
+  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `race_id` text NOT NULL,
+  `km` real,
+  `name_ja` text NOT NULL,
+  `name_en` text,
+  `note_ja` text,
+  `note_en` text,
+  `sort_order` integer DEFAULT 0 NOT NULL,
+  `category_id` integer,
+  FOREIGN KEY (`race_id`) REFERENCES `races`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`category_id`) REFERENCES `race_categories`(`id`) ON UPDATE no action ON DELETE cascade
+);
+INSERT INTO `race_course_highlights_new` (`id`, `race_id`, `km`, `name_ja`, `name_en`, `note_ja`, `note_en`, `sort_order`, `category_id`)
+  SELECT `id`, `race_id`, `km`, `name_ja`, `name_en`, `note_ja`, `note_en`, `sort_order`, `category_id`
+  FROM `race_course_highlights`;
+DROP TABLE `race_course_highlights`;
+ALTER TABLE `race_course_highlights_new` RENAME TO `race_course_highlights`;
+CREATE INDEX `race_course_highlights_race_id_idx` ON `race_course_highlights` (`race_id`);

--- a/migrations/seed-races-all.sql
+++ b/migrations/seed-races-all.sql
@@ -1,10 +1,24 @@
 -- 自動生成: generate-seed-races.js
--- 生成日時: 2026-05-12T14:03:23.337Z
--- 対象ファイル数: 76 件（既存 2 件はskip）
+-- 生成日時: 2026-05-15T15:25:44.900Z
+-- 対象ファイル数: 78 件（既存 2 件はskip）
 
 -- ==================
 -- オホーツク網走マラソン (abashiri-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'abashiri-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'abashiri-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'abashiri-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'abashiri-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'abashiri-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'abashiri-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'abashiri-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'abashiri-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'abashiri-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'abashiri-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'abashiri-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'abashiri-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'abashiri-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'abashiri-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -62,20 +76,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-29T11:38:18.538Z',
   '2026-03-29T11:38:18.538Z'
 );
-DELETE FROM race_categories WHERE race_id = 'abashiri-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'abashiri-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'abashiri-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'abashiri-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'abashiri-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'abashiri-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'abashiri-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'abashiri-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'abashiri-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'abashiri-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'abashiri-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'abashiri-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'abashiri-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'abashiri-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('abashiri-marathon-2026', 'full', 42.195, 390, '08:45', 2600, 12000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
@@ -86,6 +86,20 @@ INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label
 -- ==================
 -- 北緯40°秋田内陸リゾートカップ100キロチャレンジマラソン (akita-nairiku-ultra-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'akita-nairiku-ultra-2026';
+DELETE FROM race_categories WHERE race_id = 'akita-nairiku-ultra-2026';
+DELETE FROM aid_stations WHERE race_id = 'akita-nairiku-ultra-2026';
+DELETE FROM checkpoints WHERE race_id = 'akita-nairiku-ultra-2026';
+DELETE FROM access_points WHERE race_id = 'akita-nairiku-ultra-2026';
+DELETE FROM nearby_spots WHERE race_id = 'akita-nairiku-ultra-2026';
+DELETE FROM weather_history WHERE race_id = 'akita-nairiku-ultra-2026';
+DELETE FROM participation_gifts WHERE race_id = 'akita-nairiku-ultra-2026';
+DELETE FROM race_entry_links WHERE race_id = 'akita-nairiku-ultra-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'akita-nairiku-ultra-2026';
+DELETE FROM race_results WHERE race_id = 'akita-nairiku-ultra-2026';
+DELETE FROM race_gallery WHERE race_id = 'akita-nairiku-ultra-2026';
+DELETE FROM race_voices WHERE race_id = 'akita-nairiku-ultra-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'akita-nairiku-ultra-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -143,20 +157,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-29T00:00:00Z',
   '2026-03-29T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'akita-nairiku-ultra-2026';
-DELETE FROM aid_stations WHERE race_id = 'akita-nairiku-ultra-2026';
-DELETE FROM checkpoints WHERE race_id = 'akita-nairiku-ultra-2026';
-DELETE FROM access_points WHERE race_id = 'akita-nairiku-ultra-2026';
-DELETE FROM nearby_spots WHERE race_id = 'akita-nairiku-ultra-2026';
-DELETE FROM weather_history WHERE race_id = 'akita-nairiku-ultra-2026';
-DELETE FROM participation_gifts WHERE race_id = 'akita-nairiku-ultra-2026';
-DELETE FROM race_entry_links WHERE race_id = 'akita-nairiku-ultra-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'akita-nairiku-ultra-2026';
-DELETE FROM race_results WHERE race_id = 'akita-nairiku-ultra-2026';
-DELETE FROM race_gallery WHERE race_id = 'akita-nairiku-ultra-2026';
-DELETE FROM race_voices WHERE race_id = 'akita-nairiku-ultra-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'akita-nairiku-ultra-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'akita-nairiku-ultra-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('akita-nairiku-ultra-2026', 'ultra', 100, 780, '05:00', 650, 22000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -175,6 +175,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- あおもり桜マラソン (aomori-sakura-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'aomori-sakura-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'aomori-sakura-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'aomori-sakura-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'aomori-sakura-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'aomori-sakura-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'aomori-sakura-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'aomori-sakura-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'aomori-sakura-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'aomori-sakura-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'aomori-sakura-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'aomori-sakura-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'aomori-sakura-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'aomori-sakura-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'aomori-sakura-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -232,20 +246,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-15T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'aomori-sakura-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'aomori-sakura-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'aomori-sakura-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'aomori-sakura-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'aomori-sakura-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'aomori-sakura-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'aomori-sakura-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'aomori-sakura-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'aomori-sakura-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'aomori-sakura-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'aomori-sakura-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'aomori-sakura-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'aomori-sakura-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'aomori-sakura-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('aomori-sakura-marathon-2026', 'full', 42.195, 330, '08:50', 2400, 7000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -268,6 +268,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- 旭川ハーフマラソン (asahikawa-half-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'asahikawa-half-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'asahikawa-half-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'asahikawa-half-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'asahikawa-half-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'asahikawa-half-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'asahikawa-half-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'asahikawa-half-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'asahikawa-half-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'asahikawa-half-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'asahikawa-half-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'asahikawa-half-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'asahikawa-half-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'asahikawa-half-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'asahikawa-half-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -325,20 +339,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-29T00:00:00Z',
   '2026-03-29T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'asahikawa-half-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'asahikawa-half-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'asahikawa-half-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'asahikawa-half-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'asahikawa-half-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'asahikawa-half-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'asahikawa-half-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'asahikawa-half-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'asahikawa-half-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'asahikawa-half-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'asahikawa-half-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'asahikawa-half-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'asahikawa-half-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'asahikawa-half-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('asahikawa-half-marathon-2026', 'half', 21.0975, 180, '08:30', 2500, 6500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -351,6 +351,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- 別府大分毎日マラソン (beppu-oita-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'beppu-oita-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'beppu-oita-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'beppu-oita-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'beppu-oita-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'beppu-oita-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'beppu-oita-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'beppu-oita-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'beppu-oita-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'beppu-oita-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'beppu-oita-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'beppu-oita-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'beppu-oita-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'beppu-oita-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'beppu-oita-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -408,20 +422,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-16T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'beppu-oita-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'beppu-oita-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'beppu-oita-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'beppu-oita-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'beppu-oita-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'beppu-oita-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'beppu-oita-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'beppu-oita-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'beppu-oita-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'beppu-oita-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'beppu-oita-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'beppu-oita-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'beppu-oita-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'beppu-oita-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('beppu-oita-marathon-2026', 'full', 42.195, 0, '12:00', 4000, 15000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -440,6 +440,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- びわ湖マラソン (biwako-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'biwako-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'biwako-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'biwako-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'biwako-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'biwako-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'biwako-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'biwako-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'biwako-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'biwako-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'biwako-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'biwako-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'biwako-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'biwako-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'biwako-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -497,20 +511,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-15T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'biwako-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'biwako-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'biwako-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'biwako-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'biwako-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'biwako-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'biwako-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'biwako-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'biwako-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'biwako-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'biwako-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'biwako-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'biwako-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'biwako-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('biwako-marathon-2026', 'full', 42.195, 360, '08:20', 7000, 15000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -527,6 +527,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- ちばアクアラインマラソン (chiba-aqualine-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'chiba-aqualine-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'chiba-aqualine-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'chiba-aqualine-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'chiba-aqualine-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'chiba-aqualine-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'chiba-aqualine-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'chiba-aqualine-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'chiba-aqualine-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'chiba-aqualine-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'chiba-aqualine-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'chiba-aqualine-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'chiba-aqualine-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'chiba-aqualine-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'chiba-aqualine-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -584,20 +598,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-30T00:00:00Z',
   '2026-03-30T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'chiba-aqualine-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'chiba-aqualine-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'chiba-aqualine-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'chiba-aqualine-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'chiba-aqualine-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'chiba-aqualine-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'chiba-aqualine-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'chiba-aqualine-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'chiba-aqualine-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'chiba-aqualine-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'chiba-aqualine-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'chiba-aqualine-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'chiba-aqualine-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'chiba-aqualine-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('chiba-aqualine-marathon-2026', 'full', 42.195, 375, '09:45', 12000, 16500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -618,6 +618,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- 愛媛マラソン (ehime-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'ehime-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'ehime-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'ehime-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'ehime-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'ehime-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'ehime-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'ehime-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'ehime-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'ehime-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'ehime-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'ehime-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'ehime-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'ehime-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'ehime-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -675,20 +689,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-15T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'ehime-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'ehime-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'ehime-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'ehime-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'ehime-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'ehime-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'ehime-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'ehime-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'ehime-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'ehime-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'ehime-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'ehime-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'ehime-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'ehime-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('ehime-marathon-2026', 'full', 42.195, 360, '10:00', 10000, 12900, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -707,6 +707,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- 富士登山競走 (fuji-mountain-race-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'fuji-mountain-race-2026';
+DELETE FROM race_categories WHERE race_id = 'fuji-mountain-race-2026';
+DELETE FROM aid_stations WHERE race_id = 'fuji-mountain-race-2026';
+DELETE FROM checkpoints WHERE race_id = 'fuji-mountain-race-2026';
+DELETE FROM access_points WHERE race_id = 'fuji-mountain-race-2026';
+DELETE FROM nearby_spots WHERE race_id = 'fuji-mountain-race-2026';
+DELETE FROM weather_history WHERE race_id = 'fuji-mountain-race-2026';
+DELETE FROM participation_gifts WHERE race_id = 'fuji-mountain-race-2026';
+DELETE FROM race_entry_links WHERE race_id = 'fuji-mountain-race-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'fuji-mountain-race-2026';
+DELETE FROM race_results WHERE race_id = 'fuji-mountain-race-2026';
+DELETE FROM race_gallery WHERE race_id = 'fuji-mountain-race-2026';
+DELETE FROM race_voices WHERE race_id = 'fuji-mountain-race-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'fuji-mountain-race-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -770,20 +784,6 @@ Please note that if you forget your race number or timing chip on the day of the
   '2026-04-28T16:44:56.479Z',
   '2026-04-28T16:44:56.479Z'
 );
-DELETE FROM race_categories WHERE race_id = 'fuji-mountain-race-2026';
-DELETE FROM aid_stations WHERE race_id = 'fuji-mountain-race-2026';
-DELETE FROM checkpoints WHERE race_id = 'fuji-mountain-race-2026';
-DELETE FROM access_points WHERE race_id = 'fuji-mountain-race-2026';
-DELETE FROM nearby_spots WHERE race_id = 'fuji-mountain-race-2026';
-DELETE FROM weather_history WHERE race_id = 'fuji-mountain-race-2026';
-DELETE FROM participation_gifts WHERE race_id = 'fuji-mountain-race-2026';
-DELETE FROM race_entry_links WHERE race_id = 'fuji-mountain-race-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'fuji-mountain-race-2026';
-DELETE FROM race_results WHERE race_id = 'fuji-mountain-race-2026';
-DELETE FROM race_gallery WHERE race_id = 'fuji-mountain-race-2026';
-DELETE FROM race_voices WHERE race_id = 'fuji-mountain-race-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'fuji-mountain-race-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'fuji-mountain-race-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('fuji-mountain-race-2026', 'other', 21, 260, '07:00', 1770, 18000, NULL, '山頂コース', NULL, NULL, NULL, '第76回大会、第77回大会、第78回大会のいずれかにおいて五合目関門（五合目ゴール）通過時間が2時間20分以内の実績のある者。又は、第2回富士山クライムランにおいて五合目ゴール時間が2時間以内の実績がある者とする。 過去(第76回、第77回、第78回)の大会の記録についてはこちらからご確認ください。 第2回富士山クライムランの記録についてはこちらからご確認ください。', 'Participants must have completed the 5th Station checkpoint (5th Station finish) in 2 hours and 20 minutes or less in either the 76th, 77th, or 78th edition of the race. Alternatively, participants must have completed the 5th Station finish in 2 hours or less in the 2nd Mount Fuji Climb Run. Please click here to view records from past editions (76th, 77th, and 78th). Please click here to view records from the 2nd Mt. Fuji Climb Run.  Translated with DeepL.com (free version)', 'fuji-mountain-race-2026.gpx', '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -796,6 +796,20 @@ INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label
 -- ==================
 -- 富士山マラソン (fujisan-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'fujisan-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'fujisan-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'fujisan-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'fujisan-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'fujisan-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'fujisan-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'fujisan-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'fujisan-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'fujisan-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'fujisan-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'fujisan-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'fujisan-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'fujisan-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'fujisan-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -853,20 +867,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-16T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'fujisan-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'fujisan-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'fujisan-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'fujisan-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'fujisan-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'fujisan-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'fujisan-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'fujisan-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'fujisan-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'fujisan-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'fujisan-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'fujisan-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'fujisan-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'fujisan-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('fujisan-marathon-2026', 'full', 42.195, 360, '09:00', 0, 12900, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 'fujisan-marathon-2026.kml', '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -881,6 +881,20 @@ INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label
 -- ==================
 -- 福知山マラソン (fukuchiyama-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'fukuchiyama-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'fukuchiyama-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'fukuchiyama-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'fukuchiyama-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'fukuchiyama-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'fukuchiyama-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'fukuchiyama-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'fukuchiyama-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'fukuchiyama-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'fukuchiyama-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'fukuchiyama-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'fukuchiyama-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'fukuchiyama-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'fukuchiyama-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -938,20 +952,6 @@ INSERT OR REPLACE INTO races (
   '2026-04-30T00:00:00Z',
   '2026-04-30T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'fukuchiyama-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'fukuchiyama-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'fukuchiyama-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'fukuchiyama-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'fukuchiyama-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'fukuchiyama-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'fukuchiyama-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'fukuchiyama-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'fukuchiyama-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'fukuchiyama-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'fukuchiyama-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'fukuchiyama-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'fukuchiyama-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'fukuchiyama-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('fukuchiyama-marathon-2026', 'full', 42.195, 360, '', 5400, 11000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -970,6 +970,20 @@ INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label
 -- ==================
 -- ふくい桜マラソン (fukui-sakura-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'fukui-sakura-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'fukui-sakura-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'fukui-sakura-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'fukui-sakura-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'fukui-sakura-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'fukui-sakura-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'fukui-sakura-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'fukui-sakura-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'fukui-sakura-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'fukui-sakura-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'fukui-sakura-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'fukui-sakura-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'fukui-sakura-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'fukui-sakura-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -1027,20 +1041,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-15T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'fukui-sakura-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'fukui-sakura-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'fukui-sakura-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'fukui-sakura-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'fukui-sakura-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'fukui-sakura-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'fukui-sakura-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'fukui-sakura-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'fukui-sakura-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'fukui-sakura-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'fukui-sakura-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'fukui-sakura-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'fukui-sakura-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'fukui-sakura-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('fukui-sakura-marathon-2026', 'full', 42.195, 420, '08:30', 13200, 14000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -1063,6 +1063,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- 福岡国際マラソン (fukuoka-international-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'fukuoka-international-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'fukuoka-international-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'fukuoka-international-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'fukuoka-international-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'fukuoka-international-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'fukuoka-international-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'fukuoka-international-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'fukuoka-international-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'fukuoka-international-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'fukuoka-international-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'fukuoka-international-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'fukuoka-international-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'fukuoka-international-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'fukuoka-international-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -1120,20 +1134,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-16T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'fukuoka-international-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'fukuoka-international-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'fukuoka-international-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'fukuoka-international-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'fukuoka-international-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'fukuoka-international-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'fukuoka-international-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'fukuoka-international-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'fukuoka-international-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'fukuoka-international-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'fukuoka-international-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'fukuoka-international-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'fukuoka-international-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'fukuoka-international-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('fukuoka-international-marathon-2026', 'full', 42.195, 155, '12:10', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -1150,6 +1150,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- 福岡マラソン (fukuoka-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'fukuoka-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'fukuoka-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'fukuoka-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'fukuoka-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'fukuoka-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'fukuoka-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'fukuoka-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'fukuoka-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'fukuoka-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'fukuoka-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'fukuoka-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'fukuoka-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'fukuoka-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'fukuoka-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -1207,32 +1221,18 @@ INSERT OR REPLACE INTO races (
   '2026-04-30T00:00:00Z',
   '2026-04-30T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'fukuoka-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'fukuoka-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'fukuoka-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'fukuoka-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'fukuoka-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'fukuoka-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'fukuoka-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'fukuoka-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'fukuoka-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'fukuoka-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'fukuoka-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'fukuoka-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'fukuoka-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'fukuoka-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('fukuoka-marathon-2026', 'full', 42.195, 420, '08:20', 13000, 16000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('fukuoka-marathon-2026', last_insert_rowid(), 5, 'シーサイドももち', NULL, '福岡タワーやみずほPayPayドーム福岡など、福岡を代表する観光スポットが並ぶシーサイドももち地区では、近代的できれいな街並みが楽しめます。かつての百道（ももち）の海岸が漫画『サザエさん』発案の地であることから、地元市民の声を受けて、2012年5月に「サザエさん通り」が誕生しました。', NULL, 0);
+  ('fukuoka-marathon-2026', (SELECT id FROM race_categories WHERE race_id = 'fukuoka-marathon-2026' AND distance_type = 'full' ORDER BY id DESC LIMIT 1), 5, 'シーサイドももち', NULL, '福岡タワーやみずほPayPayドーム福岡など、福岡を代表する観光スポットが並ぶシーサイドももち地区では、近代的できれいな街並みが楽しめます。かつての百道（ももち）の海岸が漫画『サザエさん』発案の地であることから、地元市民の声を受けて、2012年5月に「サザエさん通り」が誕生しました。', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('fukuoka-marathon-2026', last_insert_rowid(), 11, '生の松原・長垂海岸', NULL, '白砂青松百選の生の松原は、元寇防塁があることでも有名です。美しい松林を抜けるとコース右手に博多湾が広がり、四季折々の花が咲く能古島が一望できます。', NULL, 1);
+  ('fukuoka-marathon-2026', (SELECT id FROM race_categories WHERE race_id = 'fukuoka-marathon-2026' AND distance_type = 'full' ORDER BY id DESC LIMIT 1), 11, '生の松原・長垂海岸', NULL, '白砂青松百選の生の松原は、元寇防塁があることでも有名です。美しい松林を抜けるとコース右手に博多湾が広がり、四季折々の花が咲く能古島が一望できます。', NULL, 1);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('fukuoka-marathon-2026', last_insert_rowid(), 20, '九州大学伊都キャンパス', NULL, '2018年に移転が完了した九州大学伊都キャンパスは、みずほPayPayドーム福岡約40個分の広さを誇り、その雄大さは圧巻です。キャンパスの入口に向かう緩やかな坂道は、コース前半の山場になるでしょう。ここは、沿道の声援を力にして乗り切りましょう！', NULL, 2);
+  ('fukuoka-marathon-2026', (SELECT id FROM race_categories WHERE race_id = 'fukuoka-marathon-2026' AND distance_type = 'full' ORDER BY id DESC LIMIT 1), 20, '九州大学伊都キャンパス', NULL, '2018年に移転が完了した九州大学伊都キャンパスは、みずほPayPayドーム福岡約40個分の広さを誇り、その雄大さは圧巻です。キャンパスの入口に向かう緩やかな坂道は、コース前半の山場になるでしょう。ここは、沿道の声援を力にして乗り切りましょう！', NULL, 2);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('fukuoka-marathon-2026', last_insert_rowid(), 29, '海づり公園', NULL, '福岡市西区の今津・北崎エリアは、海づり公園のほかにカフェやお食事処、牡蠣小屋があり、週末には多くの人が訪れます。博多湾に目を向けると、遠くには福岡タワーや金印で有名な志賀島が望めます', NULL, 3);
+  ('fukuoka-marathon-2026', (SELECT id FROM race_categories WHERE race_id = 'fukuoka-marathon-2026' AND distance_type = 'full' ORDER BY id DESC LIMIT 1), 29, '海づり公園', NULL, '福岡市西区の今津・北崎エリアは、海づり公園のほかにカフェやお食事処、牡蠣小屋があり、週末には多くの人が訪れます。博多湾に目を向けると、遠くには福岡タワーや金印で有名な志賀島が望めます', NULL, 3);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('fukuoka-marathon-2026', last_insert_rowid(), 35, '二見ヶ浦', NULL, 'コース後半の高低差25mの山場を過ぎると、玄界灘の美しい海岸線が見えてきます。渚百選・夕陽百選の一つである二見ヶ浦は、福岡市と糸島市の境にある観光スポットで、付近はおしゃれな飲食店が並び、親子連れやカップル、また多くの観光客で賑わいます。', NULL, 4);
+  ('fukuoka-marathon-2026', (SELECT id FROM race_categories WHERE race_id = 'fukuoka-marathon-2026' AND distance_type = 'full' ORDER BY id DESC LIMIT 1), 35, '二見ヶ浦', NULL, 'コース後半の高低差25mの山場を過ぎると、玄界灘の美しい海岸線が見えてきます。渚百選・夕陽百選の一つである二見ヶ浦は、福岡市と糸島市の境にある観光スポットで、付近はおしゃれな飲食店が並び、親子連れやカップル、また多くの観光客で賑わいます。', NULL, 4);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('fukuoka-marathon-2026', '観光地', '天神・博多エリア', 'Tenjin & Hakata Area', 'スタート地点の天神は福岡最大の繁華街。大会前後のショッピング・グルメに便利。', 'Tenjin, the start point, is Fukuoka''s largest shopping district. Convenient for pre/post-race dining and shopping.', 'スタート地点', NULL, 33.5904, 130.399);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -1247,6 +1247,20 @@ INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label
 -- ==================
 -- ぐんまマラソン (gunma-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'gunma-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'gunma-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'gunma-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'gunma-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'gunma-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'gunma-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'gunma-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'gunma-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'gunma-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'gunma-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'gunma-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'gunma-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'gunma-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'gunma-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -1314,20 +1328,6 @@ If you are unable to participate after registering, you do not need to contact u
   '2026-03-15T00:00:00Z',
   '2026-03-15T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'gunma-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'gunma-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'gunma-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'gunma-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'gunma-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'gunma-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'gunma-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'gunma-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'gunma-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'gunma-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'gunma-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'gunma-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'gunma-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'gunma-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('gunma-marathon-2026', 'full', 42.195, 360, '08:55', 5500, 13500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -1354,6 +1354,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- さくらんぼマラソン大会 (higashine-sakuranbo-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'higashine-sakuranbo-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'higashine-sakuranbo-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'higashine-sakuranbo-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'higashine-sakuranbo-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'higashine-sakuranbo-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'higashine-sakuranbo-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'higashine-sakuranbo-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'higashine-sakuranbo-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'higashine-sakuranbo-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'higashine-sakuranbo-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'higashine-sakuranbo-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'higashine-sakuranbo-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'higashine-sakuranbo-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'higashine-sakuranbo-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -1411,20 +1425,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-30T00:00:00Z',
   '2026-03-30T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'higashine-sakuranbo-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'higashine-sakuranbo-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'higashine-sakuranbo-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'higashine-sakuranbo-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'higashine-sakuranbo-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'higashine-sakuranbo-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'higashine-sakuranbo-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'higashine-sakuranbo-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'higashine-sakuranbo-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'higashine-sakuranbo-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'higashine-sakuranbo-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'higashine-sakuranbo-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'higashine-sakuranbo-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'higashine-sakuranbo-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('higashine-sakuranbo-marathon-2026', 'half', 21.0975, 170, '08:40', 5500, 6000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -1443,6 +1443,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- 東日本ハーフマラソン (higashinipon-half-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'higashinipon-half-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'higashinipon-half-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'higashinipon-half-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'higashinipon-half-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'higashinipon-half-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'higashinipon-half-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'higashinipon-half-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'higashinipon-half-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'higashinipon-half-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'higashinipon-half-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'higashinipon-half-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'higashinipon-half-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'higashinipon-half-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'higashinipon-half-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -1500,20 +1514,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-29T00:00:00Z',
   '2026-03-29T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'higashinipon-half-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'higashinipon-half-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'higashinipon-half-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'higashinipon-half-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'higashinipon-half-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'higashinipon-half-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'higashinipon-half-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'higashinipon-half-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'higashinipon-half-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'higashinipon-half-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'higashinipon-half-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'higashinipon-half-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'higashinipon-half-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'higashinipon-half-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('higashinipon-half-marathon-2026', 'half', 21.0975, 180, '09:00', 4000, 5500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -1528,6 +1528,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- 世界遺産姫路城マラソン (himeji-castle-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'himeji-castle-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'himeji-castle-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'himeji-castle-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'himeji-castle-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'himeji-castle-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'himeji-castle-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'himeji-castle-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'himeji-castle-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'himeji-castle-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'himeji-castle-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'himeji-castle-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'himeji-castle-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'himeji-castle-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'himeji-castle-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -1585,20 +1599,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-15T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'himeji-castle-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'himeji-castle-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'himeji-castle-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'himeji-castle-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'himeji-castle-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'himeji-castle-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'himeji-castle-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'himeji-castle-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'himeji-castle-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'himeji-castle-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'himeji-castle-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'himeji-castle-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'himeji-castle-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'himeji-castle-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('himeji-castle-marathon-2026', 'full', 42.195, 360, '', 9000, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -1613,6 +1613,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- ひたちシーサイドマラソン (hitachi-seaside-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'hitachi-seaside-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'hitachi-seaside-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'hitachi-seaside-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'hitachi-seaside-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'hitachi-seaside-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'hitachi-seaside-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'hitachi-seaside-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'hitachi-seaside-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'hitachi-seaside-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'hitachi-seaside-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'hitachi-seaside-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'hitachi-seaside-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'hitachi-seaside-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'hitachi-seaside-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -1674,20 +1688,6 @@ With the scenery and the sea breeze pushing you forward, you can fully savor the
   '2026-04-11T14:28:19.021Z',
   '2026-04-11T14:28:19.021Z'
 );
-DELETE FROM race_categories WHERE race_id = 'hitachi-seaside-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'hitachi-seaside-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'hitachi-seaside-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'hitachi-seaside-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'hitachi-seaside-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'hitachi-seaside-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'hitachi-seaside-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'hitachi-seaside-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'hitachi-seaside-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'hitachi-seaside-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'hitachi-seaside-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'hitachi-seaside-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'hitachi-seaside-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'hitachi-seaside-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('hitachi-seaside-marathon-2026', 'full', 42.195, 360, '10:00', 6000, 10000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
@@ -1702,6 +1702,20 @@ INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label
 -- ==================
 -- 防府読売マラソン (hofu-yomiuri-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'hofu-yomiuri-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'hofu-yomiuri-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'hofu-yomiuri-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'hofu-yomiuri-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'hofu-yomiuri-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'hofu-yomiuri-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'hofu-yomiuri-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'hofu-yomiuri-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'hofu-yomiuri-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'hofu-yomiuri-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'hofu-yomiuri-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'hofu-yomiuri-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'hofu-yomiuri-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'hofu-yomiuri-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -1759,20 +1773,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-16T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'hofu-yomiuri-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'hofu-yomiuri-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'hofu-yomiuri-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'hofu-yomiuri-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'hofu-yomiuri-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'hofu-yomiuri-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'hofu-yomiuri-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'hofu-yomiuri-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'hofu-yomiuri-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'hofu-yomiuri-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'hofu-yomiuri-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'hofu-yomiuri-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'hofu-yomiuri-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'hofu-yomiuri-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('hofu-yomiuri-marathon-2026', 'full', 42.195, 240, '12:03', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -1785,6 +1785,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- 北海道マラソン (hokkaido-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'hokkaido-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'hokkaido-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'hokkaido-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'hokkaido-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'hokkaido-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'hokkaido-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'hokkaido-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'hokkaido-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'hokkaido-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'hokkaido-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'hokkaido-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'hokkaido-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'hokkaido-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'hokkaido-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -1842,20 +1856,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-15T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'hokkaido-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'hokkaido-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'hokkaido-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'hokkaido-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'hokkaido-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'hokkaido-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'hokkaido-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'hokkaido-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'hokkaido-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'hokkaido-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'hokkaido-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'hokkaido-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'hokkaido-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'hokkaido-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('hokkaido-marathon-2026', 'full', 42.195, 360, '08:30', 20000, 16500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -1878,6 +1878,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- いぶすき菜の花マラソン (ibusuki-nanohana-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'ibusuki-nanohana-2026';
+DELETE FROM race_categories WHERE race_id = 'ibusuki-nanohana-2026';
+DELETE FROM aid_stations WHERE race_id = 'ibusuki-nanohana-2026';
+DELETE FROM checkpoints WHERE race_id = 'ibusuki-nanohana-2026';
+DELETE FROM access_points WHERE race_id = 'ibusuki-nanohana-2026';
+DELETE FROM nearby_spots WHERE race_id = 'ibusuki-nanohana-2026';
+DELETE FROM weather_history WHERE race_id = 'ibusuki-nanohana-2026';
+DELETE FROM participation_gifts WHERE race_id = 'ibusuki-nanohana-2026';
+DELETE FROM race_entry_links WHERE race_id = 'ibusuki-nanohana-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'ibusuki-nanohana-2026';
+DELETE FROM race_results WHERE race_id = 'ibusuki-nanohana-2026';
+DELETE FROM race_gallery WHERE race_id = 'ibusuki-nanohana-2026';
+DELETE FROM race_voices WHERE race_id = 'ibusuki-nanohana-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'ibusuki-nanohana-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -1935,20 +1949,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-16T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'ibusuki-nanohana-2026';
-DELETE FROM aid_stations WHERE race_id = 'ibusuki-nanohana-2026';
-DELETE FROM checkpoints WHERE race_id = 'ibusuki-nanohana-2026';
-DELETE FROM access_points WHERE race_id = 'ibusuki-nanohana-2026';
-DELETE FROM nearby_spots WHERE race_id = 'ibusuki-nanohana-2026';
-DELETE FROM weather_history WHERE race_id = 'ibusuki-nanohana-2026';
-DELETE FROM participation_gifts WHERE race_id = 'ibusuki-nanohana-2026';
-DELETE FROM race_entry_links WHERE race_id = 'ibusuki-nanohana-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'ibusuki-nanohana-2026';
-DELETE FROM race_results WHERE race_id = 'ibusuki-nanohana-2026';
-DELETE FROM race_gallery WHERE race_id = 'ibusuki-nanohana-2026';
-DELETE FROM race_voices WHERE race_id = 'ibusuki-nanohana-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'ibusuki-nanohana-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'ibusuki-nanohana-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('ibusuki-nanohana-2026', 'full', 42.195, 480, '09:00', 10000, 10000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO aid_stations (race_id, distance_km, offerings_ja, offerings_en, is_featured) VALUES
@@ -1977,6 +1977,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- 一関国際ハーフマラソン (ichinoseki-half-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'ichinoseki-half-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'ichinoseki-half-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'ichinoseki-half-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'ichinoseki-half-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'ichinoseki-half-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'ichinoseki-half-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'ichinoseki-half-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'ichinoseki-half-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'ichinoseki-half-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'ichinoseki-half-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'ichinoseki-half-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'ichinoseki-half-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'ichinoseki-half-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'ichinoseki-half-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -2034,20 +2048,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-29T00:00:00Z',
   '2026-03-29T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'ichinoseki-half-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'ichinoseki-half-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'ichinoseki-half-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'ichinoseki-half-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'ichinoseki-half-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'ichinoseki-half-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'ichinoseki-half-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'ichinoseki-half-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'ichinoseki-half-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'ichinoseki-half-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'ichinoseki-half-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'ichinoseki-half-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'ichinoseki-half-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'ichinoseki-half-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('ichinoseki-half-marathon-2026', 'half', 21.0975, 170, '09:00', 2000, 6000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -2060,6 +2060,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- 神々の島 壱岐ウルトラマラソン (iki-ultra-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'iki-ultra-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'iki-ultra-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'iki-ultra-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'iki-ultra-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'iki-ultra-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'iki-ultra-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'iki-ultra-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'iki-ultra-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'iki-ultra-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'iki-ultra-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'iki-ultra-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'iki-ultra-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'iki-ultra-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'iki-ultra-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -2117,20 +2131,6 @@ INSERT OR REPLACE INTO races (
   '2026-04-05T08:19:26.353Z',
   '2026-04-05T08:19:26.353Z'
 );
-DELETE FROM race_categories WHERE race_id = 'iki-ultra-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'iki-ultra-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'iki-ultra-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'iki-ultra-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'iki-ultra-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'iki-ultra-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'iki-ultra-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'iki-ultra-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'iki-ultra-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'iki-ultra-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'iki-ultra-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'iki-ultra-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'iki-ultra-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'iki-ultra-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('iki-ultra-marathon-2026', 'ultra', 100, 840, '05:00', 1000, 20000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -2143,6 +2143,20 @@ INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label
 -- ==================
 -- 板橋Cityマラソン (itabashi-city-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'itabashi-city-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'itabashi-city-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'itabashi-city-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'itabashi-city-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'itabashi-city-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'itabashi-city-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'itabashi-city-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'itabashi-city-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'itabashi-city-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'itabashi-city-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'itabashi-city-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'itabashi-city-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'itabashi-city-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'itabashi-city-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -2200,20 +2214,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-15T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'itabashi-city-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'itabashi-city-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'itabashi-city-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'itabashi-city-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'itabashi-city-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'itabashi-city-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'itabashi-city-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'itabashi-city-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'itabashi-city-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'itabashi-city-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'itabashi-city-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'itabashi-city-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'itabashi-city-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'itabashi-city-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('itabashi-city-marathon-2026', 'full', 42.195, 420, '09:00', 10000, 11550, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -2230,6 +2230,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- いわきサンシャインマラソン (iwaki-sunshine-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'iwaki-sunshine-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'iwaki-sunshine-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'iwaki-sunshine-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'iwaki-sunshine-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'iwaki-sunshine-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'iwaki-sunshine-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'iwaki-sunshine-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'iwaki-sunshine-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'iwaki-sunshine-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'iwaki-sunshine-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'iwaki-sunshine-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'iwaki-sunshine-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'iwaki-sunshine-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'iwaki-sunshine-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -2287,20 +2301,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-15T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'iwaki-sunshine-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'iwaki-sunshine-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'iwaki-sunshine-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'iwaki-sunshine-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'iwaki-sunshine-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'iwaki-sunshine-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'iwaki-sunshine-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'iwaki-sunshine-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'iwaki-sunshine-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'iwaki-sunshine-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'iwaki-sunshine-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'iwaki-sunshine-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'iwaki-sunshine-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'iwaki-sunshine-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('iwaki-sunshine-marathon-2026', 'full', 42.195, 360, '', 5000, 9000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -2321,6 +2321,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- いわて盛岡シティマラソン (iwate-morioka-city-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'iwate-morioka-city-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'iwate-morioka-city-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'iwate-morioka-city-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'iwate-morioka-city-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'iwate-morioka-city-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'iwate-morioka-city-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'iwate-morioka-city-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'iwate-morioka-city-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'iwate-morioka-city-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'iwate-morioka-city-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'iwate-morioka-city-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'iwate-morioka-city-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'iwate-morioka-city-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'iwate-morioka-city-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -2408,20 +2422,6 @@ Translated with DeepL.com (free version)',
   '2026-04-16T15:23:52.019Z',
   '2026-04-16T15:23:52.019Z'
 );
-DELETE FROM race_categories WHERE race_id = 'iwate-morioka-city-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'iwate-morioka-city-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'iwate-morioka-city-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'iwate-morioka-city-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'iwate-morioka-city-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'iwate-morioka-city-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'iwate-morioka-city-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'iwate-morioka-city-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'iwate-morioka-city-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'iwate-morioka-city-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'iwate-morioka-city-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'iwate-morioka-city-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'iwate-morioka-city-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'iwate-morioka-city-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('iwate-morioka-city-marathon-2026', 'full', 42.195, 360, '09:00', 6000, 12000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
@@ -2432,6 +2432,20 @@ INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label
 -- ==================
 -- いわて奥州きらめきマラソン (iwate-oshu-kirameki-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -2489,20 +2503,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-15T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('iwate-oshu-kirameki-marathon-2026', 'full', 42.195, 360, '08:30', 3000, 10000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -2517,6 +2517,20 @@ INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label
 -- ==================
 -- かがわマラソン (kagawa-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'kagawa-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'kagawa-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'kagawa-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'kagawa-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'kagawa-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'kagawa-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'kagawa-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'kagawa-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'kagawa-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'kagawa-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'kagawa-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'kagawa-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'kagawa-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'kagawa-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -2574,20 +2588,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-15T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'kagawa-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'kagawa-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'kagawa-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'kagawa-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'kagawa-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'kagawa-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'kagawa-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'kagawa-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'kagawa-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'kagawa-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'kagawa-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'kagawa-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'kagawa-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'kagawa-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kagawa-marathon-2026', 'full', 42.195, 360, '10:00', 10000, 14000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -2602,6 +2602,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- 鹿児島マラソン (kagoshima-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'kagoshima-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'kagoshima-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'kagoshima-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'kagoshima-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'kagoshima-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'kagoshima-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'kagoshima-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'kagoshima-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'kagoshima-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'kagoshima-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'kagoshima-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'kagoshima-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'kagoshima-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'kagoshima-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -2659,20 +2673,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-15T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'kagoshima-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'kagoshima-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'kagoshima-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'kagoshima-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'kagoshima-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'kagoshima-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'kagoshima-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'kagoshima-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'kagoshima-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'kagoshima-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'kagoshima-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'kagoshima-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'kagoshima-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'kagoshima-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kagoshima-marathon-2026', 'full', 42.195, 420, '08:30', 10000, 14000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -2691,6 +2691,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- 下関海響マラソン (kaikyo-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'kaikyo-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'kaikyo-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'kaikyo-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'kaikyo-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'kaikyo-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'kaikyo-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'kaikyo-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'kaikyo-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'kaikyo-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'kaikyo-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'kaikyo-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'kaikyo-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'kaikyo-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'kaikyo-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -2748,20 +2762,6 @@ INSERT OR REPLACE INTO races (
   '2026-04-30T00:00:00Z',
   '2026-04-30T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'kaikyo-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'kaikyo-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'kaikyo-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'kaikyo-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'kaikyo-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'kaikyo-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'kaikyo-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'kaikyo-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'kaikyo-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'kaikyo-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'kaikyo-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'kaikyo-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'kaikyo-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'kaikyo-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kaikyo-marathon-2026', 'full', 42.195, 360, '', 10000, 12000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -2784,6 +2784,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- 金沢マラソン (kanazawa-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'kanazawa-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'kanazawa-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'kanazawa-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'kanazawa-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'kanazawa-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'kanazawa-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'kanazawa-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'kanazawa-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'kanazawa-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'kanazawa-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'kanazawa-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'kanazawa-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'kanazawa-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'kanazawa-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -2841,20 +2855,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-15T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'kanazawa-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'kanazawa-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'kanazawa-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'kanazawa-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'kanazawa-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'kanazawa-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'kanazawa-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'kanazawa-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'kanazawa-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'kanazawa-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'kanazawa-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'kanazawa-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'kanazawa-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'kanazawa-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kanazawa-marathon-2026', 'full', 42.195, 420, '08:30', 15000, 14000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -2877,6 +2877,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- かさま陶芸の里ハーフマラソン (kasama-togeinosato-half-2025-2025)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'kasama-togeinosato-half-2025-2025';
+DELETE FROM race_categories WHERE race_id = 'kasama-togeinosato-half-2025-2025';
+DELETE FROM aid_stations WHERE race_id = 'kasama-togeinosato-half-2025-2025';
+DELETE FROM checkpoints WHERE race_id = 'kasama-togeinosato-half-2025-2025';
+DELETE FROM access_points WHERE race_id = 'kasama-togeinosato-half-2025-2025';
+DELETE FROM nearby_spots WHERE race_id = 'kasama-togeinosato-half-2025-2025';
+DELETE FROM weather_history WHERE race_id = 'kasama-togeinosato-half-2025-2025';
+DELETE FROM participation_gifts WHERE race_id = 'kasama-togeinosato-half-2025-2025';
+DELETE FROM race_entry_links WHERE race_id = 'kasama-togeinosato-half-2025-2025';
+DELETE FROM race_entry_periods WHERE race_id = 'kasama-togeinosato-half-2025-2025';
+DELETE FROM race_results WHERE race_id = 'kasama-togeinosato-half-2025-2025';
+DELETE FROM race_gallery WHERE race_id = 'kasama-togeinosato-half-2025-2025';
+DELETE FROM race_voices WHERE race_id = 'kasama-togeinosato-half-2025-2025';
+DELETE FROM race_time_buckets WHERE race_id = 'kasama-togeinosato-half-2025-2025';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -2934,20 +2948,6 @@ INSERT OR REPLACE INTO races (
   '2026-05-09T14:16:13.893Z',
   '2026-05-09T14:16:13.893Z'
 );
-DELETE FROM race_categories WHERE race_id = 'kasama-togeinosato-half-2025-2025';
-DELETE FROM aid_stations WHERE race_id = 'kasama-togeinosato-half-2025-2025';
-DELETE FROM checkpoints WHERE race_id = 'kasama-togeinosato-half-2025-2025';
-DELETE FROM access_points WHERE race_id = 'kasama-togeinosato-half-2025-2025';
-DELETE FROM nearby_spots WHERE race_id = 'kasama-togeinosato-half-2025-2025';
-DELETE FROM weather_history WHERE race_id = 'kasama-togeinosato-half-2025-2025';
-DELETE FROM participation_gifts WHERE race_id = 'kasama-togeinosato-half-2025-2025';
-DELETE FROM race_entry_links WHERE race_id = 'kasama-togeinosato-half-2025-2025';
-DELETE FROM race_entry_periods WHERE race_id = 'kasama-togeinosato-half-2025-2025';
-DELETE FROM race_results WHERE race_id = 'kasama-togeinosato-half-2025-2025';
-DELETE FROM race_gallery WHERE race_id = 'kasama-togeinosato-half-2025-2025';
-DELETE FROM race_voices WHERE race_id = 'kasama-togeinosato-half-2025-2025';
-DELETE FROM race_time_buckets WHERE race_id = 'kasama-togeinosato-half-2025-2025';
-DELETE FROM race_course_highlights WHERE race_id = 'kasama-togeinosato-half-2025-2025';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kasama-togeinosato-half-2025-2025', 'half', 21.0975, 150, '10:00', 2000, 5000, NULL, NULL, NULL, NULL, NULL, '18歳以上（高校生を除く）で健康に異常がなく２時間30分以内で完走できる方。なお、安全管理運営上、車いすやベビーカーを使用しての参加はできません。
 
@@ -2980,6 +2980,20 @@ INSERT OR REPLACE INTO race_time_buckets (race_id, bucket, pct, sort_order) VALU
 -- ==================
 -- かすみがうらマラソン (kasumigaura-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'kasumigaura-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'kasumigaura-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'kasumigaura-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'kasumigaura-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'kasumigaura-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'kasumigaura-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'kasumigaura-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'kasumigaura-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'kasumigaura-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'kasumigaura-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'kasumigaura-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'kasumigaura-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'kasumigaura-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'kasumigaura-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -3037,20 +3051,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-15T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'kasumigaura-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'kasumigaura-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'kasumigaura-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'kasumigaura-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'kasumigaura-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'kasumigaura-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'kasumigaura-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'kasumigaura-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'kasumigaura-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'kasumigaura-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'kasumigaura-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'kasumigaura-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'kasumigaura-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'kasumigaura-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kasumigaura-marathon-2026', 'full', 42.195, 360, '09:45', 14000, 12000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -3069,6 +3069,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- 勝田全国マラソン (katsuta-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'katsuta-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'katsuta-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'katsuta-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'katsuta-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'katsuta-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'katsuta-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'katsuta-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'katsuta-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'katsuta-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'katsuta-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'katsuta-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'katsuta-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'katsuta-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'katsuta-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -3126,20 +3140,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-16T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'katsuta-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'katsuta-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'katsuta-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'katsuta-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'katsuta-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'katsuta-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'katsuta-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'katsuta-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'katsuta-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'katsuta-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'katsuta-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'katsuta-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'katsuta-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'katsuta-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('katsuta-marathon-2026', 'full', 42.195, 360, '10:30', 0, 8000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -3156,6 +3156,20 @@ INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label
 -- ==================
 -- 北九州マラソン (kitakyushu-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'kitakyushu-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'kitakyushu-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'kitakyushu-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'kitakyushu-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'kitakyushu-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'kitakyushu-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'kitakyushu-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'kitakyushu-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'kitakyushu-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'kitakyushu-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'kitakyushu-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'kitakyushu-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'kitakyushu-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'kitakyushu-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -3213,20 +3227,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-15T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'kitakyushu-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'kitakyushu-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'kitakyushu-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'kitakyushu-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'kitakyushu-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'kitakyushu-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'kitakyushu-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'kitakyushu-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'kitakyushu-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'kitakyushu-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'kitakyushu-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'kitakyushu-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'kitakyushu-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'kitakyushu-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kitakyushu-marathon-2026', 'full', 42.195, 360, '09:00', 10800, 14500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -3245,6 +3245,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- KIX泉州国際マラソン (kix-senshu-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'kix-senshu-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'kix-senshu-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'kix-senshu-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'kix-senshu-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'kix-senshu-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'kix-senshu-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'kix-senshu-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'kix-senshu-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'kix-senshu-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'kix-senshu-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'kix-senshu-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'kix-senshu-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'kix-senshu-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'kix-senshu-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -3302,20 +3316,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-15T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'kix-senshu-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'kix-senshu-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'kix-senshu-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'kix-senshu-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'kix-senshu-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'kix-senshu-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'kix-senshu-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'kix-senshu-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'kix-senshu-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'kix-senshu-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'kix-senshu-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'kix-senshu-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'kix-senshu-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'kix-senshu-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kix-senshu-marathon-2026', 'full', 42.195, 420, '10:30', 700, 5000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -3330,6 +3330,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- 神戸マラソン (kobe-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'kobe-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'kobe-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'kobe-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'kobe-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'kobe-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'kobe-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'kobe-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'kobe-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'kobe-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'kobe-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'kobe-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'kobe-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'kobe-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'kobe-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -3405,20 +3419,6 @@ For relay runs, both runners must register together. Registration by one person,
   '2026-03-15T00:00:00Z',
   '2026-03-15T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'kobe-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'kobe-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'kobe-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'kobe-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'kobe-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'kobe-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'kobe-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'kobe-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'kobe-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'kobe-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'kobe-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'kobe-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'kobe-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'kobe-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kobe-marathon-2026', 'full', 42.195, 420, '09:00', 20000, 18000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -3441,6 +3441,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- 高知龍馬マラソン (kochi-ryoma-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'kochi-ryoma-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'kochi-ryoma-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'kochi-ryoma-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'kochi-ryoma-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'kochi-ryoma-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'kochi-ryoma-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'kochi-ryoma-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'kochi-ryoma-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'kochi-ryoma-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'kochi-ryoma-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'kochi-ryoma-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'kochi-ryoma-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'kochi-ryoma-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'kochi-ryoma-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -3498,20 +3512,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-15T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'kochi-ryoma-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'kochi-ryoma-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'kochi-ryoma-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'kochi-ryoma-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'kochi-ryoma-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'kochi-ryoma-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'kochi-ryoma-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'kochi-ryoma-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'kochi-ryoma-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'kochi-ryoma-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'kochi-ryoma-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'kochi-ryoma-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'kochi-ryoma-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'kochi-ryoma-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kochi-ryoma-marathon-2026', 'full', 42.195, 420, '09:00', 10000, 13000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -3532,6 +3532,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- 熊本城マラソン (kumamoto-castle-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'kumamoto-castle-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'kumamoto-castle-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'kumamoto-castle-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'kumamoto-castle-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'kumamoto-castle-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'kumamoto-castle-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'kumamoto-castle-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'kumamoto-castle-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'kumamoto-castle-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'kumamoto-castle-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'kumamoto-castle-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'kumamoto-castle-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'kumamoto-castle-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'kumamoto-castle-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -3589,20 +3603,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-16T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'kumamoto-castle-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'kumamoto-castle-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'kumamoto-castle-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'kumamoto-castle-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'kumamoto-castle-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'kumamoto-castle-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'kumamoto-castle-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'kumamoto-castle-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'kumamoto-castle-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'kumamoto-castle-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'kumamoto-castle-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'kumamoto-castle-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'kumamoto-castle-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'kumamoto-castle-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kumamoto-castle-marathon-2026', 'full', 42.195, 420, '09:00', 13000, 13750, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -3619,6 +3619,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- 京都マラソン (kyoto-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'kyoto-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'kyoto-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'kyoto-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'kyoto-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'kyoto-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'kyoto-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'kyoto-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'kyoto-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'kyoto-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'kyoto-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'kyoto-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'kyoto-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'kyoto-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'kyoto-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -3676,20 +3690,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-15T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'kyoto-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'kyoto-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'kyoto-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'kyoto-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'kyoto-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'kyoto-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'kyoto-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'kyoto-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'kyoto-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'kyoto-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'kyoto-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'kyoto-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'kyoto-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'kyoto-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kyoto-marathon-2026', 'full', 42.195, 360, '08:55', 16000, 18500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -3716,6 +3716,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- みえ松阪マラソン (mie-matsusaka-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'mie-matsusaka-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'mie-matsusaka-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'mie-matsusaka-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'mie-matsusaka-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'mie-matsusaka-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'mie-matsusaka-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'mie-matsusaka-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'mie-matsusaka-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'mie-matsusaka-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'mie-matsusaka-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'mie-matsusaka-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'mie-matsusaka-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'mie-matsusaka-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'mie-matsusaka-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -3773,20 +3787,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-15T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'mie-matsusaka-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'mie-matsusaka-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'mie-matsusaka-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'mie-matsusaka-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'mie-matsusaka-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'mie-matsusaka-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'mie-matsusaka-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'mie-matsusaka-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'mie-matsusaka-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'mie-matsusaka-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'mie-matsusaka-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'mie-matsusaka-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'mie-matsusaka-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'mie-matsusaka-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('mie-matsusaka-marathon-2026', 'full', 42.195, 0, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -3799,6 +3799,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- 水戸黄門漫遊マラソン (mito-komon-manyu-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'mito-komon-manyu-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'mito-komon-manyu-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'mito-komon-manyu-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'mito-komon-manyu-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'mito-komon-manyu-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'mito-komon-manyu-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'mito-komon-manyu-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'mito-komon-manyu-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'mito-komon-manyu-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'mito-komon-manyu-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'mito-komon-manyu-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'mito-komon-manyu-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'mito-komon-manyu-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'mito-komon-manyu-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -3856,20 +3870,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-15T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'mito-komon-manyu-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'mito-komon-manyu-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'mito-komon-manyu-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'mito-komon-manyu-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'mito-komon-manyu-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'mito-komon-manyu-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'mito-komon-manyu-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'mito-komon-manyu-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'mito-komon-manyu-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'mito-komon-manyu-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'mito-komon-manyu-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'mito-komon-manyu-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'mito-komon-manyu-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'mito-komon-manyu-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('mito-komon-manyu-marathon-2026', 'full', 42.195, 360, '', 10000, 10000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 'mito-komon-manyu-marathon-2026', '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -3884,6 +3884,20 @@ INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label
 -- ==================
 -- 富士山クライムラン (mtfuji-climb-run-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'mtfuji-climb-run-2026';
+DELETE FROM race_categories WHERE race_id = 'mtfuji-climb-run-2026';
+DELETE FROM aid_stations WHERE race_id = 'mtfuji-climb-run-2026';
+DELETE FROM checkpoints WHERE race_id = 'mtfuji-climb-run-2026';
+DELETE FROM access_points WHERE race_id = 'mtfuji-climb-run-2026';
+DELETE FROM nearby_spots WHERE race_id = 'mtfuji-climb-run-2026';
+DELETE FROM weather_history WHERE race_id = 'mtfuji-climb-run-2026';
+DELETE FROM participation_gifts WHERE race_id = 'mtfuji-climb-run-2026';
+DELETE FROM race_entry_links WHERE race_id = 'mtfuji-climb-run-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'mtfuji-climb-run-2026';
+DELETE FROM race_results WHERE race_id = 'mtfuji-climb-run-2026';
+DELETE FROM race_gallery WHERE race_id = 'mtfuji-climb-run-2026';
+DELETE FROM race_voices WHERE race_id = 'mtfuji-climb-run-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'mtfuji-climb-run-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -3959,20 +3973,6 @@ Sunday, September 13, 6:30 AM – 30 minutes before the start time of each wave'
   '2026-04-28T13:53:53.451Z',
   '2026-04-28T13:53:53.451Z'
 );
-DELETE FROM race_categories WHERE race_id = 'mtfuji-climb-run-2026';
-DELETE FROM aid_stations WHERE race_id = 'mtfuji-climb-run-2026';
-DELETE FROM checkpoints WHERE race_id = 'mtfuji-climb-run-2026';
-DELETE FROM access_points WHERE race_id = 'mtfuji-climb-run-2026';
-DELETE FROM nearby_spots WHERE race_id = 'mtfuji-climb-run-2026';
-DELETE FROM weather_history WHERE race_id = 'mtfuji-climb-run-2026';
-DELETE FROM participation_gifts WHERE race_id = 'mtfuji-climb-run-2026';
-DELETE FROM race_entry_links WHERE race_id = 'mtfuji-climb-run-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'mtfuji-climb-run-2026';
-DELETE FROM race_results WHERE race_id = 'mtfuji-climb-run-2026';
-DELETE FROM race_gallery WHERE race_id = 'mtfuji-climb-run-2026';
-DELETE FROM race_voices WHERE race_id = 'mtfuji-climb-run-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'mtfuji-climb-run-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'mtfuji-climb-run-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('mtfuji-climb-run-2026', 'other', 12, 180, '09:00', 2000, 15000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
@@ -3983,6 +3983,20 @@ INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label
 -- ==================
 -- 名古屋ウィメンズマラソン (nagoya-womens-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'nagoya-womens-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'nagoya-womens-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'nagoya-womens-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'nagoya-womens-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'nagoya-womens-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'nagoya-womens-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'nagoya-womens-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'nagoya-womens-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'nagoya-womens-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'nagoya-womens-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'nagoya-womens-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'nagoya-womens-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'nagoya-womens-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'nagoya-womens-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -4040,20 +4054,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-15T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'nagoya-womens-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'nagoya-womens-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'nagoya-womens-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'nagoya-womens-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'nagoya-womens-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'nagoya-womens-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'nagoya-womens-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'nagoya-womens-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'nagoya-womens-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'nagoya-womens-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'nagoya-womens-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'nagoya-womens-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'nagoya-womens-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'nagoya-womens-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('nagoya-womens-marathon-2026', 'full', 42.195, 420, '09:10', 20000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -4070,6 +4070,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- NAHAマラソン (naha-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'naha-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'naha-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'naha-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'naha-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'naha-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'naha-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'naha-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'naha-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'naha-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'naha-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'naha-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'naha-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'naha-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'naha-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -4127,20 +4141,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-15T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'naha-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'naha-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'naha-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'naha-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'naha-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'naha-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'naha-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'naha-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'naha-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'naha-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'naha-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'naha-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'naha-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'naha-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('naha-marathon-2026', 'full', 42.195, 375, '09:00', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -4159,6 +4159,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- 奈良マラソン (nara-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'nara-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'nara-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'nara-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'nara-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'nara-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'nara-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'nara-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'nara-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'nara-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'nara-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'nara-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'nara-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'nara-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'nara-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -4216,20 +4230,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-15T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'nara-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'nara-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'nara-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'nara-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'nara-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'nara-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'nara-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'nara-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'nara-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'nara-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'nara-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'nara-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'nara-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'nara-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('nara-marathon-2026', 'full', 42.195, 360, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -4250,6 +4250,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- 新潟シティマラソン (niigata-city-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'niigata-city-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'niigata-city-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'niigata-city-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'niigata-city-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'niigata-city-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'niigata-city-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'niigata-city-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'niigata-city-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'niigata-city-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'niigata-city-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'niigata-city-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'niigata-city-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'niigata-city-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'niigata-city-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -4307,20 +4321,6 @@ INSERT OR REPLACE INTO races (
   '2026-04-05T07:57:29.198Z',
   '2026-04-05T07:57:29.198Z'
 );
-DELETE FROM race_categories WHERE race_id = 'niigata-city-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'niigata-city-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'niigata-city-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'niigata-city-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'niigata-city-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'niigata-city-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'niigata-city-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'niigata-city-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'niigata-city-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'niigata-city-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'niigata-city-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'niigata-city-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'niigata-city-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'niigata-city-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('niigata-city-marathon-2026', 'full', 42.195, 420, '08:30', 9000, 12500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
@@ -4333,6 +4333,20 @@ INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label
 -- ==================
 -- にしおマラソン (nishio-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'nishio-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'nishio-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'nishio-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'nishio-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'nishio-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'nishio-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'nishio-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'nishio-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'nishio-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'nishio-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'nishio-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'nishio-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'nishio-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'nishio-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -4390,20 +4404,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-15T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'nishio-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'nishio-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'nishio-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'nishio-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'nishio-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'nishio-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'nishio-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'nishio-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'nishio-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'nishio-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'nishio-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'nishio-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'nishio-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'nishio-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('nishio-marathon-2026', 'full', 42.195, 390, '09:00', 6000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -4414,6 +4414,20 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
 -- ==================
 -- おかやまマラソン (okayama-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'okayama-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'okayama-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'okayama-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'okayama-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'okayama-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'okayama-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'okayama-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'okayama-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'okayama-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'okayama-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'okayama-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'okayama-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'okayama-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'okayama-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -4472,20 +4486,6 @@ Loppi端末(ローソン・ミニストップ店頭)',
   '2026-03-15T00:00:00Z',
   '2026-03-15T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'okayama-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'okayama-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'okayama-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'okayama-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'okayama-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'okayama-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'okayama-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'okayama-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'okayama-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'okayama-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'okayama-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'okayama-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'okayama-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'okayama-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('okayama-marathon-2026', 'full', 42.195, 360, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -4502,6 +4502,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- 奥信濃100トレイルランニングレース (okushinano100-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'okushinano100-2026';
+DELETE FROM race_categories WHERE race_id = 'okushinano100-2026';
+DELETE FROM aid_stations WHERE race_id = 'okushinano100-2026';
+DELETE FROM checkpoints WHERE race_id = 'okushinano100-2026';
+DELETE FROM access_points WHERE race_id = 'okushinano100-2026';
+DELETE FROM nearby_spots WHERE race_id = 'okushinano100-2026';
+DELETE FROM weather_history WHERE race_id = 'okushinano100-2026';
+DELETE FROM participation_gifts WHERE race_id = 'okushinano100-2026';
+DELETE FROM race_entry_links WHERE race_id = 'okushinano100-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'okushinano100-2026';
+DELETE FROM race_results WHERE race_id = 'okushinano100-2026';
+DELETE FROM race_gallery WHERE race_id = 'okushinano100-2026';
+DELETE FROM race_voices WHERE race_id = 'okushinano100-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'okushinano100-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -4559,20 +4573,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-30T00:00:00Z',
   '2026-03-30T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'okushinano100-2026';
-DELETE FROM aid_stations WHERE race_id = 'okushinano100-2026';
-DELETE FROM checkpoints WHERE race_id = 'okushinano100-2026';
-DELETE FROM access_points WHERE race_id = 'okushinano100-2026';
-DELETE FROM nearby_spots WHERE race_id = 'okushinano100-2026';
-DELETE FROM weather_history WHERE race_id = 'okushinano100-2026';
-DELETE FROM participation_gifts WHERE race_id = 'okushinano100-2026';
-DELETE FROM race_entry_links WHERE race_id = 'okushinano100-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'okushinano100-2026';
-DELETE FROM race_results WHERE race_id = 'okushinano100-2026';
-DELETE FROM race_gallery WHERE race_id = 'okushinano100-2026';
-DELETE FROM race_voices WHERE race_id = 'okushinano100-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'okushinano100-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'okushinano100-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('okushinano100-2026', 'ultra', 100, 1260, '05:00', 700, 31000, NULL, NULL, NULL, NULL, NULL, '・各種目の規定年齢に達している方（100km／50km…18歳以上、25km…高校生以上、8km…中学生以上）※未成年者は保護者の承認が必要
 ・コースを迷うことなく制限時間内に完走できる自信がある方
@@ -4604,6 +4604,20 @@ INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label
 -- ==================
 -- 大阪マラソン (osaka-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'osaka-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'osaka-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'osaka-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'osaka-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'osaka-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'osaka-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'osaka-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'osaka-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'osaka-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'osaka-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'osaka-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'osaka-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'osaka-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'osaka-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -4661,20 +4675,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-15T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'osaka-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'osaka-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'osaka-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'osaka-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'osaka-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'osaka-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'osaka-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'osaka-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'osaka-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'osaka-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'osaka-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'osaka-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'osaka-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'osaka-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('osaka-marathon-2026', 'full', 42.195, 420, '09:15', 31970, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -4697,6 +4697,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- 大阪・淀川市民マラソン (osaka-yodo-river-citizens-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -4762,20 +4776,6 @@ Based on themes such as “people,” “environment,” and “the Yodogawa Riv
   '2026-04-11T14:42:59.225Z',
   '2026-04-11T14:42:59.225Z'
 );
-DELETE FROM race_categories WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('osaka-yodo-river-citizens-marathon-2026', 'full', 42.195, 480, '09:00', 4000, 9800, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -4794,6 +4794,20 @@ INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label
 -- ==================
 -- OSJ ONTAKE100 (osj-ontake100-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'osj-ontake100-2026';
+DELETE FROM race_categories WHERE race_id = 'osj-ontake100-2026';
+DELETE FROM aid_stations WHERE race_id = 'osj-ontake100-2026';
+DELETE FROM checkpoints WHERE race_id = 'osj-ontake100-2026';
+DELETE FROM access_points WHERE race_id = 'osj-ontake100-2026';
+DELETE FROM nearby_spots WHERE race_id = 'osj-ontake100-2026';
+DELETE FROM weather_history WHERE race_id = 'osj-ontake100-2026';
+DELETE FROM participation_gifts WHERE race_id = 'osj-ontake100-2026';
+DELETE FROM race_entry_links WHERE race_id = 'osj-ontake100-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'osj-ontake100-2026';
+DELETE FROM race_results WHERE race_id = 'osj-ontake100-2026';
+DELETE FROM race_gallery WHERE race_id = 'osj-ontake100-2026';
+DELETE FROM race_voices WHERE race_id = 'osj-ontake100-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'osj-ontake100-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -4851,20 +4865,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-30T00:00:00Z',
   '2026-03-30T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'osj-ontake100-2026';
-DELETE FROM aid_stations WHERE race_id = 'osj-ontake100-2026';
-DELETE FROM checkpoints WHERE race_id = 'osj-ontake100-2026';
-DELETE FROM access_points WHERE race_id = 'osj-ontake100-2026';
-DELETE FROM nearby_spots WHERE race_id = 'osj-ontake100-2026';
-DELETE FROM weather_history WHERE race_id = 'osj-ontake100-2026';
-DELETE FROM participation_gifts WHERE race_id = 'osj-ontake100-2026';
-DELETE FROM race_entry_links WHERE race_id = 'osj-ontake100-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'osj-ontake100-2026';
-DELETE FROM race_results WHERE race_id = 'osj-ontake100-2026';
-DELETE FROM race_gallery WHERE race_id = 'osj-ontake100-2026';
-DELETE FROM race_voices WHERE race_id = 'osj-ontake100-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'osj-ontake100-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'osj-ontake100-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('osj-ontake100-2026', 'ultra', 163, 1440, '20:00', 200, 21000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -4879,6 +4879,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- 佐渡トキマラソン (sado-toki-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'sado-toki-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'sado-toki-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'sado-toki-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'sado-toki-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'sado-toki-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'sado-toki-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'sado-toki-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'sado-toki-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'sado-toki-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'sado-toki-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'sado-toki-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'sado-toki-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'sado-toki-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'sado-toki-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -4936,20 +4950,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-15T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'sado-toki-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'sado-toki-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'sado-toki-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'sado-toki-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'sado-toki-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'sado-toki-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'sado-toki-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'sado-toki-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'sado-toki-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'sado-toki-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'sado-toki-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'sado-toki-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'sado-toki-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'sado-toki-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('sado-toki-marathon-2026', 'full', 42.195, 0, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -4966,6 +4966,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- さが桜マラソン (saga-sakura-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'saga-sakura-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'saga-sakura-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'saga-sakura-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'saga-sakura-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'saga-sakura-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'saga-sakura-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'saga-sakura-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'saga-sakura-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'saga-sakura-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'saga-sakura-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'saga-sakura-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'saga-sakura-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'saga-sakura-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'saga-sakura-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -5023,20 +5037,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-15T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'saga-sakura-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'saga-sakura-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'saga-sakura-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'saga-sakura-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'saga-sakura-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'saga-sakura-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'saga-sakura-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'saga-sakura-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'saga-sakura-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'saga-sakura-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'saga-sakura-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'saga-sakura-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'saga-sakura-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'saga-sakura-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('saga-sakura-marathon-2026', 'full', 42.195, 0, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -5051,6 +5051,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- さいたまマラソン (saitama-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'saitama-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'saitama-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'saitama-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'saitama-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'saitama-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'saitama-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'saitama-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'saitama-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'saitama-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'saitama-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'saitama-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'saitama-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'saitama-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'saitama-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -5108,28 +5122,116 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-15T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'saitama-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'saitama-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'saitama-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'saitama-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'saitama-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'saitama-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'saitama-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'saitama-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'saitama-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'saitama-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'saitama-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'saitama-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'saitama-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'saitama-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('saitama-marathon-2026', 'full', 42.195, 360, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('saitama-marathon-2026', '観光地', '氷川神社', 'Hikawa Shrine', '武蔵国一宮。2km以上の参道は日本一の長さ。大宮の象徴。', 'The first shrine of Musashi Province. Its 2km+ approach is the longest in Japan.', '大宮エリア', NULL, 35.9069, 139.6286);
 
 -- ==================
+-- 札幌マラソン (sapporo-marathon-2026)
+-- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'sapporo-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'sapporo-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'sapporo-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'sapporo-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'sapporo-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'sapporo-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'sapporo-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'sapporo-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'sapporo-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'sapporo-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'sapporo-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'sapporo-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'sapporo-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'sapporo-marathon-2026';
+INSERT OR REPLACE INTO races (
+  id, name_ja, name_en, date, prefecture, city_ja, city_en,
+  description_ja, description_en, official_url,
+  entry_fee, entry_fee_by_category, entry_capacity,
+  entry_start_date, entry_end_date, entry_closed,
+  reception_type, reception_note_ja, reception_note_en,
+  tags, course_gpx_file,
+  course_max_elevation_m, course_min_elevation_m, course_elevation_diff_m,
+  course_surface, course_certification,
+  course_highlights_ja, course_highlights_en,
+  course_notes_ja, course_notes_en,
+  motif, motif_color, motif_romaji,
+  tagline_ja, tagline_en,
+  hero_image_url, hero_caption_ja, hero_caption_en,
+  created_at, updated_at
+) VALUES (
+  'sapporo-marathon-2026',
+  '札幌マラソン',
+  'Sapporo　Marathon',
+  '2026-10-04',
+  '01',
+  '札幌市南区真駒内公園3番1号',
+  '',
+  '',
+  '',
+  'https://satumara.sapporo-sport.jp/index.html',
+  NULL,
+  1,
+  0,
+  '2026-05-23',
+  '2026-07-11',
+  0,
+  'pre_mail',
+  '',
+  '',
+  '[]',
+  NULL,
+  0,
+  0,
+  0,
+  'road',
+  '[]',
+  '',
+  '',
+  '',
+  '',
+  '時計台',
+  NULL,
+  'NEW CLASSIC',
+  'その一歩から、また始まる。',
+  'It all starts with that first step.',
+  NULL,
+  NULL,
+  NULL,
+  '2026-05-15T14:40:14.753Z',
+  '2026-05-15T14:40:14.753Z'
+);
+INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
+  ('sapporo-marathon-2026', 'half', 21.0975, 0, '09:20', 8000, 8000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
+INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
+  ('sapporo-marathon-2026', '10k', 10, 0, '09:00', 4000, 5000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 1);
+INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('sapporo-marathon-2026', '["tshirt"]', 'オリジナルTシャツ
+https://satumara.sapporo-sport.jp/prizes.html', '', NULL, 0);
+INSERT OR REPLACE INTO race_entry_links (race_id, site_name, url, sort_order) VALUES
+  ('sapporo-marathon-2026', 'RUNNET', 'https://satumara.sapporo-sport.jp/images/entry/runnet.svg', 0);
+INSERT OR REPLACE INTO race_entry_links (race_id, site_name, url, sort_order) VALUES
+  ('sapporo-marathon-2026', 'SPORT ENTRY', 'https://www.sportsentry.ne.jp/event/t/105098', 1);
+INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
+  ('sapporo-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-05-23', '2026-07-11', NULL, 0);
+
+-- ==================
 -- 志賀高原100 (shiga-kogen100-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'shiga-kogen100-2026';
+DELETE FROM race_categories WHERE race_id = 'shiga-kogen100-2026';
+DELETE FROM aid_stations WHERE race_id = 'shiga-kogen100-2026';
+DELETE FROM checkpoints WHERE race_id = 'shiga-kogen100-2026';
+DELETE FROM access_points WHERE race_id = 'shiga-kogen100-2026';
+DELETE FROM nearby_spots WHERE race_id = 'shiga-kogen100-2026';
+DELETE FROM weather_history WHERE race_id = 'shiga-kogen100-2026';
+DELETE FROM participation_gifts WHERE race_id = 'shiga-kogen100-2026';
+DELETE FROM race_entry_links WHERE race_id = 'shiga-kogen100-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'shiga-kogen100-2026';
+DELETE FROM race_results WHERE race_id = 'shiga-kogen100-2026';
+DELETE FROM race_gallery WHERE race_id = 'shiga-kogen100-2026';
+DELETE FROM race_voices WHERE race_id = 'shiga-kogen100-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'shiga-kogen100-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -5278,20 +5380,6 @@ EQUIPMENT
   '2026-04-05T06:01:54.559Z',
   '2026-04-05T06:01:54.559Z'
 );
-DELETE FROM race_categories WHERE race_id = 'shiga-kogen100-2026';
-DELETE FROM aid_stations WHERE race_id = 'shiga-kogen100-2026';
-DELETE FROM checkpoints WHERE race_id = 'shiga-kogen100-2026';
-DELETE FROM access_points WHERE race_id = 'shiga-kogen100-2026';
-DELETE FROM nearby_spots WHERE race_id = 'shiga-kogen100-2026';
-DELETE FROM weather_history WHERE race_id = 'shiga-kogen100-2026';
-DELETE FROM participation_gifts WHERE race_id = 'shiga-kogen100-2026';
-DELETE FROM race_entry_links WHERE race_id = 'shiga-kogen100-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'shiga-kogen100-2026';
-DELETE FROM race_results WHERE race_id = 'shiga-kogen100-2026';
-DELETE FROM race_gallery WHERE race_id = 'shiga-kogen100-2026';
-DELETE FROM race_voices WHERE race_id = 'shiga-kogen100-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'shiga-kogen100-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'shiga-kogen100-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('shiga-kogen100-2026', 'ultra', 100, 1560, '04:30', 700, 28000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -5306,6 +5394,20 @@ INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label
 -- ==================
 -- しまだ大井川マラソン (shimada-oigawa-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'shimada-oigawa-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'shimada-oigawa-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'shimada-oigawa-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'shimada-oigawa-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'shimada-oigawa-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'shimada-oigawa-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'shimada-oigawa-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'shimada-oigawa-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'shimada-oigawa-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'shimada-oigawa-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'shimada-oigawa-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'shimada-oigawa-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'shimada-oigawa-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'shimada-oigawa-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -5369,20 +5471,6 @@ Translated with DeepL.com (free version)',
   '2026-04-25T04:12:54.667Z',
   '2026-04-25T04:12:54.667Z'
 );
-DELETE FROM race_categories WHERE race_id = 'shimada-oigawa-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'shimada-oigawa-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'shimada-oigawa-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'shimada-oigawa-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'shimada-oigawa-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'shimada-oigawa-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'shimada-oigawa-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'shimada-oigawa-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'shimada-oigawa-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'shimada-oigawa-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'shimada-oigawa-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'shimada-oigawa-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'shimada-oigawa-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'shimada-oigawa-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('shimada-oigawa-marathon-2026', 'full', 42.195, 420, '09:00', 6000, 10000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -5395,6 +5483,20 @@ INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label
 -- ==================
 -- 信越五岳トレイルランニングレース (shinetsu5mountains-trail-100-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'shinetsu5mountains-trail-100-2026';
+DELETE FROM race_categories WHERE race_id = 'shinetsu5mountains-trail-100-2026';
+DELETE FROM aid_stations WHERE race_id = 'shinetsu5mountains-trail-100-2026';
+DELETE FROM checkpoints WHERE race_id = 'shinetsu5mountains-trail-100-2026';
+DELETE FROM access_points WHERE race_id = 'shinetsu5mountains-trail-100-2026';
+DELETE FROM nearby_spots WHERE race_id = 'shinetsu5mountains-trail-100-2026';
+DELETE FROM weather_history WHERE race_id = 'shinetsu5mountains-trail-100-2026';
+DELETE FROM participation_gifts WHERE race_id = 'shinetsu5mountains-trail-100-2026';
+DELETE FROM race_entry_links WHERE race_id = 'shinetsu5mountains-trail-100-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'shinetsu5mountains-trail-100-2026';
+DELETE FROM race_results WHERE race_id = 'shinetsu5mountains-trail-100-2026';
+DELETE FROM race_gallery WHERE race_id = 'shinetsu5mountains-trail-100-2026';
+DELETE FROM race_voices WHERE race_id = 'shinetsu5mountains-trail-100-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'shinetsu5mountains-trail-100-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -5453,20 +5555,6 @@ INSERT OR REPLACE INTO races (
   '2026-04-05T07:49:25.657Z',
   '2026-04-05T07:49:25.657Z'
 );
-DELETE FROM race_categories WHERE race_id = 'shinetsu5mountains-trail-100-2026';
-DELETE FROM aid_stations WHERE race_id = 'shinetsu5mountains-trail-100-2026';
-DELETE FROM checkpoints WHERE race_id = 'shinetsu5mountains-trail-100-2026';
-DELETE FROM access_points WHERE race_id = 'shinetsu5mountains-trail-100-2026';
-DELETE FROM nearby_spots WHERE race_id = 'shinetsu5mountains-trail-100-2026';
-DELETE FROM weather_history WHERE race_id = 'shinetsu5mountains-trail-100-2026';
-DELETE FROM participation_gifts WHERE race_id = 'shinetsu5mountains-trail-100-2026';
-DELETE FROM race_entry_links WHERE race_id = 'shinetsu5mountains-trail-100-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'shinetsu5mountains-trail-100-2026';
-DELETE FROM race_results WHERE race_id = 'shinetsu5mountains-trail-100-2026';
-DELETE FROM race_gallery WHERE race_id = 'shinetsu5mountains-trail-100-2026';
-DELETE FROM race_voices WHERE race_id = 'shinetsu5mountains-trail-100-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'shinetsu5mountains-trail-100-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'shinetsu5mountains-trail-100-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('shinetsu5mountains-trail-100-2026', 'ultra', 163, 1980, '18:30', 600, 47000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -5487,6 +5575,20 @@ INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label
 -- ==================
 -- 静岡マラソン (shizuoka-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'shizuoka-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'shizuoka-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'shizuoka-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'shizuoka-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'shizuoka-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'shizuoka-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'shizuoka-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'shizuoka-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'shizuoka-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'shizuoka-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'shizuoka-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'shizuoka-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'shizuoka-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'shizuoka-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -5544,20 +5646,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-15T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'shizuoka-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'shizuoka-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'shizuoka-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'shizuoka-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'shizuoka-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'shizuoka-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'shizuoka-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'shizuoka-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'shizuoka-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'shizuoka-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'shizuoka-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'shizuoka-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'shizuoka-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'shizuoka-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('shizuoka-marathon-2026', 'full', 42.195, 0, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -5572,6 +5660,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- 湘南国際マラソン (shonan-international-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'shonan-international-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'shonan-international-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'shonan-international-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'shonan-international-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'shonan-international-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'shonan-international-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'shonan-international-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'shonan-international-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'shonan-international-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'shonan-international-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'shonan-international-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'shonan-international-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'shonan-international-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'shonan-international-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -5629,20 +5731,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-16T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'shonan-international-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'shonan-international-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'shonan-international-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'shonan-international-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'shonan-international-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'shonan-international-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'shonan-international-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'shonan-international-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'shonan-international-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'shonan-international-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'shonan-international-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'shonan-international-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'shonan-international-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'shonan-international-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('shonan-international-marathon-2026', 'full', 42.195, 345, '', 19500, 16000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -5663,6 +5751,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- そうじゃ吉備路マラソン (soja-kibiji-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'soja-kibiji-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'soja-kibiji-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'soja-kibiji-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'soja-kibiji-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'soja-kibiji-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'soja-kibiji-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'soja-kibiji-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'soja-kibiji-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'soja-kibiji-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'soja-kibiji-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'soja-kibiji-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'soja-kibiji-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'soja-kibiji-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'soja-kibiji-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -5723,20 +5825,6 @@ Therefore, there is no registration required.',
   '2026-03-15T00:00:00Z',
   '2026-03-15T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'soja-kibiji-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'soja-kibiji-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'soja-kibiji-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'soja-kibiji-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'soja-kibiji-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'soja-kibiji-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'soja-kibiji-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'soja-kibiji-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'soja-kibiji-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'soja-kibiji-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'soja-kibiji-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'soja-kibiji-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'soja-kibiji-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'soja-kibiji-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('soja-kibiji-marathon-2026', 'full', 42.195, 360, '09:20', 2000, 9100, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -5755,6 +5843,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- 丹波篠山ABCマラソン (tamba-sasayama-abc-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -5812,20 +5914,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-15T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('tamba-sasayama-abc-marathon-2026', 'full', 42.195, 330, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -5840,6 +5928,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- 館山若潮マラソン (tateyama-wakashio-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'tateyama-wakashio-2026';
+DELETE FROM race_categories WHERE race_id = 'tateyama-wakashio-2026';
+DELETE FROM aid_stations WHERE race_id = 'tateyama-wakashio-2026';
+DELETE FROM checkpoints WHERE race_id = 'tateyama-wakashio-2026';
+DELETE FROM access_points WHERE race_id = 'tateyama-wakashio-2026';
+DELETE FROM nearby_spots WHERE race_id = 'tateyama-wakashio-2026';
+DELETE FROM weather_history WHERE race_id = 'tateyama-wakashio-2026';
+DELETE FROM participation_gifts WHERE race_id = 'tateyama-wakashio-2026';
+DELETE FROM race_entry_links WHERE race_id = 'tateyama-wakashio-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'tateyama-wakashio-2026';
+DELETE FROM race_results WHERE race_id = 'tateyama-wakashio-2026';
+DELETE FROM race_gallery WHERE race_id = 'tateyama-wakashio-2026';
+DELETE FROM race_voices WHERE race_id = 'tateyama-wakashio-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'tateyama-wakashio-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -5897,20 +5999,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-16T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'tateyama-wakashio-2026';
-DELETE FROM aid_stations WHERE race_id = 'tateyama-wakashio-2026';
-DELETE FROM checkpoints WHERE race_id = 'tateyama-wakashio-2026';
-DELETE FROM access_points WHERE race_id = 'tateyama-wakashio-2026';
-DELETE FROM nearby_spots WHERE race_id = 'tateyama-wakashio-2026';
-DELETE FROM weather_history WHERE race_id = 'tateyama-wakashio-2026';
-DELETE FROM participation_gifts WHERE race_id = 'tateyama-wakashio-2026';
-DELETE FROM race_entry_links WHERE race_id = 'tateyama-wakashio-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'tateyama-wakashio-2026';
-DELETE FROM race_results WHERE race_id = 'tateyama-wakashio-2026';
-DELETE FROM race_gallery WHERE race_id = 'tateyama-wakashio-2026';
-DELETE FROM race_voices WHERE race_id = 'tateyama-wakashio-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'tateyama-wakashio-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'tateyama-wakashio-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('tateyama-wakashio-2026', 'full', 42.195, 360, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -5925,6 +6013,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- 田沢湖マラソン (tazawako-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'tazawako-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'tazawako-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'tazawako-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'tazawako-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'tazawako-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'tazawako-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'tazawako-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'tazawako-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'tazawako-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'tazawako-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'tazawako-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'tazawako-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'tazawako-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'tazawako-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -5983,20 +6085,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-29T11:30:29.091Z',
   '2026-03-29T11:30:29.091Z'
 );
-DELETE FROM race_categories WHERE race_id = 'tazawako-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'tazawako-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'tazawako-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'tazawako-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'tazawako-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'tazawako-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'tazawako-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'tazawako-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'tazawako-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'tazawako-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'tazawako-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'tazawako-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'tazawako-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'tazawako-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('tazawako-marathon-2026', 'full', 42.195, 360, '08:30', 1600, 10000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -6009,6 +6097,20 @@ INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label
 -- ==================
 -- とくしまマラソン (tokushima-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'tokushima-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'tokushima-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'tokushima-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'tokushima-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'tokushima-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'tokushima-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'tokushima-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'tokushima-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'tokushima-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'tokushima-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'tokushima-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'tokushima-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'tokushima-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'tokushima-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -6066,20 +6168,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-15T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'tokushima-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'tokushima-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'tokushima-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'tokushima-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'tokushima-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'tokushima-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'tokushima-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'tokushima-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'tokushima-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'tokushima-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'tokushima-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'tokushima-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'tokushima-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'tokushima-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('tokushima-marathon-2026', 'full', 42.195, 0, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -6090,8 +6178,176 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
   ('tokushima-marathon-2026', NULL, NULL, '吉野川', 'Yoshino River', NULL, NULL, 0);
 
 -- ==================
+-- 東京レガシーハーフマラソン (tokyo-legacy-half-2026)
+-- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'tokyo-legacy-half-2026';
+DELETE FROM race_categories WHERE race_id = 'tokyo-legacy-half-2026';
+DELETE FROM aid_stations WHERE race_id = 'tokyo-legacy-half-2026';
+DELETE FROM checkpoints WHERE race_id = 'tokyo-legacy-half-2026';
+DELETE FROM access_points WHERE race_id = 'tokyo-legacy-half-2026';
+DELETE FROM nearby_spots WHERE race_id = 'tokyo-legacy-half-2026';
+DELETE FROM weather_history WHERE race_id = 'tokyo-legacy-half-2026';
+DELETE FROM participation_gifts WHERE race_id = 'tokyo-legacy-half-2026';
+DELETE FROM race_entry_links WHERE race_id = 'tokyo-legacy-half-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'tokyo-legacy-half-2026';
+DELETE FROM race_results WHERE race_id = 'tokyo-legacy-half-2026';
+DELETE FROM race_gallery WHERE race_id = 'tokyo-legacy-half-2026';
+DELETE FROM race_voices WHERE race_id = 'tokyo-legacy-half-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'tokyo-legacy-half-2026';
+INSERT OR REPLACE INTO races (
+  id, name_ja, name_en, date, prefecture, city_ja, city_en,
+  description_ja, description_en, official_url,
+  entry_fee, entry_fee_by_category, entry_capacity,
+  entry_start_date, entry_end_date, entry_closed,
+  reception_type, reception_note_ja, reception_note_en,
+  tags, course_gpx_file,
+  course_max_elevation_m, course_min_elevation_m, course_elevation_diff_m,
+  course_surface, course_certification,
+  course_highlights_ja, course_highlights_en,
+  course_notes_ja, course_notes_en,
+  motif, motif_color, motif_romaji,
+  tagline_ja, tagline_en,
+  hero_image_url, hero_caption_ja, hero_caption_en,
+  created_at, updated_at
+) VALUES (
+  'tokyo-legacy-half-2026',
+  '東京レガシーハーフマラソン',
+  'Tokyo Legacy Half ',
+  '2026-10-18',
+  '13',
+  '新宿区霞ヶ丘町',
+  'Kasumigaoka-cho, Shinjuku Ward',
+  '',
+  '',
+  'https://legacyhalf.tokyo/',
+  NULL,
+  1,
+  0,
+  '2026-05-18',
+  '2026-05-25',
+  0,
+  'pre_day',
+  '期間
+2026年10月16日(金)　11時00分～20時30分
+2026年10月17日(土)　10時00分～19時30分
+※ 上記受付期間内に、必ずランナー本人が受付を行ってください。
+※ 大会当日【10月18日(日)】は、ランナー受付を行いません。
+会場
+MUFGスタジアム(国立競技場)：東京都新宿区霞ヶ丘町10-1',
+  'Dates and Times
+Friday, October 16, 2026: 11:00 AM – 8:30 PM
+Saturday, October 17, 2026: 10:00 AM – 7:30 PM
+* Runners must check in in person during the above registration period.
+* There will be no runner registration on the day of the event [Sunday, October 18].
+Venue
+MUFG Stadium (National Stadium): 10-1 Kasumigaoka-cho, Shinjuku-ku, Tokyo',
+  '[]',
+  NULL,
+  0,
+  0,
+  0,
+  'road',
+  '[]',
+  '',
+  '',
+  '',
+  '',
+  '遺産',
+  '#F8F8FF',
+  'Legacy',
+  '感動や文化を次世代へ引き継ぐ',
+  'Passing on inspiration and culture to the next generation',
+  NULL,
+  NULL,
+  NULL,
+  '2026-05-14T14:47:07.523Z',
+  '2026-05-14T14:47:07.523Z'
+);
+INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
+  ('tokyo-legacy-half-2026', 'half', 21.0975, 180, '08:05', 18000, 13200, NULL, NULL, NULL, NULL, NULL, '大会当日満18歳以上で以下の条件にあてはまる者で、主催者が出場を認めた者。
+※主催者が実施するイベント等による出走権付与者を含みます。
+一般の部：2時間40分以内に完走できる男子・女子・ノンバイナリー。
+障がい者の部：2時間40分以内に完走できる男子・女子・ノンバイナリー。
+※ 障がいのある方で単独走行が困難な方はガイドランナーを1名つけることができます。(盲導犬等の伴走は不可とします。)
+障がい者(車いす)の部：レース仕様車でハーフマラソンを1時間40分以内に完走できる男子・女子・ノンバイナリー。
+学生チームの部：2時間40分以内に完走できる学生(国内のみ)。
+※ 1チーム7名～10名とします。
+※ ランナー受付時に学生証の提示が必須となります。
+※ 障がいのある方で単独走行が困難な方はガイドランナーを1名つけることができます。(盲導犬等の伴走は不可とします。)
+準エリートの部
+国内
+2026年度日本陸上競技連盟登録競技者である男子・女子。
+2024年5月1日から2026年4月30日までの公認記録またはワールドアスレティックスラベルロードレース公式記録で下記参加基準に達する男子・女子。
+　　男子：ハーフマラソン1時間14分00秒以内
+　　女子：ハーフマラソン1時間40分00秒以内
+海外
+2024年5月1日から2026年4月30日までのワールドアスレティックスラベルロードレース公式記録で下記参加基準に達する男子・女子。
+　　男子：ハーフマラソン1時間14分00秒以内
+　　女子：ハーフマラソン1時間40分00秒以内
+※ 障がいのある方で単独走行が困難な方はガイドランナーを1名つけることができます。(盲導犬等の伴走は不可とします。)
+エリートの部
+2026年度日本陸上競技連盟登録競技者で、別途定める参加基準に達する男子・女子。
+招待選手(主催者または日本陸上競技連盟が推薦する国内・海外の男子・女子)。
+パラアスリートの部
+2026年度日本パラスポーツ協会に加盟するパラ陸上競技団体登録競技者で、大会当日までに有効な競技クラスを有し、別途定める参加基準に達する男子・女子。
+招待選手(主催者または日本パラスポーツ協会に加盟するパラ陸上競技団体が推薦する国内・海外の男子・女子)。
+実施クラス：
+①視覚障がいT11/T12、上肢障がいT45/T46、車いすT53/T54
+②上記以外でIPC(国際パラリンピック委員会)のカテゴリーにあるすべてのクラス', 'Participants must be at least 18 years of age on the day of the event, meet the following criteria, and have been approved by the organizers.
+*This includes individuals who have been granted entry through events organized by the organizers.
+General Division: Men, women, and non-binary individuals capable of completing the race within 2 hours and 40 minutes.
+Disabled Division: Men, women, and non-binary individuals capable of completing the race within 2 hours and 40 minutes.
+* Participants with disabilities who have difficulty running independently may be accompanied by one guide runner. (Assistance from guide dogs or similar animals is not permitted.)
+Disabled (Wheelchair) Division: Men, women, and non-binary individuals who can complete the half marathon in a race-spec wheelchair within 1 hour and 40 minutes.
+Student Team Division: Students (domestic only) who can complete the race within 2 hours and 40 minutes.
+* Teams must consist of 7 to 10 members.
+* A student ID must be presented at runner registration.
+* Participants with disabilities who have difficulty running independently may be accompanied by one guide runner. (Guide dogs and other assistance animals are not permitted.)
+Semi-Elite Division* Participants with disabilities who have difficulty running independently may be accompanied by one guide runner. (Guide dogs and other assistance animals are not permitted.)
+Domestic
+Men and women registered with the Japan Association of Athletics Federations for the 2026 season.
+Men and women who meet the following participation criteria based on certified records or official World Athletics Label Road Race records from May 1, 2024, to April 30, 2026.
+　　Men: Half marathon in 1 hour 14 minutes 00 seconds or less
+　　Women: Half marathon in 1 hour 40 minutes 00 seconds or less
+International
+Men and women who meet the following participation standards based on official World Athletics Label Road Race records from May 1, 2024, to April 30, 2026.
+　　Men: Half marathon in 1 hour 14 minutes 00 seconds or faster
+　　Women: Half marathon in 1 hour 40 minutes 00 seconds or faster
+Elite Division
+Men and women who are registered athletes with the Japan Association of Athletics Federations for the 2026 season and meet the separately specified participation criteria.
+Invited Athletes (men and women from Japan and overseas recommended by the organizer or the Japan Association of Athletics Federations).
+Para-Athletes Division
+Men and women who are registered athletes with a para-athletics organization affiliated with the Japan Para Sports Association for the 2026 season, hold a valid competition class by the day of the event, and meet the separately specified participation criteria.
+Invited Athletes (men and women from Japan and overseas recommended by the organizer or a para-athletics organization affiliated with the Japan Para Sports Association).
+Competition Classes:
+① Visual Impairment T11/T12, Upper Limb Impairment T45/T46, Wheelchair T53/T54
+② All classes falling under the IPC (International Paralympic Committee) categories other than those listed above
+
+Translated with DeepL.com (free version)', NULL, '[]', 0);
+INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('tokyo-legacy-half-2026', '["medal","goods"]', '', '', NULL, 0);
+INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
+  ('tokyo-legacy-half-2026', NULL, 'ジャパンプレミアハーフ優先エントリー', 'General Entry', '2026-05-18', '2026-05-25', NULL, 0);
+INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
+  ('tokyo-legacy-half-2026', NULL, '一般エントリー', 'General Entry', '2026-05-26', '2026-06-09', NULL, 1);
+
+-- ==================
 -- 東京マラソン (tokyo-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'tokyo-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'tokyo-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'tokyo-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'tokyo-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'tokyo-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'tokyo-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'tokyo-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'tokyo-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'tokyo-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'tokyo-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'tokyo-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'tokyo-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'tokyo-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'tokyo-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -6149,20 +6405,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-15T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'tokyo-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'tokyo-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'tokyo-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'tokyo-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'tokyo-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'tokyo-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'tokyo-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'tokyo-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'tokyo-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'tokyo-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'tokyo-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'tokyo-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'tokyo-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'tokyo-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('tokyo-marathon-2026', 'full', 42.195, 420, '09:10', 38500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, sort_order) VALUES
@@ -6195,6 +6437,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- 東京マラソン (tokyo-marathon-2027)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'tokyo-marathon-2027';
+DELETE FROM race_categories WHERE race_id = 'tokyo-marathon-2027';
+DELETE FROM aid_stations WHERE race_id = 'tokyo-marathon-2027';
+DELETE FROM checkpoints WHERE race_id = 'tokyo-marathon-2027';
+DELETE FROM access_points WHERE race_id = 'tokyo-marathon-2027';
+DELETE FROM nearby_spots WHERE race_id = 'tokyo-marathon-2027';
+DELETE FROM weather_history WHERE race_id = 'tokyo-marathon-2027';
+DELETE FROM participation_gifts WHERE race_id = 'tokyo-marathon-2027';
+DELETE FROM race_entry_links WHERE race_id = 'tokyo-marathon-2027';
+DELETE FROM race_entry_periods WHERE race_id = 'tokyo-marathon-2027';
+DELETE FROM race_results WHERE race_id = 'tokyo-marathon-2027';
+DELETE FROM race_gallery WHERE race_id = 'tokyo-marathon-2027';
+DELETE FROM race_voices WHERE race_id = 'tokyo-marathon-2027';
+DELETE FROM race_time_buckets WHERE race_id = 'tokyo-marathon-2027';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -6252,20 +6508,6 @@ INSERT OR REPLACE INTO races (
   '2026-04-27T13:59:53.295Z',
   '2026-04-27T13:59:53.295Z'
 );
-DELETE FROM race_categories WHERE race_id = 'tokyo-marathon-2027';
-DELETE FROM aid_stations WHERE race_id = 'tokyo-marathon-2027';
-DELETE FROM checkpoints WHERE race_id = 'tokyo-marathon-2027';
-DELETE FROM access_points WHERE race_id = 'tokyo-marathon-2027';
-DELETE FROM nearby_spots WHERE race_id = 'tokyo-marathon-2027';
-DELETE FROM weather_history WHERE race_id = 'tokyo-marathon-2027';
-DELETE FROM participation_gifts WHERE race_id = 'tokyo-marathon-2027';
-DELETE FROM race_entry_links WHERE race_id = 'tokyo-marathon-2027';
-DELETE FROM race_entry_periods WHERE race_id = 'tokyo-marathon-2027';
-DELETE FROM race_results WHERE race_id = 'tokyo-marathon-2027';
-DELETE FROM race_gallery WHERE race_id = 'tokyo-marathon-2027';
-DELETE FROM race_voices WHERE race_id = 'tokyo-marathon-2027';
-DELETE FROM race_time_buckets WHERE race_id = 'tokyo-marathon-2027';
-DELETE FROM race_course_highlights WHERE race_id = 'tokyo-marathon-2027';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('tokyo-marathon-2027', 'full', 42.195, 0, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, sort_order) VALUES
@@ -6298,6 +6540,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- 富里スイカロードレース (tomisato-suikaroad-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'tomisato-suikaroad-2026';
+DELETE FROM race_categories WHERE race_id = 'tomisato-suikaroad-2026';
+DELETE FROM aid_stations WHERE race_id = 'tomisato-suikaroad-2026';
+DELETE FROM checkpoints WHERE race_id = 'tomisato-suikaroad-2026';
+DELETE FROM access_points WHERE race_id = 'tomisato-suikaroad-2026';
+DELETE FROM nearby_spots WHERE race_id = 'tomisato-suikaroad-2026';
+DELETE FROM weather_history WHERE race_id = 'tomisato-suikaroad-2026';
+DELETE FROM participation_gifts WHERE race_id = 'tomisato-suikaroad-2026';
+DELETE FROM race_entry_links WHERE race_id = 'tomisato-suikaroad-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'tomisato-suikaroad-2026';
+DELETE FROM race_results WHERE race_id = 'tomisato-suikaroad-2026';
+DELETE FROM race_gallery WHERE race_id = 'tomisato-suikaroad-2026';
+DELETE FROM race_voices WHERE race_id = 'tomisato-suikaroad-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'tomisato-suikaroad-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -6355,20 +6611,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-30T00:00:00Z',
   '2026-03-30T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'tomisato-suikaroad-2026';
-DELETE FROM aid_stations WHERE race_id = 'tomisato-suikaroad-2026';
-DELETE FROM checkpoints WHERE race_id = 'tomisato-suikaroad-2026';
-DELETE FROM access_points WHERE race_id = 'tomisato-suikaroad-2026';
-DELETE FROM nearby_spots WHERE race_id = 'tomisato-suikaroad-2026';
-DELETE FROM weather_history WHERE race_id = 'tomisato-suikaroad-2026';
-DELETE FROM participation_gifts WHERE race_id = 'tomisato-suikaroad-2026';
-DELETE FROM race_entry_links WHERE race_id = 'tomisato-suikaroad-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'tomisato-suikaroad-2026';
-DELETE FROM race_results WHERE race_id = 'tomisato-suikaroad-2026';
-DELETE FROM race_gallery WHERE race_id = 'tomisato-suikaroad-2026';
-DELETE FROM race_voices WHERE race_id = 'tomisato-suikaroad-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'tomisato-suikaroad-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'tomisato-suikaroad-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('tomisato-suikaroad-2026', '10k', 10, 70, '09:15', 1500, 6500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
@@ -6383,6 +6625,20 @@ INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label
 -- ==================
 -- 鳥取マラソン (tottori-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'tottori-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'tottori-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'tottori-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'tottori-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'tottori-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'tottori-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'tottori-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'tottori-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'tottori-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'tottori-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'tottori-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'tottori-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'tottori-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'tottori-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -6440,20 +6696,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-15T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'tottori-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'tottori-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'tottori-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'tottori-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'tottori-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'tottori-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'tottori-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'tottori-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'tottori-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'tottori-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'tottori-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'tottori-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'tottori-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'tottori-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('tottori-marathon-2026', 'full', 42.195, 0, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -6477,6 +6719,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- 洞爺湖マラソン (toyako-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'toyako-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'toyako-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'toyako-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'toyako-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'toyako-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'toyako-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'toyako-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'toyako-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'toyako-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'toyako-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'toyako-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'toyako-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'toyako-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'toyako-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -6534,20 +6790,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-15T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'toyako-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'toyako-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'toyako-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'toyako-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'toyako-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'toyako-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'toyako-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'toyako-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'toyako-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'toyako-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'toyako-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'toyako-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'toyako-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'toyako-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('toyako-marathon-2026', 'full', 42.195, 0, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -6566,6 +6808,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- 富山マラソン (toyama-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'toyama-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'toyama-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'toyama-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'toyama-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'toyama-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'toyama-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'toyama-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'toyama-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'toyama-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'toyama-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'toyama-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'toyama-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'toyama-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'toyama-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -6623,20 +6879,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-16T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'toyama-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'toyama-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'toyama-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'toyama-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'toyama-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'toyama-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'toyama-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'toyama-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'toyama-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'toyama-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'toyama-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'toyama-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'toyama-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'toyama-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('toyama-marathon-2026', 'full', 42.195, 420, '09:30', 13000, 14000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -6657,6 +6899,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- つくばマラソン (tsukuba-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'tsukuba-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'tsukuba-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'tsukuba-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'tsukuba-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'tsukuba-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'tsukuba-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'tsukuba-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'tsukuba-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'tsukuba-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'tsukuba-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'tsukuba-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'tsukuba-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'tsukuba-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'tsukuba-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -6714,20 +6970,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-16T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'tsukuba-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'tsukuba-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'tsukuba-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'tsukuba-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'tsukuba-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'tsukuba-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'tsukuba-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'tsukuba-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'tsukuba-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'tsukuba-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'tsukuba-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'tsukuba-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'tsukuba-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'tsukuba-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('tsukuba-marathon-2026', 'full', 42.195, 0, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -6740,6 +6982,20 @@ INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label
 -- ==================
 -- 日本最北端わっかない平和マラソン (wakkanai-peace-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'wakkanai-peace-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'wakkanai-peace-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'wakkanai-peace-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'wakkanai-peace-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'wakkanai-peace-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'wakkanai-peace-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'wakkanai-peace-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'wakkanai-peace-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'wakkanai-peace-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'wakkanai-peace-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'wakkanai-peace-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'wakkanai-peace-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'wakkanai-peace-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'wakkanai-peace-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -6797,20 +7053,6 @@ INSERT OR REPLACE INTO races (
   '2026-04-30T00:00:00Z',
   '2026-04-30T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'wakkanai-peace-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'wakkanai-peace-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'wakkanai-peace-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'wakkanai-peace-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'wakkanai-peace-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'wakkanai-peace-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'wakkanai-peace-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'wakkanai-peace-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'wakkanai-peace-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'wakkanai-peace-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'wakkanai-peace-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'wakkanai-peace-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'wakkanai-peace-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'wakkanai-peace-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('wakkanai-peace-marathon-2026', 'full', 42.195, 390, '', 1000, 10000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -6831,6 +7073,20 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
 -- ==================
 -- 横浜マラソン (yokohama-marathon-2026)
 -- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'yokohama-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'yokohama-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'yokohama-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'yokohama-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'yokohama-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'yokohama-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'yokohama-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'yokohama-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'yokohama-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'yokohama-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'yokohama-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'yokohama-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'yokohama-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'yokohama-marathon-2026';
 INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -6888,20 +7144,6 @@ INSERT OR REPLACE INTO races (
   '2026-03-15T00:00:00Z',
   '2026-03-16T00:00:00Z'
 );
-DELETE FROM race_categories WHERE race_id = 'yokohama-marathon-2026';
-DELETE FROM aid_stations WHERE race_id = 'yokohama-marathon-2026';
-DELETE FROM checkpoints WHERE race_id = 'yokohama-marathon-2026';
-DELETE FROM access_points WHERE race_id = 'yokohama-marathon-2026';
-DELETE FROM nearby_spots WHERE race_id = 'yokohama-marathon-2026';
-DELETE FROM weather_history WHERE race_id = 'yokohama-marathon-2026';
-DELETE FROM participation_gifts WHERE race_id = 'yokohama-marathon-2026';
-DELETE FROM race_entry_links WHERE race_id = 'yokohama-marathon-2026';
-DELETE FROM race_entry_periods WHERE race_id = 'yokohama-marathon-2026';
-DELETE FROM race_results WHERE race_id = 'yokohama-marathon-2026';
-DELETE FROM race_gallery WHERE race_id = 'yokohama-marathon-2026';
-DELETE FROM race_voices WHERE race_id = 'yokohama-marathon-2026';
-DELETE FROM race_time_buckets WHERE race_id = 'yokohama-marathon-2026';
-DELETE FROM race_course_highlights WHERE race_id = 'yokohama-marathon-2026';
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('yokohama-marathon-2026', 'full', 42.195, 390, '08:30', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES

--- a/scripts/generate-seed-races.js
+++ b/scripts/generate-seed-races.js
@@ -29,7 +29,25 @@ function generateRaceSQL(r) {
   const ci = r.course_info || {};
   const lines = [];
 
-  // races テーブル
+  // 子テーブルの既存データを先に削除する
+  // race_course_highlights.category_id → race_categories.id は NO ACTION FK のため、
+  // INSERT OR REPLACE INTO races のカスケード削除より前に手動削除が必要
+  lines.push(`DELETE FROM race_course_highlights WHERE race_id = ${esc(r.id)};`);
+  lines.push(`DELETE FROM race_categories WHERE race_id = ${esc(r.id)};`);
+  lines.push(`DELETE FROM aid_stations WHERE race_id = ${esc(r.id)};`);
+  lines.push(`DELETE FROM checkpoints WHERE race_id = ${esc(r.id)};`);
+  lines.push(`DELETE FROM access_points WHERE race_id = ${esc(r.id)};`);
+  lines.push(`DELETE FROM nearby_spots WHERE race_id = ${esc(r.id)};`);
+  lines.push(`DELETE FROM weather_history WHERE race_id = ${esc(r.id)};`);
+  lines.push(`DELETE FROM participation_gifts WHERE race_id = ${esc(r.id)};`);
+  lines.push(`DELETE FROM race_entry_links WHERE race_id = ${esc(r.id)};`);
+  lines.push(`DELETE FROM race_entry_periods WHERE race_id = ${esc(r.id)};`);
+  lines.push(`DELETE FROM race_results WHERE race_id = ${esc(r.id)};`);
+  lines.push(`DELETE FROM race_gallery WHERE race_id = ${esc(r.id)};`);
+  lines.push(`DELETE FROM race_voices WHERE race_id = ${esc(r.id)};`);
+  lines.push(`DELETE FROM race_time_buckets WHERE race_id = ${esc(r.id)};`);
+
+  // races テーブル（子テーブルのDELETE後に実行することでカスケード削除のFK競合を回避）
   lines.push(`INSERT OR REPLACE INTO races (
   id, name_ja, name_en, date, prefecture, city_ja, city_en,
   description_ja, description_en, official_url,
@@ -88,32 +106,17 @@ function generateRaceSQL(r) {
   ${esc(r.updated_at)}
 );`);
 
-  // 子テーブルの既存データを削除（INSERT OR REPLACE が id なしでは重複するため）
-  lines.push(`DELETE FROM race_categories WHERE race_id = ${esc(r.id)};`);
-  lines.push(`DELETE FROM aid_stations WHERE race_id = ${esc(r.id)};`);
-  lines.push(`DELETE FROM checkpoints WHERE race_id = ${esc(r.id)};`);
-  lines.push(`DELETE FROM access_points WHERE race_id = ${esc(r.id)};`);
-  lines.push(`DELETE FROM nearby_spots WHERE race_id = ${esc(r.id)};`);
-  lines.push(`DELETE FROM weather_history WHERE race_id = ${esc(r.id)};`);
-  lines.push(`DELETE FROM participation_gifts WHERE race_id = ${esc(r.id)};`);
-  lines.push(`DELETE FROM race_entry_links WHERE race_id = ${esc(r.id)};`);
-  lines.push(`DELETE FROM race_entry_periods WHERE race_id = ${esc(r.id)};`);
-  lines.push(`DELETE FROM race_results WHERE race_id = ${esc(r.id)};`);
-  lines.push(`DELETE FROM race_gallery WHERE race_id = ${esc(r.id)};`);
-  lines.push(`DELETE FROM race_voices WHERE race_id = ${esc(r.id)};`);
-  lines.push(`DELETE FROM race_time_buckets WHERE race_id = ${esc(r.id)};`);
-  lines.push(`DELETE FROM race_course_highlights WHERE race_id = ${esc(r.id)};`);
-
   // race_categories（+ カテゴリに付随する course_highlights）
   if (r.categories && r.categories.length > 0) {
     r.categories.forEach((cat, idx) => {
       lines.push(`INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   (${esc(r.id)}, ${esc(cat.distance_type)}, ${esc(cat.distance_km)}, ${esc(cat.time_limit_minutes || 0)}, ${esc(cat.start_time || '')}, ${esc(cat.capacity || 0)}, ${esc(cat.entry_fee ?? null)}, ${esc(cat.entry_fee_u25 ?? null)}, ${esc(cat.name_ja ?? null)}, ${esc(cat.name_en ?? null)}, ${esc(cat.description_ja ?? null)}, ${esc(cat.description_en ?? null)}, ${esc(cat.eligibility_ja ?? null)}, ${esc(cat.eligibility_en ?? null)}, ${esc(cat.course_gpx_file ?? null)}, ${escJson(cat.waves || [])}, ${idx});`);
-      // カテゴリ直下の course_highlights: last_insert_rowid() で category_id を取得
+      // カテゴリ直下の course_highlights: サブクエリで category_id を取得
+      // （last_insert_rowid() は race_course_highlights INSERT後に更新されるため使用不可）
       if (cat.course_highlights && cat.course_highlights.length > 0) {
         cat.course_highlights.forEach((ch, cidx) => {
           lines.push(`INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  (${esc(r.id)}, last_insert_rowid(), ${esc(ch.km)}, ${esc(ch.name_ja)}, ${esc(ch.name_en ?? null)}, ${esc(ch.note_ja ?? null)}, ${esc(ch.note_en ?? null)}, ${cidx});`);
+  (${esc(r.id)}, (SELECT id FROM race_categories WHERE race_id = ${esc(r.id)} AND distance_type = ${esc(cat.distance_type)} ORDER BY id DESC LIMIT 1), ${esc(ch.km)}, ${esc(ch.name_ja)}, ${esc(ch.name_en ?? null)}, ${esc(ch.note_ja ?? null)}, ${esc(ch.note_en ?? null)}, ${cidx});`);
         });
       }
     });

--- a/src/data/races/sapporo-marathon-2026.json
+++ b/src/data/races/sapporo-marathon-2026.json
@@ -1,0 +1,112 @@
+{
+  "id": "sapporo-marathon-2026",
+  "name_ja": "札幌マラソン",
+  "name_en": "Sapporo　Marathon",
+  "full_name_ja": "第51回札幌マラソン",
+  "full_name_en": "51st Sapporo　Marathon",
+  "edition": 51,
+  "date": "2026-10-04",
+  "prefecture": "01",
+  "city_ja": "札幌市南区真駒内公園3番1号",
+  "city_en": "",
+  "description_ja": "",
+  "description_en": "",
+  "official_url": "https://satumara.sapporo-sport.jp/index.html",
+  "entry_fee": null,
+  "entry_fee_by_category": true,
+  "entry_capacity": 0,
+  "entry_start_date": "2026-05-23",
+  "entry_end_date": "2026-07-11",
+  "reception_type": "pre_mail",
+  "reception_note_ja": "",
+  "reception_note_en": "",
+  "tags": [],
+  "course_gpx_file": null,
+  "course_info": {
+    "max_elevation_m": null,
+    "min_elevation_m": null,
+    "elevation_diff_m": null,
+    "surface": "road",
+    "certification": [],
+    "highlights_ja": "",
+    "highlights_en": "",
+    "notes_ja": "",
+    "notes_en": ""
+  },
+  "categories": [
+    {
+      "distance_type": "half",
+      "distance_km": 21.0975,
+      "entry_fee": 8000,
+      "capacity": 8000,
+      "time_limit_minutes": 0,
+      "start_time": "09:20",
+      "name_ja": null,
+      "eligibility_ja": null,
+      "eligibility_en": null,
+      "course_gpx_file": null,
+      "course_highlights": []
+    },
+    {
+      "distance_type": "10k",
+      "distance_km": 10,
+      "entry_fee": 5000,
+      "capacity": 4000,
+      "time_limit_minutes": 0,
+      "start_time": "09:00",
+      "name_ja": null,
+      "eligibility_ja": null,
+      "eligibility_en": null,
+      "course_gpx_file": null,
+      "course_highlights": []
+    }
+  ],
+  "aid_stations": [],
+  "checkpoints": [],
+  "access_points": [],
+  "nearby_spots": [],
+  "result": null,
+  "created_at": "2026-05-15T14:40:14.753Z",
+  "updated_at": "2026-05-15T14:40:14.753Z",
+  "entry_periods": [
+    {
+      "start_date": "2026-05-23",
+      "end_date": "2026-07-11",
+      "entry_fee": null,
+      "label_ja": "",
+      "label_en": ""
+    }
+  ],
+  "entry_closed": false,
+  "entry_links": [
+    {
+      "site_name": "RUNNET",
+      "url": "https://satumara.sapporo-sport.jp/images/entry/runnet.svg"
+    },
+    {
+      "site_name": "SPORT ENTRY",
+      "url": "https://www.sportsentry.ne.jp/event/t/105098"
+    }
+  ],
+  "participation_gifts": [
+    {
+      "gift_categories": [
+        "tshirt"
+      ],
+      "description_ja": "オリジナルTシャツ\nhttps://satumara.sapporo-sport.jp/prizes.html",
+      "description_en": "",
+      "image": null
+    }
+  ],
+  "motif": "時計台",
+  "motif_romaji": "NEW CLASSIC",
+  "motif_color": null,
+  "tagline_ja": "その一歩から、また始まる。",
+  "tagline_en": "It all starts with that first step.",
+  "hero_image_url": null,
+  "hero_caption_ja": null,
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": []
+}


### PR DESCRIPTION
## Summary

- `race_course_highlights.category_id → race_categories.id` の FK が ON DELETE 句なし（RESTRICT）だったため、再シード時に FK 制約エラーが発生していた問題を修正
- シード生成スクリプトの2つのバグを修正（DELETE 順序・`last_insert_rowid()` の誤用）
- 新レース2件を追加（札幌マラソン・東京レガシーハーフマラソン）

## 変更内容

### `migrations/0010_fix_course_highlights_fk.sql`（新規）
- `race_course_highlights` テーブルを再作成し `category_id` FK に `ON DELETE CASCADE` を追加
- `schema.ts` の `onDelete: "cascade"` 定義と DB の実態を一致させる

### `scripts/generate-seed-races.js`
- **バグ1**: 子テーブルの DELETE を `INSERT OR REPLACE INTO races` より**先に**実行するよう順序変更
  - 旧: `INSERT OR REPLACE INTO races` → カスケード削除 → `category_id` RESTRICT FK でエラー
  - 新: `DELETE FROM race_course_highlights` → `DELETE FROM race_categories` → ... → `INSERT OR REPLACE INTO races`
- **バグ2**: カテゴリレベル `race_course_highlights` の `category_id` で `last_insert_rowid()` → サブクエリに変更
  - 2件目以降の INSERT 後に `last_insert_rowid()` が highlights の rowid に更新され、FK 違反になっていた

### 新レース
- `src/data/races/sapporo-marathon-2026.json`: 札幌マラソン（2026-10-04、ハーフ・10km）
- `migrations/seed-races-all.sql`: 78件分を再生成

## Test plan

- [ ] `npm run db:seed-races:local` が2回連続でエラーなく完了することを確認
- [ ] `npm run db:migrate:remote` + `npm run db:seed-races:remote` でリモートにも適用

🤖 Generated with [Claude Code](https://claude.com/claude-code)