### PR TITLE
ci: GitHub Actions デプロイワークフローを追加（Windows ビルド問題の恒久対策）

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,19 +5,24 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: Build & Deploy
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@7088e561eb65bb68695d245aa206f005ef30921d # v4.1.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -29,7 +34,8 @@ jobs:
         run: pnpm run cf:build
 
       - name: Deploy to Cloudflare Pages
-        run: npx wrangler pages deploy --commit-message "${{ github.event.head_commit.message || 'deploy' }}"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message || 'deploy' }}
+        run: npx wrangler pages deploy --commit-message "$COMMIT_MESSAGE"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,35 @@
+name: Deploy to Cloudflare Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Build & Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build (OpenNext + Cloudflare)
+        run: pnpm run cf:build
+
+      - name: Deploy to Cloudflare Pages
+        run: npx wrangler pages deploy --commit-message "${{ github.event.head_commit.message || 'deploy' }}"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 /node_modules
+/.pnpm-store
 /.pnp
 .pnp.*
 .yarn/*

--- a/src/data/races/gunma-marathon-2026.json
+++ b/src/data/races/gunma-marathon-2026.json
@@ -111,7 +111,7 @@
   "entry_periods": [
     {
       "start_date": "2026-04-09",
-      "end_date": "2026-08-17",
+      "end_date": "2026-05-13",
       "entry_fee": null,
       "label_ja": "",
       "label_en": ""

--- a/src/data/races/gunma-marathon-2026.json
+++ b/src/data/races/gunma-marathon-2026.json
@@ -16,7 +16,7 @@
   "entry_fee_by_category": true,
   "entry_capacity": 5500,
   "entry_start_date": "2026-04-09",
-  "entry_end_date": "2026-08-17",
+  "entry_end_date": "2026-05-13",
   "reception_type": "pre_mail",
   "reception_note_ja": "参加者には、アスリートビブス、計測チップ、参加マニュアル等を申込時の住所に事前に発送します（10月下旬発送予定）。大会前日・当日の受付は行いません。\n\nエントリー締切後の住所変更は、郵便局にて転送手続きをお願いします。\n計測チップは、アスリートビブスに貼り付けてあります。外さずに参加してください。なお、詳細につきましてはアスリートビブスが入ったビニール袋同封の案内をご覧ください。\n大会にエントリー後、出場できなくなった場合のご連絡は不要です。参加賞の受取方法は「参加マニュアル」をご参照ください。",
   "reception_note_en": "Participants will receive their athlete bibs, timing chips, and participation manuals in advance at the address provided during registration (scheduled for late October). There will be no registration on the day before or the day of the event.\n\nFor address changes after the entry deadline, please arrange for mail forwarding at the post office.\n\nThe timing chip is attached to the athlete bib. Please do not remove it during the event. For further details, please refer to the instructions enclosed in the plastic bag containing the athlete bib.\n\nIf you are unable to participate after registering, you do not need to contact us. Please refer to the \"Participation Manual\" for instructions on how to receive your participation prize.",
@@ -96,15 +96,16 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-05-25T01:19:17.709Z",
+  "updated_at": "2026-05-27T14:55:42.669Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
       "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
       "秋冬大会の日程は例年パターンからの推定を含む。正式発表後に要更新",
-      "2026-05-25: 自動クロールで更新"
+      "2026-05-25: 自動クロールで更新",
+      "2026-05-27: 自動クロールで更新"
     ],
-    "last_verified": "2026-05-25",
+    "last_verified": "2026-05-27",
     "detail_level": "medium"
   },
   "entry_periods": [

--- a/src/data/races/higashine-sakuranbo-marathon-2026.json
+++ b/src/data/races/higashine-sakuranbo-marathon-2026.json
@@ -12,9 +12,9 @@
   "description_ja": "さくらんぼの名産地・山形県東根市で毎年6月に開催される大会。陸上自衛隊神町駐屯地をスタート・フィニッシュ地点とし、フルーツラインの周回コースを走る。ハーフマラソン・10km・5kmの3種目。さくらんぼの季節に合わせた地域密着型のレース。",
   "description_en": "A popular race held every June in Higashine City, Yamagata, famous for its cherries. The course starts and finishes at JGSDF Kanomachi Garrison and loops around the Fruit Line road. Three distances: half marathon, 10km, and 5km.",
   "official_url": "https://www.sakuranbo-m.jp/",
-  "entry_fee": 0,
+  "entry_fee": 6000,
   "entry_fee_by_category": true,
-  "entry_capacity": 0,
+  "entry_capacity": 10000,
   "entry_start_date": "2026-02-01",
   "entry_end_date": "2026-03-31",
   "reception_type": "pre_day",
@@ -82,13 +82,14 @@
   ],
   "result": null,
   "created_at": "2026-03-30T00:00:00Z",
-  "updated_at": "2026-03-30T00:00:00Z",
+  "updated_at": "2026-05-27T14:55:48.396Z",
   "_metadata": {
     "data_source": "公式サイト（https://www.sakuranbo-m.jp/）・大会概要ページ",
     "data_accuracy_notes": [
-      "基本情報のみ。エイド、周辺スポット等は未入力"
+      "基本情報のみ。エイド、周辺スポット等は未入力",
+      "2026-05-27: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-30",
+    "last_verified": "2026-05-27",
     "detail_level": "basic"
   },
   "entry_periods": [


### PR DESCRIPTION
## 背景

Windows 上で `pnpm run cf:deploy` を実行すると、OpenNext が `node_modules` の pnpm シンボリックリンクを `.open-next` にコピーした際に esbuild が「Access is denied」エラーを起こしてビルドが失敗する。

これは OpenNext が公式に「Windows では WSL 推奨」と警告している既知の問題。

## 対策

`ubuntu-latest` 上で実行する GitHub Actions ワークフローを追加。Linux 環境ではシンボリックリンクの問題が発生しない。

## 必要な設定

マージ後、GitHub リポジトリの **Settings → Secrets and variables → Actions** に以下の Secret を追加：

| Secret 名 | 値 |
|---|---|
| `CLOUDFLARE_API_TOKEN` | Cloudflare ダッシュボード → My Profile → API Tokens → Pages:Edit 権限のトークン |
| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare ダッシュボード → 右サイドバーの Account ID |

## 動作

- `main` へのプッシュで自動デプロイ
- GitHub の「Actions」タブから手動トリガーも可能（`workflow_dispatch`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * main ブランチへの push と手動実行で Cloudflare Pages へ自動デプロイするワークフローを追加しました。

* **Updates**
  * 複数のマラソン大会の開催情報を更新しました。群馬マラソン2026のエントリー終了日を短縮し、最上（桜ん坊）マラソン2026では参加料金と募集定員を追加しました。自動更新プロセスで確認・更新済みです。

* **Chores**
  * ローカルのパッケージ管理用ストアを無視対象に追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/krote/krote-run/pull/70?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->