### PR TITLE
fix: AbortSignal をリクエストごとに生成してクロールタイムアウトバグを修正

### DIFF
--- a/migrations/seed-races-all.sql
+++ b/migrations/seed-races-all.sql
@@ -1,5 +1,5 @@
 -- 自動生成: generate-seed-races.js
--- 生成日時: 2026-05-25T14:45:30.146Z
+-- 生成日時: 2026-05-31T14:06:45.508Z
 -- 対象ファイル数: 79 件（既存 2 件はskip）
 
 -- ==================
@@ -921,7 +921,7 @@ INSERT OR REPLACE INTO races (
   '京都府福知山市で開催される歴史あるフルマラソン。由良川沿いの起伏あるコースが特徴で、ランナーの実力が試される大会として知られる。三段池扶桑化学工業アリーナ西側をスタート・ゴールとする。',
   'A historic full marathon held in Fukuchiyama City, Kyoto Prefecture. Known for its challenging course along the Yura River with rolling hills. Starts and finishes at the west side of Sandaike Fusokagaku Arena.',
   'https://fukuchiyama-marathon.com/',
-  NULL,
+  10000,
   1,
   6000,
   '2026-05-01',
@@ -950,7 +950,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-04-30T00:00:00Z',
-  '2026-05-25T01:18:41.038Z'
+  '2026-05-30T06:11:39.885Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('fukuchiyama-marathon-2026', 'full', 42.195, 360, '', 5400, 11000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -1291,7 +1291,7 @@ INSERT OR REPLACE INTO races (
   1,
   5500,
   '2026-04-09',
-  '2026-08-17',
+  '2026-05-13',
   0,
   'pre_mail',
   '参加者には、アスリートビブス、計測チップ、参加マニュアル等を申込時の住所に事前に発送します（10月下旬発送予定）。大会前日・当日の受付は行いません。
@@ -1326,7 +1326,7 @@ If you are unable to participate after registering, you do not need to contact u
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-05-25T01:19:17.709Z'
+  '2026-05-27T14:55:42.669Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('gunma-marathon-2026', 'full', 42.195, 360, '08:55', 5500, 13500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -1341,7 +1341,7 @@ Translated with DeepL.com (free version)', '', 'https://worldheritage.pref.gunma
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('gunma-marathon-2026', '["medal","tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
-  ('gunma-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-09', '2026-08-17', NULL, 0);
+  ('gunma-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-09', '2026-05-13', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
   ('gunma-marathon-2026', NULL, NULL, '赤城山', 'Mt. Akagi', NULL, NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -1394,9 +1394,9 @@ INSERT OR REPLACE INTO races (
   'さくらんぼの名産地・山形県東根市で毎年6月に開催される大会。陸上自衛隊神町駐屯地をスタート・フィニッシュ地点とし、フルーツラインの周回コースを走る。ハーフマラソン・10km・5kmの3種目。さくらんぼの季節に合わせた地域密着型のレース。',
   'A popular race held every June in Higashine City, Yamagata, famous for its cherries. The course starts and finishes at JGSDF Kanomachi Garrison and loops around the Fruit Line road. Three distances: half marathon, 10km, and 5km.',
   'https://www.sakuranbo-m.jp/',
-  0,
+  6000,
   1,
-  0,
+  10000,
   '2026-02-01',
   '2026-03-31',
   0,
@@ -1423,7 +1423,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-30T00:00:00Z',
-  '2026-03-30T00:00:00Z'
+  '2026-05-27T14:55:48.396Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('higashine-sakuranbo-marathon-2026', 'half', 21.0975, 170, '08:40', 5500, 6000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -1742,9 +1742,9 @@ INSERT OR REPLACE INTO races (
   '山口県防府市で開催されるエリート志向のフルマラソン。制限時間4時間で走力が求められる。MGCシリーズG1大会。',
   'An elite-oriented full marathon in Hofu, Yamaguchi. The 4-hour time limit demands strong running ability. MGC Series G1 event.',
   'https://hofu-yomiuri.jp/',
-  0,
+  13000,
   1,
-  0,
+  3500,
   NULL,
   NULL,
   0,
@@ -1771,7 +1771,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-03-16T00:00:00Z'
+  '2026-05-30T06:35:00.134Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('hofu-yomiuri-marathon-2026', 'full', 42.195, 240, '12:03', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -1825,9 +1825,9 @@ INSERT OR REPLACE INTO races (
   '夏に開催される日本唯一の大規模フルマラソン。札幌の市街地と北海道大学キャンパス内を走る。MGCシリーズG2大会。',
   'Japan''s only large-scale summer full marathon. Run through Sapporo''s city center and Hokkaido University campus. MGC Series G2 event.',
   'https://hokkaido-marathon.com',
-  0,
+  16500,
   1,
-  0,
+  20000,
   '2026-03-29',
   '2026-04-24',
   0,
@@ -1854,7 +1854,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-03-15T00:00:00Z'
+  '2026-05-30T06:35:06.519Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('hokkaido-marathon-2026', 'full', 42.195, 360, '08:30', 20000, 16500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -1918,11 +1918,11 @@ INSERT OR REPLACE INTO races (
   '南国の指宿を舞台に、菜の花が咲き誇る温暖な1月に開催されるフルマラソン。開聞岳や錦江湾の絶景を楽しみながら走れる。レース後は砂むし温泉が楽しめる。',
   'A full marathon held in warm January in Ibusuki, surrounded by blooming canola flowers. Enjoy views of Mt. Kaimon and Kinko Bay. Sand steam baths available after the race.',
   'https://ibusuki-nanohana.com',
-  NULL,
+  10000,
   1,
-  0,
-  NULL,
-  NULL,
+  10000,
+  '2025-08-01',
+  '2025-10-19',
   0,
   'race_day',
   'アスリートビブスは事前郵送。記念品引換は前日・当日に総合体育館にて。',
@@ -1947,7 +1947,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-03-16T00:00:00Z'
+  '2026-05-30T06:35:12.039Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('ibusuki-nanohana-2026', 'full', 42.195, 480, '09:00', 10000, 10000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -2011,9 +2011,9 @@ INSERT OR REPLACE INTO races (
   '最大高低差わずか15mのフラットコースを誇る一関国際ハーフマラソン。日本陸連公認の高速コースで、賞金レースとしても知られる。みちのく選手権も同時開催。優秀成績者にはホノルルマラソン派遣の特典あり。',
   'A flat course with only 15m elevation difference, the Ichinoseki International Half Marathon is a JAAF-certified fast course with prize money. Held simultaneously with the Michinoku Championship. Top finishers receive an invitation to the Honolulu Marathon.',
   'https://ichinoseki-half.jp/',
-  0,
+  6000,
   1,
-  0,
+  2500,
   '2026-04-01',
   '2026-06-30',
   0,
@@ -2040,7 +2040,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-29T00:00:00Z',
-  '2026-03-29T00:00:00Z'
+  '2026-05-30T06:35:21.220Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('ichinoseki-half-marathon-2026', 'half', 21.0975, 170, '09:00', 2000, 6000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -2096,7 +2096,7 @@ INSERT OR REPLACE INTO races (
   'https://iki-ultra.jp/',
   NULL,
   1,
-  0,
+  1000,
   '2026-04-10',
   '2026-07-17',
   0,
@@ -2123,7 +2123,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-04-05T08:19:26.353Z',
-  '2026-04-05T08:19:26.353Z'
+  '2026-05-30T06:35:34.537Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('iki-ultra-marathon-2026', 'ultra', 100, 840, '05:00', 1000, 20000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -2177,9 +2177,9 @@ INSERT OR REPLACE INTO races (
   '荒川河川敷を走るフラットなフルマラソン。記録を狙いやすいコースとして人気。制限時間7時間で初心者にも優しい。',
   'A flat full marathon along the Arakawa River. Popular for record attempts. 7-hour time limit is beginner-friendly.',
   'https://i-c-m.jp',
-  0,
+  11550,
   1,
-  0,
+  10000,
   '2025-08-01',
   '2025-11-24',
   0,
@@ -2206,7 +2206,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-03-15T00:00:00Z'
+  '2026-05-30T06:35:40.462Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('itabashi-city-marathon-2026', 'full', 42.195, 420, '09:00', 10000, 11550, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -2264,9 +2264,9 @@ INSERT OR REPLACE INTO races (
   '福島県いわき市で開催されるフルマラソン。太平洋に面した海岸コース。いわきの復興と元気を発信する大会。',
   'A full marathon in Iwaki City, Fukushima, along the Pacific coast. A race promoting Iwaki''s recovery and vitality.',
   'https://iwaki-marathon.jp',
-  0,
+  9000,
   1,
-  0,
+  8000,
   '2025-09-12',
   '2025-10-15',
   0,
@@ -2293,7 +2293,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-03-15T00:00:00Z'
+  '2026-05-30T06:35:45.814Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('iwaki-sunshine-marathon-2026', 'full', 42.195, 360, '', 5000, 9000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -2381,9 +2381,9 @@ Feature 4: Full Marathon Finisher Awards Include a Nanbu Ironware Finisher Medal
 
 Translated with DeepL.com (free version)',
   'https://iwate-morioka-city-marathon.jp/',
-  NULL,
+  12000,
   1,
-  0,
+  6000,
   '2026-04-01',
   '2026-07-20',
   0,
@@ -2414,7 +2414,7 @@ Translated with DeepL.com (free version)',
   NULL,
   NULL,
   '2026-04-16T15:23:52.019Z',
-  '2026-04-16T15:23:52.019Z'
+  '2026-05-30T06:35:52.274Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('iwate-morioka-city-marathon-2026', 'full', 42.195, 360, '09:00', 6000, 12000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -2466,11 +2466,11 @@ INSERT OR REPLACE INTO races (
   '岩手県奥州市で開催。奥州の自然と歴史を感じながら走るフルマラソン。',
   'A full marathon in Oshu City, Iwate, running through the nature and history of the region.',
   'https://oshukirameki.jp',
-  0,
+  10000,
   1,
-  0,
+  3000,
   '2025-11-28',
-  '2026-02-15',
+  '2026-02-28',
   0,
   'pre_day',
   '',
@@ -2495,7 +2495,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-03-15T00:00:00Z'
+  '2026-05-30T06:36:12.295Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('iwate-oshu-kirameki-marathon-2026', 'full', 42.195, 360, '08:30', 3000, 10000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -2553,7 +2553,7 @@ INSERT OR REPLACE INTO races (
   'https://kagawa-marathon.com',
   0,
   1,
-  0,
+  10000,
   '2025-10-06',
   '2025-11-24',
   0,
@@ -2580,7 +2580,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-03-15T00:00:00Z'
+  '2026-05-30T06:36:17.548Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kagawa-marathon-2026', 'full', 42.195, 360, '10:00', 10000, 14000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -2636,9 +2636,9 @@ INSERT OR REPLACE INTO races (
   '桜島を望みながら走るフルマラソン。錦江湾沿いの雄大な景色が魅力。',
   'A full marathon with views of Sakurajima volcano. Features magnificent scenery along Kinko Bay.',
   'https://www.kagoshima-marathon.jp',
-  0,
+  14000,
   1,
-  0,
+  10000,
   '2025-08-08',
   '2025-11-16',
   0,
@@ -2665,7 +2665,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-03-15T00:00:00Z'
+  '2026-05-30T06:36:35.675Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kagoshima-marathon-2026', 'full', 42.195, 420, '08:30', 10000, 14000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -2725,7 +2725,7 @@ INSERT OR REPLACE INTO races (
   '関門海峡を望む下関で開催されるフルマラソン。海峡沿いの爽快なコースを走り、関門大橋や巌流島など絶景スポットを楽しめる。フグの街・下関ならではのエイドも人気。',
   'A full marathon in Shimonoseki overlooking the Kanmon Strait. Enjoy scenic views of the Kanmon Bridge and Ganryujima Island. The city''s famous fugu (blowfish) appears as a unique aid station treat.',
   'https://kaikyomarathon.jp/',
-  NULL,
+  12000,
   1,
   10000,
   '2026-05-15',
@@ -2754,7 +2754,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-04-30T00:00:00Z',
-  '2026-04-30T00:00:00Z'
+  '2026-05-30T06:36:44.764Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kaikyo-marathon-2026', 'full', 42.195, 360, '', 10000, 12000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -2818,9 +2818,9 @@ INSERT OR REPLACE INTO races (
   '加賀百万石の城下町・金沢を走るフルマラソン。兼六園や金沢城など歴史的名所を巡るコース。ご当地グルメのエイドが充実。',
   'A full marathon through Kanazawa, the historic castle town. The course passes Kenroku-en Garden, Kanazawa Castle, and more. Known for excellent local food at aid stations.',
   'https://www.kanazawa-marathon.jp',
-  NULL,
+  14000,
   1,
-  0,
+  15000,
   '2026-04-10',
   '2026-05-20',
   0,
@@ -2847,7 +2847,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-03-15T00:00:00Z'
+  '2026-05-30T06:36:53.964Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kanazawa-marathon-2026', 'full', 42.195, 420, '08:30', 15000, 14000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -2905,9 +2905,9 @@ INSERT OR REPLACE INTO races (
   '',
   '',
   'https://www.kasa-mara.jp/',
-  NULL,
+  5000,
   1,
-  0,
+  2000,
   '2025-08-11',
   '2025-10-24',
   0,
@@ -2934,7 +2934,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-05-09T14:16:13.893Z',
-  '2026-05-09T14:16:13.893Z'
+  '2026-05-30T06:37:00.046Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kasama-togeinosato-half-2025-2025', 'half', 21.0975, 150, '10:00', 2000, 5000, NULL, NULL, NULL, NULL, NULL, '18歳以上（高校生を除く）で健康に異常がなく２時間30分以内で完走できる方。なお、安全管理運営上、車いすやベビーカーを使用しての参加はできません。
@@ -3008,9 +3008,9 @@ INSERT OR REPLACE INTO races (
   '霞ヶ浦湖畔を走るフルマラソン。平坦なコースで記録を狙いやすい。',
   'A full marathon along the shore of Lake Kasumigaura. A flat course ideal for personal records.',
   'https://www.kasumigaura-marathon.jp',
-  0,
+  12000,
   1,
-  0,
+  20000,
   '2025-12-01',
   '2026-01-25',
   0,
@@ -3037,7 +3037,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-03-15T00:00:00Z'
+  '2026-05-30T06:37:10.498Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kasumigaura-marathon-2026', 'full', 42.195, 360, '09:45', 14000, 12000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -3097,9 +3097,9 @@ INSERT OR REPLACE INTO races (
   '茨城県ひたちなか市で開催される歴史ある市民マラソン。1953年からの長い歴史を持つ伝統大会。',
   'A historic citizens'' marathon held in Hitachinaka City, Ibaraki. A traditional race with a long history since 1953.',
   'https://katsutamarathon.jp',
-  0,
+  8000,
   1,
-  0,
+  12000,
   '2025-09-26',
   '2025-10-31',
   0,
@@ -3126,7 +3126,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-03-16T00:00:00Z'
+  '2026-05-30T06:37:19.558Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('katsuta-marathon-2026', 'full', 42.195, 360, '10:30', 0, 8000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -3184,9 +3184,9 @@ INSERT OR REPLACE INTO races (
   '福岡県北九州市で開催されるフルマラソン。小倉の市街地と関門海峡を望むコース。',
   'A full marathon in Kitakyushu, Fukuoka. Course features Kokura city center and views of the Kanmon Strait.',
   'https://kitakyushu-marathon.jp',
-  0,
+  14500,
   1,
-  0,
+  10800,
   '2025-08-08',
   '2025-09-25',
   0,
@@ -3213,7 +3213,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-03-15T00:00:00Z'
+  '2026-05-30T06:37:31.465Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kitakyushu-marathon-2026', 'full', 42.195, 360, '09:00', 10800, 14500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -3273,9 +3273,9 @@ INSERT OR REPLACE INTO races (
   '大阪南部の泉州地域を走るフルマラソン。関西国際空港連絡橋付近をコースに含む。',
   'A full marathon through the Senshu area of southern Osaka, with parts of the course near the Kansai International Airport bridge.',
   'http://www.senshu-marathon.jp',
-  0,
+  5000,
   1,
-  0,
+  700,
   '2025-10-10',
   '2025-11-30',
   0,
@@ -3302,7 +3302,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-03-15T00:00:00Z'
+  '2026-05-30T06:37:37.791Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kix-senshu-marathon-2026', 'full', 42.195, 420, '10:30', 700, 5000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -3358,9 +3358,9 @@ INSERT OR REPLACE INTO races (
   '神戸の港町を走る大規模フルマラソン。明石海峡大橋の折り返しが見どころ。「感謝と友情」がテーマ。',
   'A large-scale marathon through the port city of Kobe. The turnaround point near Akashi Kaikyo Bridge is a highlight. Theme: Gratitude and Friendship.',
   'https://www.kobe-marathon.net',
-  NULL,
+  18000,
   1,
-  0,
+  20000,
   '2026-04-17',
   '2026-06-01',
   0,
@@ -3405,7 +3405,7 @@ For relay runs, both runners must register together. Registration by one person,
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-03-15T00:00:00Z'
+  '2026-05-30T06:37:42.947Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kobe-marathon-2026', 'full', 42.195, 420, '09:00', 20000, 18000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -3469,9 +3469,9 @@ INSERT OR REPLACE INTO races (
   '坂本龍馬ゆかりの高知で開催されるフルマラソン。太平洋を望む雄大なコースが魅力。制限時間7時間で初心者にも優しい。',
   'A full marathon in Kochi, the home of Sakamoto Ryoma. Features a magnificent course overlooking the Pacific Ocean. 7-hour time limit is beginner-friendly.',
   'https://ryoma-marathon.jp',
-  0,
+  13000,
   1,
-  0,
+  10000,
   '2025-08-01',
   '2025-10-31',
   0,
@@ -3498,7 +3498,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-03-15T00:00:00Z'
+  '2026-05-30T06:37:49.063Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kochi-ryoma-marathon-2026', 'full', 42.195, 420, '09:00', 10000, 13000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -3560,9 +3560,9 @@ INSERT OR REPLACE INTO races (
   '熊本城を発着点とするフルマラソン。復興のシンボル・熊本城を目指してゴールする感動のフィニッシュ。',
   'A full marathon starting and finishing at Kumamoto Castle, the symbol of the city''s recovery.',
   'https://kumamotojyo-marathon.jp',
-  0,
+  13750,
   1,
-  0,
+  13000,
   '2025-07-29',
   '2025-09-24',
   0,
@@ -3589,7 +3589,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-03-16T00:00:00Z'
+  '2026-05-30T06:37:58.617Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kumamoto-castle-marathon-2026', 'full', 42.195, 420, '09:00', 13000, 13750, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -3649,7 +3649,7 @@ INSERT OR REPLACE INTO races (
   'https://kyoto-marathon.com',
   0,
   1,
-  0,
+  16000,
   '2025-07-17',
   '2025-09-22',
   0,
@@ -3676,7 +3676,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-03-15T00:00:00Z'
+  '2026-05-30T06:38:04.533Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kyoto-marathon-2026', 'full', 42.195, 360, '08:55', 16000, 18500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -3744,11 +3744,11 @@ INSERT OR REPLACE INTO races (
   '三重県松阪市で開催。松阪牛の産地を走るフルマラソン。ご当地グルメのエイドが期待される。',
   'Held in Matsusaka, Mie, home of the famous Matsusaka beef. Expect local gourmet food at aid stations.',
   'https://mie-matsusaka-marathon.jp',
-  0,
+  12900,
   1,
-  0,
-  NULL,
-  NULL,
+  10000,
+  '2026-05-24',
+  '2026-07-31',
   0,
   'pre_day',
   '',
@@ -3773,7 +3773,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-03-15T00:00:00Z'
+  '2026-05-30T06:38:15.333Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('mie-matsusaka-marathon-2026', 'full', 42.195, 0, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -3827,9 +3827,9 @@ INSERT OR REPLACE INTO races (
   '茨城県水戸市で開催。偕楽園や千波湖など水戸の名所を巡るコース。',
   'Held in Mito City, Ibaraki. Course visits Kairakuen Garden, Lake Senba, and other Mito landmarks.',
   'https://www.mitokomon-manyu-marathon.com',
-  NULL,
+  10000,
   1,
-  0,
+  10000,
   '2026-04-16',
   '2026-06-30',
   1,
@@ -3856,7 +3856,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-03-15T00:00:00Z'
+  '2026-05-30T06:38:20.579Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('mito-komon-manyu-marathon-2026', 'full', 42.195, 360, '', 10000, 10000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 'mito-komon-manyu-marathon-2026', '[]', 0);
@@ -3928,9 +3928,9 @@ Participants who finish within 1 hour and 50 minutes (net time) will qualify to 
 
 Translated with DeepL.com (free version)',
   'https://mtfujiclimbrun.com/',
-  NULL,
+  15000,
   1,
-  0,
+  2000,
   '2026-04-24',
   '2026-07-31',
   0,
@@ -3959,7 +3959,7 @@ Sunday, September 13, 6:30 AM – 30 minutes before the start time of each wave'
   NULL,
   NULL,
   '2026-04-28T13:53:53.451Z',
-  '2026-04-28T13:53:53.451Z'
+  '2026-05-30T06:38:26.366Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('mtfuji-climb-run-2026', 'other', 12, 180, '09:00', 2000, 15000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -4100,10 +4100,10 @@ INSERT OR REPLACE INTO races (
   '世界最大の女性限定マラソン。完走者全員にティファニーのオリジナルペンダントが贈られる。MGCシリーズ女子G1大会。',
   'The world''s largest women-only marathon. All finishers receive an original Tiffany pendant. MGC Series Women''s G1 event.',
   'https://womens-marathon.nagoya',
-  NULL,
+  18000,
   0,
-  20000,
-  NULL,
+  22000,
+  '2025-07-02',
   NULL,
   0,
   'pre_day',
@@ -4129,7 +4129,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-03-15T00:00:00Z'
+  '2026-05-30T06:39:00.304Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('nagoya-womens-marathon-2026', 'full', 42.195, 420, '09:10', 20000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -4187,9 +4187,9 @@ INSERT OR REPLACE INTO races (
   '沖縄・那覇で開催される日本最南端の大規模フルマラソン。南国の温暖な気候で走れる12月の人気大会。制限時間6時間15分。',
   'Japan''s southernmost large-scale full marathon in Naha, Okinawa. A popular December race in the subtropical climate. 6 hour 15 min time limit.',
   'https://www.naha-marathon.jp',
-  NULL,
+  11000,
   1,
-  0,
+  30000,
   NULL,
   NULL,
   0,
@@ -4216,7 +4216,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-03-15T00:00:00Z'
+  '2026-05-30T06:39:09.521Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('naha-marathon-2026', 'full', 42.195, 375, '09:00', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -4270,11 +4270,11 @@ INSERT OR REPLACE INTO races (
   '世界遺産の古都・奈良を走るフルマラソン。東大寺、春日大社などの名所を巡る。アップダウンが多いが、運営の評価が非常に高い人気大会。',
   'A full marathon through the ancient World Heritage city of Nara. Pass Todai-ji, Kasuga Shrine, and more. Hilly course but highly rated operations.',
   'https://www.nara-marathon.jp',
-  NULL,
+  15000,
   0,
-  0,
-  NULL,
-  NULL,
+  11750,
+  '2026-06-05',
+  '2026-07-09',
   0,
   'race_day',
   '',
@@ -4299,7 +4299,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-03-15T00:00:00Z'
+  '2026-05-30T06:39:22.310Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('nara-marathon-2026', 'full', 42.195, 360, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -4525,9 +4525,9 @@ INSERT OR REPLACE INTO races (
   '岡山城や後楽園を巡る岡山のフルマラソン。',
   'A full marathon in Okayama passing Okayama Castle and Korakuen Garden.',
   'https://www.okayamamarathon.jp',
-  0,
+  14000,
   1,
-  0,
+  15000,
   '2026-04-16',
   '2026-05-18',
   0,
@@ -4555,7 +4555,7 @@ Loppi端末(ローソン・ミニストップ店頭)',
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-03-15T00:00:00Z'
+  '2026-05-30T06:39:43.610Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('okayama-marathon-2026', 'full', 42.195, 360, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -4613,9 +4613,9 @@ INSERT OR REPLACE INTO races (
   '長野県奥信濃の豊かな自然の中を走るトレイルランニングレース。「たくさんの方に奥信濃の幸せなトレイルランニングを楽しんでほしい。トレイルランニングと奥信濃が100年続くように」という願いを込めた大会。100km・50km・25km・8kmの4種目。スタートはSBCホテル前（旧木島平スキー場）。',
   'A trail running race through the lush natural landscape of Okushinano in Nagano Prefecture. Four distances: 100km, 50km, 25km, and 8km. Start at the former Kijimadaira Ski Resort (SBC Hotel).',
   'https://okushinano100.com/',
-  NULL,
+  31000,
   1,
-  0,
+  700,
   '2025-12-14',
   '2026-05-10',
   0,
@@ -4642,7 +4642,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-30T00:00:00Z',
-  '2026-03-30T00:00:00Z'
+  '2026-05-30T06:40:08.022Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('okushinano100-2026', 'ultra', 100, 1260, '05:00', 700, 31000, NULL, NULL, NULL, NULL, NULL, '・各種目の規定年齢に達している方（100km／50km…18歳以上、25km…高校生以上、8km…中学生以上）※未成年者は保護者の承認が必要
@@ -4717,9 +4717,9 @@ INSERT OR REPLACE INTO races (
   'https://www.osaka-marathon.com',
   NULL,
   0,
-  31970,
-  NULL,
-  NULL,
+  34000,
+  '2025-07-30',
+  '2025-08-29',
   0,
   'pre_day',
   'EXPO会場にて前日受付',
@@ -4744,7 +4744,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-03-15T00:00:00Z'
+  '2026-05-30T06:40:23.729Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('osaka-marathon-2026', 'full', 42.195, 420, '09:15', 31970, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -4905,9 +4905,9 @@ INSERT OR REPLACE INTO races (
   '御嶽山（標高3,067m）麓の通常立入禁止の国有林を特別開放して行われる夜間スタートのロングレース。100Kと100マイルの2種目。深い森と御嶽山の雄大な景色の中を走る。「フィニッシュの感動は格別」と称されるOSJが誇るロングレースシリーズの一戦。',
   'A night-start long race through special-access national forest at the foot of Mt. Ontake (3,067m). Two distances: 100K and 100 Miles. Run through deep forest with majestic views of Mt. Ontake. Part of OSJ''s premier long-race series, renowned for an exceptional finish experience.',
   'https://www.outdoorsportsjapan.com/trail/ontake100/',
-  0,
+  19000,
   1,
-  0,
+  1400,
   '2026-02-01',
   '2026-06-14',
   0,
@@ -4934,7 +4934,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-30T00:00:00Z',
-  '2026-03-30T00:00:00Z'
+  '2026-05-30T06:40:45.827Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('osj-ontake100-2026', 'ultra', 163, 1440, '20:00', 200, 21000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -5075,11 +5075,11 @@ INSERT OR REPLACE INTO races (
   '桜の季節に開催される佐賀のフルマラソン。佐賀平野を駆け抜ける。',
   'A full marathon in Saga during cherry blossom season. Run across the Saga Plain.',
   'https://sagasakura-marathon.jp',
-  NULL,
+  14500,
   0,
-  0,
-  NULL,
-  NULL,
+  8500,
+  '2025-10-01',
+  '2025-10-21',
   0,
   'race_day',
   '',
@@ -5104,7 +5104,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-03-15T00:00:00Z'
+  '2026-05-30T06:40:53.342Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('saga-sakura-marathon-2026', 'full', 42.195, 0, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -5239,9 +5239,9 @@ INSERT OR REPLACE INTO races (
   '',
   '',
   'https://satumara.sapporo-sport.jp/index.html',
-  NULL,
+  8000,
   1,
-  0,
+  8000,
   '2026-05-23',
   '2026-07-11',
   0,
@@ -5268,7 +5268,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-05-15T14:40:14.753Z',
-  '2026-05-15T14:40:14.753Z'
+  '2026-05-30T06:41:49.778Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('sapporo-marathon-2026', 'half', 21.0975, 0, '09:20', 8000, 8000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -5334,7 +5334,7 @@ INSERT OR REPLACE INTO races (
   'https://www.nature-scene.net/shiga100',
   NULL,
   1,
-  0,
+  700,
   '2026-04-05',
   '2026-07-27',
   0,
@@ -5447,7 +5447,7 @@ EQUIPMENT
   NULL,
   NULL,
   '2026-04-05T06:01:54.559Z',
-  '2026-04-05T06:01:54.559Z'
+  '2026-05-30T06:41:54.953Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('shiga-kogen100-2026', 'ultra', 100, 1560, '04:30', 700, 28000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -5593,9 +5593,9 @@ INSERT OR REPLACE INTO races (
 家族や友人が選手にサポートを提供できるアシスタントポイントの設置、夜間走行となる選手の安全に配慮したぺーサ1名の同行を許可する区間の設定など、選手はじめ、沢山の人々がトレイルランニングの魅力を味わえるレーススタイル',
   '',
   'https://sfmt100.com',
-  NULL,
+  35000,
   1,
-  0,
+  1300,
   '2026-04-08',
   '2026-04-15',
   0,
@@ -5622,7 +5622,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-04-05T07:49:25.657Z',
-  '2026-04-05T07:49:25.657Z'
+  '2026-05-30T06:42:15.502Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('shinetsu5mountains-trail-100-2026', 'ultra', 163, 1980, '18:30', 600, 47000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -5852,9 +5852,9 @@ INSERT OR REPLACE INTO races (
   '岡山県総社市で開催。吉備路の歴史ある風景の中を走るマラソン。五重塔や古墳群を眺めながら走れる。',
   'Held in Soja City, Okayama. Run through the historic Kibiji landscape, passing a five-story pagoda and ancient burial mounds.',
   'https://soja-kibijimarathon.jp',
-  NULL,
+  9100,
   1,
-  0,
+  15000,
   '2025-10-01',
   '2026-01-03',
   0,
@@ -5884,7 +5884,7 @@ Therefore, there is no registration required.',
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-03-15T00:00:00Z'
+  '2026-05-30T06:42:39.583Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('soja-kibiji-marathon-2026', 'full', 42.195, 360, '09:20', 2000, 9100, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -5944,11 +5944,11 @@ INSERT OR REPLACE INTO races (
   '兵庫県丹波篠山で開催。城下町の風情と田園風景の中を走る。制限時間5時間30分。',
   'Held in Tamba-Sasayama, Hyogo. Run through a castle town atmosphere and rural landscapes. 5.5-hour time limit.',
   'https://tambasasayama-abc-marathon.jp',
-  NULL,
+  10000,
   0,
-  0,
-  NULL,
-  NULL,
+  8000,
+  '2025-10-01',
+  '2026-01-31',
   0,
   'race_day',
   '',
@@ -5973,7 +5973,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-03-15T00:00:00Z'
+  '2026-05-30T06:42:47.716Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('tamba-sasayama-abc-marathon-2026', 'full', 42.195, 330, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -6029,11 +6029,11 @@ INSERT OR REPLACE INTO races (
   '千葉県館山市の海沿いを走るフルマラソン。温暖な房総の海を眺めながら走れる冬の人気大会。',
   'A full marathon along the coast of Tateyama, Chiba. A popular winter race with views of the warm Boso coast.',
   'https://tateyama-wakasio.jp',
-  NULL,
+  9000,
   0,
-  0,
-  NULL,
-  NULL,
+  5000,
+  '2025-09-14',
+  '2025-11-13',
   0,
   'race_day',
   '',
@@ -6058,7 +6058,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-03-16T00:00:00Z'
+  '2026-05-30T06:42:59.250Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('tateyama-wakashio-2026', 'full', 42.195, 360, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -6115,9 +6115,9 @@ INSERT OR REPLACE INTO races (
 田沢湖マラソンは、1986年、県内初のフルマラソン大会として始まりました。 全国のフルマラソン大会の中でも開催時期が早いことで愛好者からの人気が高く、近年では国内外から3,000人前後が出場しています。 国内でも屈指の難コースといわれる日本一深い神秘の田沢湖を周回することで、国内外に仙北市の魅力を発信し、交流人口の増加を図りたいと考えています。',
   '',
   'https://tazawako-marathon.com/',
-  NULL,
+  10000,
   1,
-  0,
+  5550,
   '2026-04-01',
   '2026-05-27',
   0,
@@ -6144,7 +6144,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-29T11:30:29.091Z',
-  '2026-03-29T11:30:29.091Z'
+  '2026-05-30T06:43:05.830Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('tazawako-marathon-2026', 'full', 42.195, 360, '08:30', 1600, 10000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -6200,11 +6200,11 @@ INSERT OR REPLACE INTO races (
   '吉野川沿いを走る徳島のフルマラソン。阿波踊りの街を駆け抜ける。',
   'A full marathon along the Yoshino River in Tokushima, the city of Awa Odori dance.',
   'https://www.tokushima-marathon.jp',
-  NULL,
+  11000,
   0,
   0,
-  NULL,
-  NULL,
+  '2025-09-30',
+  '2025-12-31',
   0,
   'race_day',
   '',
@@ -6229,7 +6229,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-03-15T00:00:00Z'
+  '2026-05-30T06:43:19.054Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('tokushima-marathon-2026', 'full', 42.195, 0, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -6643,9 +6643,9 @@ INSERT OR REPLACE INTO races (
   'スイカの一大産地・千葉県富里市で毎年6月に開催される人気大会。エイドステーションでスイカを食べながら走れる名物大会。コース沿いのスイカ畑が広がる田園風景の中、7kmと10kmで競う。マイカップ給水対応。',
   'A popular race held every June in Tomisato City, Chiba, the top watermelon-producing area in Japan. Famous for eating watermelon at aid stations while running. Race through scenic watermelon fields in 7km and 10km distances. Supports personal cup hydration.',
   'https://tomisato-suikaroad.jp/',
-  NULL,
+  6500,
   1,
-  0,
+  7000,
   '2026-02-22',
   '2026-04-04',
   0,
@@ -6672,7 +6672,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-30T00:00:00Z',
-  '2026-03-30T00:00:00Z'
+  '2026-05-30T06:43:46.887Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('tomisato-suikaroad-2026', '10k', 10, 70, '09:15', 1500, 6500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -6728,9 +6728,9 @@ INSERT OR REPLACE INTO races (
   '鳥取砂丘に近いコースを走るフルマラソン。日本海沿いの景色を楽しめる。',
   'A full marathon near Tottori Sand Dunes. Enjoy views along the Sea of Japan coast.',
   'https://tottori-marathon.jp',
-  0,
+  13000,
   1,
-  0,
+  4000,
   '2025-10-15',
   '2025-12-12',
   0,
@@ -6757,7 +6757,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-03-15T00:00:00Z'
+  '2026-05-30T06:43:52.495Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('tottori-marathon-2026', 'full', 42.195, 0, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -6822,9 +6822,9 @@ INSERT OR REPLACE INTO races (
   '北海道・洞爺湖畔を一周するフルマラソン。羊蹄山と洞爺湖の絶景を楽しめる。新緑の季節に開催。',
   'A full marathon circling Lake Toya in Hokkaido. Enjoy magnificent views of Mt. Yotei and Lake Toya in the fresh green season.',
   'https://www.toyako-marathon.jp',
-  0,
+  11500,
   1,
-  0,
+  4500,
   '2026-02-01',
   '2026-03-08',
   0,
@@ -6851,7 +6851,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-03-15T00:00:00Z'
+  '2026-05-30T06:44:01.797Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('toyako-marathon-2026', 'full', 42.195, 0, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -6911,9 +6911,9 @@ INSERT OR REPLACE INTO races (
   '立山連峰を望みながら走るフルマラソン。新湊大橋を渡るコースが特徴。富山湾の景色が美しい。',
   'A full marathon with views of the Tateyama mountain range. Features crossing the Shinminato Bridge with beautiful Toyama Bay scenery.',
   'https://www.toyamamarathon.com',
-  NULL,
+  14000,
   1,
-  0,
+  13000,
   '2026-04-11',
   '2026-06-30',
   0,
@@ -6940,7 +6940,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-03-16T00:00:00Z'
+  '2026-05-30T06:44:11.814Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('toyama-marathon-2026', 'full', 42.195, 420, '09:30', 13000, 14000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -7038,7 +7038,7 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('tsukuba-marathon-2026', '観光地', '筑波山', 'Mt. Tsukuba', '関東平野にそびえる名山。ロープウェイで山頂へ。コースからも望める。', 'A famous mountain rising from the Kanto Plain. Ropeway to the summit. Visible from the course.', 'つくば市から車約30分', NULL, 36.2253, 140.1);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('tsukuba-marathon-2026', '["medal","tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+  ('tsukuba-marathon-2026', '["tshirt"]', '大会Tシャツ', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('tsukuba-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-07-05', '2026-07-27', NULL, 0);
 
@@ -7180,7 +7180,7 @@ INSERT OR REPLACE INTO races (
   1,
   0,
   '2026-04-08',
-  '2026-05-08',
+  '2026-05-17',
   0,
   'pre_day',
   'ローソンWEB',
@@ -7205,7 +7205,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-03-16T00:00:00Z'
+  '2026-05-30T06:44:28.893Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('yokohama-marathon-2026', 'full', 42.195, 390, '08:30', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);

--- a/migrations/seed-races-all.sql
+++ b/migrations/seed-races-all.sql
@@ -1,5 +1,5 @@
 -- 自動生成: generate-seed-races.js
--- 生成日時: 2026-05-31T14:06:45.508Z
+-- 生成日時: 2026-05-31T14:52:06.979Z
 -- 対象ファイル数: 79 件（既存 2 件はskip）
 
 -- ==================
@@ -2506,7 +2506,7 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('iwate-oshu-kirameki-marathon-2026', '["tshirt","medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
-  ('iwate-oshu-kirameki-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-11-28', '2026-02-15', NULL, 0);
+  ('iwate-oshu-kirameki-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-11-28', '2026-02-28', NULL, 0);
 
 -- ==================
 -- かがわマラソン (kagawa-marathon-2026)
@@ -7038,7 +7038,7 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('tsukuba-marathon-2026', '観光地', '筑波山', 'Mt. Tsukuba', '関東平野にそびえる名山。ロープウェイで山頂へ。コースからも望める。', 'A famous mountain rising from the Kanto Plain. Ropeway to the summit. Visible from the course.', 'つくば市から車約30分', NULL, 36.2253, 140.1);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('tsukuba-marathon-2026', '["tshirt"]', '大会Tシャツ', 'Race T-shirt, Finisher medal', NULL, 0);
+  ('tsukuba-marathon-2026', '["tshirt"]', '大会Tシャツ', 'Race T-shirt', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('tsukuba-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-07-05', '2026-07-27', NULL, 0);
 
@@ -7216,7 +7216,7 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('yokohama-marathon-2026', '["medal","tshirt","towel"]', '大会Tシャツ、完走メダル、フィニッシャータオル', 'Race T-shirt, Finisher medal, Finisher towel', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
-  ('yokohama-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-08', '2026-05-08', NULL, 0);
+  ('yokohama-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-08', '2026-05-17', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
   ('yokohama-marathon-2026', NULL, NULL, 'みなとみらい', 'Minato Mirai', NULL, NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES

--- a/src/data/races/hofu-yomiuri-marathon-2026.json
+++ b/src/data/races/hofu-yomiuri-marathon-2026.json
@@ -12,9 +12,9 @@
   "description_ja": "山口県防府市で開催されるエリート志向のフルマラソン。制限時間4時間で走力が求められる。MGCシリーズG1大会。",
   "description_en": "An elite-oriented full marathon in Hofu, Yamaguchi. The 4-hour time limit demands strong running ability. MGC Series G1 event.",
   "official_url": "https://hofu-yomiuri.jp/",
-  "entry_fee": 0,
+  "entry_fee": 13000,
   "entry_fee_by_category": true,
-  "entry_capacity": 0,
+  "entry_capacity": 3500,
   "entry_start_date": null,
   "entry_end_date": null,
   "reception_type": "pre_day",
@@ -78,14 +78,15 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-03-16T00:00:00Z",
+  "updated_at": "2026-05-30T06:35:00.134Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
       "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
-      "秋冬大会の日程は例年パターンからの推定を含む。正式発表後に要更新"
+      "秋冬大会の日程は例年パターンからの推定を含む。正式発表後に要更新",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-16",
+    "last_verified": "2026-05-30",
     "detail_level": "medium"
   },
   "entry_periods": [],

--- a/src/data/races/hokkaido-marathon-2026.json
+++ b/src/data/races/hokkaido-marathon-2026.json
@@ -12,9 +12,9 @@
   "description_ja": "夏に開催される日本唯一の大規模フルマラソン。札幌の市街地と北海道大学キャンパス内を走る。MGCシリーズG2大会。",
   "description_en": "Japan's only large-scale summer full marathon. Run through Sapporo's city center and Hokkaido University campus. MGC Series G2 event.",
   "official_url": "https://hokkaido-marathon.com",
-  "entry_fee": 0,
+  "entry_fee": 16500,
   "entry_fee_by_category": true,
-  "entry_capacity": 0,
+  "entry_capacity": 20000,
   "entry_start_date": "2026-03-29",
   "entry_end_date": "2026-04-24",
   "reception_type": "pre_day",
@@ -108,13 +108,14 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-03-15T00:00:00Z",
+  "updated_at": "2026-05-30T06:35:06.519Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
-      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力"
+      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-15",
+    "last_verified": "2026-05-30",
     "detail_level": "medium"
   },
   "entry_periods": [

--- a/src/data/races/ibusuki-nanohana-2026.json
+++ b/src/data/races/ibusuki-nanohana-2026.json
@@ -12,11 +12,11 @@
   "description_ja": "南国の指宿を舞台に、菜の花が咲き誇る温暖な1月に開催されるフルマラソン。開聞岳や錦江湾の絶景を楽しみながら走れる。レース後は砂むし温泉が楽しめる。",
   "description_en": "A full marathon held in warm January in Ibusuki, surrounded by blooming canola flowers. Enjoy views of Mt. Kaimon and Kinko Bay. Sand steam baths available after the race.",
   "official_url": "https://ibusuki-nanohana.com",
-  "entry_fee": null,
+  "entry_fee": 10000,
   "entry_fee_by_category": true,
-  "entry_capacity": 0,
-  "entry_start_date": null,
-  "entry_end_date": null,
+  "entry_capacity": 10000,
+  "entry_start_date": "2025-08-01",
+  "entry_end_date": "2025-10-19",
   "reception_type": "",
   "reception_note_ja": "アスリートビブスは事前郵送。記念品引換は前日・当日に総合体育館にて。",
   "reception_note_en": "Bibs mailed in advance. Gift exchange at gymnasium the day before and on race day.",
@@ -132,13 +132,14 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-03-16T00:00:00Z",
+  "updated_at": "2026-05-30T06:35:12.039Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
-      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力"
+      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-16",
+    "last_verified": "2026-05-30",
     "detail_level": "full"
   },
   "entry_periods": [],

--- a/src/data/races/ichinoseki-half-marathon-2026.json
+++ b/src/data/races/ichinoseki-half-marathon-2026.json
@@ -12,9 +12,9 @@
   "description_ja": "最大高低差わずか15mのフラットコースを誇る一関国際ハーフマラソン。日本陸連公認の高速コースで、賞金レースとしても知られる。みちのく選手権も同時開催。優秀成績者にはホノルルマラソン派遣の特典あり。",
   "description_en": "A flat course with only 15m elevation difference, the Ichinoseki International Half Marathon is a JAAF-certified fast course with prize money. Held simultaneously with the Michinoku Championship. Top finishers receive an invitation to the Honolulu Marathon.",
   "official_url": "https://ichinoseki-half.jp/",
-  "entry_fee": 0,
+  "entry_fee": 6000,
   "entry_fee_by_category": true,
-  "entry_capacity": 0,
+  "entry_capacity": 2500,
   "entry_start_date": "2026-04-01",
   "entry_end_date": "2026-06-30",
   "reception_type": "pre_day",
@@ -65,13 +65,14 @@
   "participation_gifts": [],
   "result": null,
   "created_at": "2026-03-29T00:00:00Z",
-  "updated_at": "2026-03-29T00:00:00Z",
+  "updated_at": "2026-05-30T06:35:21.220Z",
   "_metadata": {
     "data_source": "公式サイト（https://ichinoseki-half.jp/）およびRunnet掲載情報",
     "data_accuracy_notes": [
-      "基本情報のみ。エイド、周辺スポット等は未入力"
+      "基本情報のみ。エイド、周辺スポット等は未入力",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-29",
+    "last_verified": "2026-05-30",
     "detail_level": "basic"
   },
   "entry_periods": [

--- a/src/data/races/iki-ultra-marathon-2026.json
+++ b/src/data/races/iki-ultra-marathon-2026.json
@@ -14,7 +14,7 @@
   "official_url": "https://iki-ultra.jp/",
   "entry_fee": null,
   "entry_fee_by_category": true,
-  "entry_capacity": 0,
+  "entry_capacity": 1000,
   "entry_start_date": "2026-04-10",
   "entry_end_date": "2026-07-17",
   "reception_type": "pre_mail",
@@ -59,7 +59,7 @@
   "nearby_spots": [],
   "result": null,
   "created_at": "2026-04-05T08:19:26.353Z",
-  "updated_at": "2026-04-05T08:19:26.353Z",
+  "updated_at": "2026-05-30T06:35:34.537Z",
   "entry_periods": [
     {
       "start_date": "2026-04-10",
@@ -112,5 +112,11 @@
       "url": "https://iki-ultra.jp/access/",
       "label": "アクセス"
     }
-  ]
+  ],
+  "_metadata": {
+    "last_verified": "2026-05-30",
+    "data_accuracy_notes": [
+      "2026-05-30: 自動クロールで更新"
+    ]
+  }
 }

--- a/src/data/races/itabashi-city-marathon-2026.json
+++ b/src/data/races/itabashi-city-marathon-2026.json
@@ -12,9 +12,9 @@
   "description_ja": "荒川河川敷を走るフラットなフルマラソン。記録を狙いやすいコースとして人気。制限時間7時間で初心者にも優しい。",
   "description_en": "A flat full marathon along the Arakawa River. Popular for record attempts. 7-hour time limit is beginner-friendly.",
   "official_url": "https://i-c-m.jp",
-  "entry_fee": 0,
+  "entry_fee": 11550,
   "entry_fee_by_category": true,
-  "entry_capacity": 0,
+  "entry_capacity": 10000,
   "entry_start_date": "2025-08-01",
   "entry_end_date": "2025-11-24",
   "reception_type": "pre_day",
@@ -91,13 +91,14 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-03-15T00:00:00Z",
+  "updated_at": "2026-05-30T06:35:40.462Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
-      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力"
+      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-15",
+    "last_verified": "2026-05-30",
     "detail_level": "medium"
   },
   "entry_periods": [

--- a/src/data/races/iwaki-sunshine-marathon-2026.json
+++ b/src/data/races/iwaki-sunshine-marathon-2026.json
@@ -12,9 +12,9 @@
   "description_ja": "福島県いわき市で開催されるフルマラソン。太平洋に面した海岸コース。いわきの復興と元気を発信する大会。",
   "description_en": "A full marathon in Iwaki City, Fukushima, along the Pacific coast. A race promoting Iwaki's recovery and vitality.",
   "official_url": "https://iwaki-marathon.jp",
-  "entry_fee": 0,
+  "entry_fee": 9000,
   "entry_fee_by_category": true,
-  "entry_capacity": 0,
+  "entry_capacity": 8000,
   "entry_start_date": "2025-09-12",
   "entry_end_date": "2025-10-15",
   "reception_type": "pre_day",
@@ -105,13 +105,14 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-03-15T00:00:00Z",
+  "updated_at": "2026-05-30T06:35:45.814Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
-      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力"
+      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-15",
+    "last_verified": "2026-05-30",
     "detail_level": "medium"
   },
   "entry_periods": [

--- a/src/data/races/iwate-morioka-city-marathon-2026.json
+++ b/src/data/races/iwate-morioka-city-marathon-2026.json
@@ -12,9 +12,9 @@
   "description_ja": "特徴1「盛岡」ならではのエイドステーション\nエイドステーションでは、テレビやRUNNET大会レポなどで度々取り上げられている、話題の盛岡銘菓やわんこそばなどを多数提供予定です！ 盛岡の味を堪能しながら、完走を目指しましょう。\n\n特徴2いわて盛岡を満喫できるコース！！\n盛岡城跡公園、赤レンガ館、盛岡八幡宮など盛岡の歴史を感じられます。\nフルマラソン、ペアランのフィニッシュは、きたぎんボールパーク野球場内。\n秋の爽やかな盛岡路を満喫しましょう！\n\n特徴3市民のあたたかい応援\nコースの一部が市街地となっているため、多くの市民が沿道応援をします。\nさらに「さんさ踊り」の太鼓や吹奏楽、地元中学生の応援団がエールを送ります。\n\n特徴4フルマラソン完走賞は、南部鉄器製完走メダルとフィニッシャータオル！！",
   "description_en": "Feature 1: Aid Stations Unique to Morioka\nAt the aid stations, we plan to offer a wide variety of popular Morioka specialties—such as the famous local sweets and wanko soba—which have frequently been featured on TV and in RUNNET event reports! Enjoy the flavors of Morioka as you strive to finish the race.\n\nFeature 2: A Course That Lets You Fully Enjoy Iwate and Morioka!!\nExperience Morioka’s history at sites such as Morioka Castle Ruins Park, the Red Brick Hall, and Morioka Hachimangu Shrine.\nThe finish line for the full marathon and the pair run is located inside Kitagin Ballpark.\nEnjoy the refreshing autumn roads of Morioka!\n\nFeature 3: Warm Cheers from the Locals\nSince part of the course runs through the city center, many residents will be cheering you on along the route.\nPlus, you’ll be greeted by the drums and brass bands of the “Sansa Odori” dance, as well as cheers from local junior high school cheerleading squads.\n\nFeature 4: Full Marathon Finisher Awards Include a Nanbu Ironware Finisher Medal and a Finisher Towel!!\n\nTranslated with DeepL.com (free version)",
   "official_url": "https://iwate-morioka-city-marathon.jp/",
-  "entry_fee": null,
+  "entry_fee": 12000,
   "entry_fee_by_category": true,
-  "entry_capacity": 0,
+  "entry_capacity": 6000,
   "entry_start_date": "2026-04-01",
   "entry_end_date": "2026-07-20",
   "reception_type": "pre_day",
@@ -49,7 +49,7 @@
   "nearby_spots": [],
   "result": null,
   "created_at": "2026-04-16T15:23:52.019Z",
-  "updated_at": "2026-04-16T15:23:52.019Z",
+  "updated_at": "2026-05-30T06:35:52.274Z",
   "entry_periods": [
     {
       "start_date": "2026-04-01",
@@ -103,5 +103,11 @@
       "url": "https://iwate-morioka-city-marathon.jp/faq_reception/",
       "label": "FAQ"
     }
-  ]
+  ],
+  "_metadata": {
+    "last_verified": "2026-05-30",
+    "data_accuracy_notes": [
+      "2026-05-30: 自動クロールで更新"
+    ]
+  }
 }

--- a/src/data/races/iwate-oshu-kirameki-marathon-2026.json
+++ b/src/data/races/iwate-oshu-kirameki-marathon-2026.json
@@ -12,11 +12,11 @@
   "description_ja": "岩手県奥州市で開催。奥州の自然と歴史を感じながら走るフルマラソン。",
   "description_en": "A full marathon in Oshu City, Iwate, running through the nature and history of the region.",
   "official_url": "https://oshukirameki.jp",
-  "entry_fee": 0,
+  "entry_fee": 10000,
   "entry_fee_by_category": true,
-  "entry_capacity": 0,
+  "entry_capacity": 3000,
   "entry_start_date": "2025-11-28",
-  "entry_end_date": "2026-02-15",
+  "entry_end_date": "2026-02-28",
   "reception_type": "pre_day",
   "reception_note_ja": "",
   "reception_note_en": "",
@@ -87,14 +87,15 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-03-15T00:00:00Z",
+  "updated_at": "2026-05-30T06:36:12.295Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
       "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
-      "秋冬大会の日程は例年パターンからの推定を含む。正式発表後に要更新"
+      "秋冬大会の日程は例年パターンからの推定を含む。正式発表後に要更新",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-15",
+    "last_verified": "2026-05-30",
     "detail_level": "medium"
   },
   "entry_periods": [

--- a/src/data/races/iwate-oshu-kirameki-marathon-2026.json
+++ b/src/data/races/iwate-oshu-kirameki-marathon-2026.json
@@ -103,7 +103,7 @@
       "label_ja": "一般エントリー",
       "label_en": "General Entry",
       "start_date": "2025-11-28",
-      "end_date": "2026-02-15",
+      "end_date": "2026-02-28",
       "entry_fee": null
     }
   ],

--- a/src/data/races/kagawa-marathon-2026.json
+++ b/src/data/races/kagawa-marathon-2026.json
@@ -14,7 +14,7 @@
   "official_url": "https://kagawa-marathon.com",
   "entry_fee": 0,
   "entry_fee_by_category": true,
-  "entry_capacity": 0,
+  "entry_capacity": 10000,
   "entry_start_date": "2025-10-06",
   "entry_end_date": "2025-11-24",
   "reception_type": "pre_day",
@@ -84,13 +84,14 @@
   "participation_gifts": [],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-03-15T00:00:00Z",
+  "updated_at": "2026-05-30T06:36:17.548Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
-      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力"
+      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-15",
+    "last_verified": "2026-05-30",
     "detail_level": "medium"
   },
   "entry_periods": [

--- a/src/data/races/kagoshima-marathon-2026.json
+++ b/src/data/races/kagoshima-marathon-2026.json
@@ -12,9 +12,9 @@
   "description_ja": "桜島を望みながら走るフルマラソン。錦江湾沿いの雄大な景色が魅力。",
   "description_en": "A full marathon with views of Sakurajima volcano. Features magnificent scenery along Kinko Bay.",
   "official_url": "https://www.kagoshima-marathon.jp",
-  "entry_fee": 0,
+  "entry_fee": 14000,
   "entry_fee_by_category": true,
-  "entry_capacity": 0,
+  "entry_capacity": 10000,
   "entry_start_date": "2025-08-08",
   "entry_end_date": "2025-11-16",
   "reception_type": "pre_day",
@@ -93,13 +93,14 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-03-15T00:00:00Z",
+  "updated_at": "2026-05-30T06:36:35.675Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
-      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力"
+      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-15",
+    "last_verified": "2026-05-30",
     "detail_level": "medium"
   },
   "entry_periods": [

--- a/src/data/races/kaikyo-marathon-2026.json
+++ b/src/data/races/kaikyo-marathon-2026.json
@@ -12,7 +12,7 @@
   "description_ja": "関門海峡を望む下関で開催されるフルマラソン。海峡沿いの爽快なコースを走り、関門大橋や巌流島など絶景スポットを楽しめる。フグの街・下関ならではのエイドも人気。",
   "description_en": "A full marathon in Shimonoseki overlooking the Kanmon Strait. Enjoy scenic views of the Kanmon Bridge and Ganryujima Island. The city's famous fugu (blowfish) appears as a unique aid station treat.",
   "official_url": "https://kaikyomarathon.jp/",
-  "entry_fee": null,
+  "entry_fee": 12000,
   "entry_fee_by_category": true,
   "entry_capacity": 10000,
   "entry_start_date": "2026-05-15",
@@ -106,14 +106,15 @@
   ],
   "result": null,
   "created_at": "2026-04-30T00:00:00Z",
-  "updated_at": "2026-04-30T00:00:00Z",
+  "updated_at": "2026-05-30T06:36:44.764Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
       "ライト版：基本情報のみ。エイド、気象データ等は未入力",
-      "参加費は2025年実績からの推定。正式発表後に要更新"
+      "参加費は2025年実績からの推定。正式発表後に要更新",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-04-30",
+    "last_verified": "2026-05-30",
     "detail_level": "light"
   },
   "entry_periods": [

--- a/src/data/races/kanazawa-marathon-2026.json
+++ b/src/data/races/kanazawa-marathon-2026.json
@@ -12,9 +12,9 @@
   "description_ja": "加賀百万石の城下町・金沢を走るフルマラソン。兼六園や金沢城など歴史的名所を巡るコース。ご当地グルメのエイドが充実。",
   "description_en": "A full marathon through Kanazawa, the historic castle town. The course passes Kenroku-en Garden, Kanazawa Castle, and more. Known for excellent local food at aid stations.",
   "official_url": "https://www.kanazawa-marathon.jp",
-  "entry_fee": null,
+  "entry_fee": 14000,
   "entry_fee_by_category": true,
-  "entry_capacity": 0,
+  "entry_capacity": 15000,
   "entry_start_date": "2026-04-10",
   "entry_end_date": "2026-05-20",
   "reception_type": "pre_day",
@@ -111,14 +111,15 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-03-15T00:00:00Z",
+  "updated_at": "2026-05-30T06:36:53.964Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
       "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
-      "秋冬大会の日程は例年パターンからの推定を含む。正式発表後に要更新"
+      "秋冬大会の日程は例年パターンからの推定を含む。正式発表後に要更新",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-15",
+    "last_verified": "2026-05-30",
     "detail_level": "medium"
   },
   "entry_periods": [

--- a/src/data/races/kasama-togeinosato-half-2025-2025.json
+++ b/src/data/races/kasama-togeinosato-half-2025-2025.json
@@ -12,9 +12,9 @@
   "description_ja": "",
   "description_en": "",
   "official_url": "https://www.kasa-mara.jp/",
-  "entry_fee": null,
+  "entry_fee": 5000,
   "entry_fee_by_category": true,
-  "entry_capacity": 0,
+  "entry_capacity": 2000,
   "entry_start_date": "2025-08-11",
   "entry_end_date": "2025-10-24",
   "reception_type": "pre_mail",
@@ -66,7 +66,7 @@
   ],
   "result": null,
   "created_at": "2026-05-09T14:16:13.893Z",
-  "updated_at": "2026-05-09T14:16:13.893Z",
+  "updated_at": "2026-05-30T06:37:00.046Z",
   "entry_periods": [
     {
       "start_date": "2025-08-11",
@@ -147,5 +147,11 @@
       "url": "https://www.kasa-mara.jp/course/",
       "label": "コース情報"
     }
-  ]
+  ],
+  "_metadata": {
+    "last_verified": "2026-05-30",
+    "data_accuracy_notes": [
+      "2026-05-30: 自動クロールで更新"
+    ]
+  }
 }

--- a/src/data/races/kasumigaura-marathon-2026.json
+++ b/src/data/races/kasumigaura-marathon-2026.json
@@ -12,9 +12,9 @@
   "description_ja": "霞ヶ浦湖畔を走るフルマラソン。平坦なコースで記録を狙いやすい。",
   "description_en": "A full marathon along the shore of Lake Kasumigaura. A flat course ideal for personal records.",
   "official_url": "https://www.kasumigaura-marathon.jp",
-  "entry_fee": 0,
+  "entry_fee": 12000,
   "entry_fee_by_category": true,
-  "entry_capacity": 0,
+  "entry_capacity": 20000,
   "entry_start_date": "2025-12-01",
   "entry_end_date": "2026-01-25",
   "reception_type": "pre_day",
@@ -101,13 +101,14 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-03-15T00:00:00Z",
+  "updated_at": "2026-05-30T06:37:10.498Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
-      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力"
+      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-15",
+    "last_verified": "2026-05-30",
     "detail_level": "medium"
   },
   "entry_periods": [

--- a/src/data/races/katsuta-marathon-2026.json
+++ b/src/data/races/katsuta-marathon-2026.json
@@ -12,9 +12,9 @@
   "description_ja": "茨城県ひたちなか市で開催される歴史ある市民マラソン。1953年からの長い歴史を持つ伝統大会。",
   "description_en": "A historic citizens' marathon held in Hitachinaka City, Ibaraki. A traditional race with a long history since 1953.",
   "official_url": "https://katsutamarathon.jp",
-  "entry_fee": 0,
+  "entry_fee": 8000,
   "entry_fee_by_category": true,
-  "entry_capacity": 0,
+  "entry_capacity": 12000,
   "entry_start_date": "2025-09-26",
   "entry_end_date": "2025-10-31",
   "reception_type": "none",
@@ -103,13 +103,14 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-03-16T00:00:00Z",
+  "updated_at": "2026-05-30T06:37:19.558Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
-      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力"
+      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-16",
+    "last_verified": "2026-05-30",
     "detail_level": "medium"
   },
   "entry_periods": [

--- a/src/data/races/kitakyushu-marathon-2026.json
+++ b/src/data/races/kitakyushu-marathon-2026.json
@@ -12,9 +12,9 @@
   "description_ja": "福岡県北九州市で開催されるフルマラソン。小倉の市街地と関門海峡を望むコース。",
   "description_en": "A full marathon in Kitakyushu, Fukuoka. Course features Kokura city center and views of the Kanmon Strait.",
   "official_url": "https://kitakyushu-marathon.jp",
-  "entry_fee": 0,
+  "entry_fee": 14500,
   "entry_fee_by_category": true,
-  "entry_capacity": 0,
+  "entry_capacity": 10800,
   "entry_start_date": "2025-08-08",
   "entry_end_date": "2025-09-25",
   "reception_type": "pre_day",
@@ -90,13 +90,14 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-03-15T00:00:00Z",
+  "updated_at": "2026-05-30T06:37:31.465Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
-      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力"
+      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-15",
+    "last_verified": "2026-05-30",
     "detail_level": "medium"
   },
   "entry_periods": [

--- a/src/data/races/kix-senshu-marathon-2026.json
+++ b/src/data/races/kix-senshu-marathon-2026.json
@@ -12,9 +12,9 @@
   "description_ja": "大阪南部の泉州地域を走るフルマラソン。関西国際空港連絡橋付近をコースに含む。",
   "description_en": "A full marathon through the Senshu area of southern Osaka, with parts of the course near the Kansai International Airport bridge.",
   "official_url": "http://www.senshu-marathon.jp",
-  "entry_fee": 0,
+  "entry_fee": 5000,
   "entry_fee_by_category": true,
-  "entry_capacity": 0,
+  "entry_capacity": 700,
   "entry_start_date": "2025-10-10",
   "entry_end_date": "2025-11-30",
   "reception_type": "pre_day",
@@ -82,14 +82,15 @@
   "participation_gifts": [],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-03-15T00:00:00Z",
+  "updated_at": "2026-05-30T06:37:37.791Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
       "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
-      "秋冬大会の日程は例年パターンからの推定を含む。正式発表後に要更新"
+      "秋冬大会の日程は例年パターンからの推定を含む。正式発表後に要更新",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-15",
+    "last_verified": "2026-05-30",
     "detail_level": "medium"
   },
   "entry_periods": [

--- a/src/data/races/kobe-marathon-2026.json
+++ b/src/data/races/kobe-marathon-2026.json
@@ -12,9 +12,9 @@
   "description_ja": "神戸の港町を走る大規模フルマラソン。明石海峡大橋の折り返しが見どころ。「感謝と友情」がテーマ。",
   "description_en": "A large-scale marathon through the port city of Kobe. The turnaround point near Akashi Kaikyo Bridge is a highlight. Theme: Gratitude and Friendship.",
   "official_url": "https://www.kobe-marathon.net",
-  "entry_fee": null,
+  "entry_fee": 18000,
   "entry_fee_by_category": true,
-  "entry_capacity": 0,
+  "entry_capacity": 20000,
   "entry_start_date": "2026-04-17",
   "entry_end_date": "2026-06-01",
   "reception_type": "pre_day",
@@ -109,14 +109,15 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-03-15T00:00:00Z",
+  "updated_at": "2026-05-30T06:37:42.947Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
       "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
-      "秋冬大会の日程は例年パターンからの推定を含む。正式発表後に要更新"
+      "秋冬大会の日程は例年パターンからの推定を含む。正式発表後に要更新",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-15",
+    "last_verified": "2026-05-30",
     "detail_level": "medium"
   },
   "entry_periods": [

--- a/src/data/races/kochi-ryoma-marathon-2026.json
+++ b/src/data/races/kochi-ryoma-marathon-2026.json
@@ -12,9 +12,9 @@
   "description_ja": "坂本龍馬ゆかりの高知で開催されるフルマラソン。太平洋を望む雄大なコースが魅力。制限時間7時間で初心者にも優しい。",
   "description_en": "A full marathon in Kochi, the home of Sakamoto Ryoma. Features a magnificent course overlooking the Pacific Ocean. 7-hour time limit is beginner-friendly.",
   "official_url": "https://ryoma-marathon.jp",
-  "entry_fee": 0,
+  "entry_fee": 13000,
   "entry_fee_by_category": true,
-  "entry_capacity": 0,
+  "entry_capacity": 10000,
   "entry_start_date": "2025-08-01",
   "entry_end_date": "2025-10-31",
   "reception_type": "pre_day",
@@ -96,13 +96,14 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-03-15T00:00:00Z",
+  "updated_at": "2026-05-30T06:37:49.063Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
-      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力"
+      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-15",
+    "last_verified": "2026-05-30",
     "detail_level": "medium"
   },
   "entry_periods": [

--- a/src/data/races/kumamoto-castle-marathon-2026.json
+++ b/src/data/races/kumamoto-castle-marathon-2026.json
@@ -12,9 +12,9 @@
   "description_ja": "熊本城を発着点とするフルマラソン。復興のシンボル・熊本城を目指してゴールする感動のフィニッシュ。",
   "description_en": "A full marathon starting and finishing at Kumamoto Castle, the symbol of the city's recovery.",
   "official_url": "https://kumamotojyo-marathon.jp",
-  "entry_fee": 0,
+  "entry_fee": 13750,
   "entry_fee_by_category": true,
-  "entry_capacity": 0,
+  "entry_capacity": 13000,
   "entry_start_date": "2025-07-29",
   "entry_end_date": "2025-09-24",
   "reception_type": "pre_day",
@@ -95,13 +95,14 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-03-16T00:00:00Z",
+  "updated_at": "2026-05-30T06:37:58.617Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
-      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力"
+      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-16",
+    "last_verified": "2026-05-30",
     "detail_level": "medium"
   },
   "entry_periods": [

--- a/src/data/races/kyoto-marathon-2026.json
+++ b/src/data/races/kyoto-marathon-2026.json
@@ -14,7 +14,7 @@
   "official_url": "https://kyoto-marathon.com",
   "entry_fee": 0,
   "entry_fee_by_category": true,
-  "entry_capacity": 0,
+  "entry_capacity": 16000,
   "entry_start_date": "2025-07-17",
   "entry_end_date": "2025-09-22",
   "reception_type": "pre_day",
@@ -107,13 +107,14 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-03-15T00:00:00Z",
+  "updated_at": "2026-05-30T06:38:04.533Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
-      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力"
+      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-15",
+    "last_verified": "2026-05-30",
     "detail_level": "medium"
   },
   "entry_periods": [

--- a/src/data/races/mie-matsusaka-marathon-2026.json
+++ b/src/data/races/mie-matsusaka-marathon-2026.json
@@ -12,11 +12,11 @@
   "description_ja": "三重県松阪市で開催。松阪牛の産地を走るフルマラソン。ご当地グルメのエイドが期待される。",
   "description_en": "Held in Matsusaka, Mie, home of the famous Matsusaka beef. Expect local gourmet food at aid stations.",
   "official_url": "https://mie-matsusaka-marathon.jp",
-  "entry_fee": 0,
+  "entry_fee": 12900,
   "entry_fee_by_category": true,
-  "entry_capacity": 0,
-  "entry_start_date": null,
-  "entry_end_date": null,
+  "entry_capacity": 10000,
+  "entry_start_date": "2026-05-24",
+  "entry_end_date": "2026-07-31",
   "reception_type": "pre_day",
   "reception_note_ja": "",
   "reception_note_en": "",
@@ -82,14 +82,15 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-03-15T00:00:00Z",
+  "updated_at": "2026-05-30T06:38:15.333Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
       "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
-      "秋冬大会の日程は例年パターンからの推定を含む。正式発表後に要更新"
+      "秋冬大会の日程は例年パターンからの推定を含む。正式発表後に要更新",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-15",
+    "last_verified": "2026-05-30",
     "detail_level": "medium"
   },
   "entry_periods": [],

--- a/src/data/races/mito-komon-manyu-marathon-2026.json
+++ b/src/data/races/mito-komon-manyu-marathon-2026.json
@@ -12,9 +12,9 @@
   "description_ja": "茨城県水戸市で開催。偕楽園や千波湖など水戸の名所を巡るコース。",
   "description_en": "Held in Mito City, Ibaraki. Course visits Kairakuen Garden, Lake Senba, and other Mito landmarks.",
   "official_url": "https://www.mitokomon-manyu-marathon.com",
-  "entry_fee": null,
+  "entry_fee": 10000,
   "entry_fee_by_category": true,
-  "entry_capacity": 0,
+  "entry_capacity": 10000,
   "entry_start_date": "2026-04-16",
   "entry_end_date": "2026-06-30",
   "reception_type": "pre_mail",
@@ -86,14 +86,15 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-03-15T00:00:00Z",
+  "updated_at": "2026-05-30T06:38:20.579Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
       "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
-      "秋冬大会の日程は例年パターンからの推定を含む。正式発表後に要更新"
+      "秋冬大会の日程は例年パターンからの推定を含む。正式発表後に要更新",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-15",
+    "last_verified": "2026-05-30",
     "detail_level": "medium"
   },
   "entry_periods": [

--- a/src/data/races/mtfuji-climb-run-2026.json
+++ b/src/data/races/mtfuji-climb-run-2026.json
@@ -12,9 +12,9 @@
   "description_ja": "コースは人気上昇中の富士吉田登山道\n平安時代から多くの修験者が富士登山に利用した歴史ある登山道。\n江戸時代には多くの茶屋も並び活況を呈したそう。 近年、外国人登山客がこの登山道の魅力を数多く発信しており、日本人の間でも人気が上昇中。\n樹林帯が続くトレイルを進む気持ちよさは格別です。\n\n1時間50分以内の完走で「富士登山競走山頂コース」挑戦資格ゲット！\n※2027年7月大会\n1時間50分以内（ネットタイム）で完走された方は、2027年7月開催の「第80回富士登山競走 山頂コース」への出場資格を獲得することができます。",
   "description_en": "The course follows the increasingly popular Fujiyoshida Trail.\nThis historic trail has been used by many ascetic practitioners to climb Mount Fuji since the Heian period.\nIt is said to have been bustling with numerous teahouses lining the path during the Edo period. In recent years, foreign hikers have been sharing the trail’s appeal, and its popularity is on the rise among Japanese people as well.\nThe feeling of walking along this trail through continuous woodlands is truly exceptional.\n\nFinish in 1 hour and 50 minutes or less to qualify for the “Fuji Mountain Race Summit Course”!\n*July 2027 Event\nParticipants who finish within 1 hour and 50 minutes (net time) will qualify to compete in the “80th Fuji Mountain Race Summit Course” to be held in July 2027.\n\nTranslated with DeepL.com (free version)",
   "official_url": "https://mtfujiclimbrun.com/",
-  "entry_fee": null,
+  "entry_fee": 15000,
   "entry_fee_by_category": true,
-  "entry_capacity": 0,
+  "entry_capacity": 2000,
   "entry_start_date": "2026-04-24",
   "entry_end_date": "2026-07-31",
   "reception_type": "pre_day",
@@ -49,7 +49,7 @@
   "nearby_spots": [],
   "result": null,
   "created_at": "2026-04-28T13:53:53.451Z",
-  "updated_at": "2026-04-28T13:53:53.451Z",
+  "updated_at": "2026-05-30T06:38:26.366Z",
   "entry_periods": [
     {
       "start_date": "2026-04-24",
@@ -102,5 +102,11 @@
       "url": "https://mtfujiclimbrun.com/qa/",
       "label": "FAQ"
     }
-  ]
+  ],
+  "_metadata": {
+    "last_verified": "2026-05-30",
+    "data_accuracy_notes": [
+      "2026-05-30: 自動クロールで更新"
+    ]
+  }
 }

--- a/src/data/races/nagano-marathon-2026.json
+++ b/src/data/races/nagano-marathon-2026.json
@@ -12,11 +12,11 @@
   "description_ja": "1998年長野冬季オリンピックの理念を継承し、1999年に初開催された歴史ある市民マラソン大会。エムウェーブ、ホワイトリング、ビッグハットなどのオリンピック施設を巡りながら、春の信濃路を駆け抜ける42.195km。日本陸連公認・AIMS公認コース。AbbottWMMワンダ・エイジグループワールドランキング予選大会。",
   "description_en": "A historic citizens' marathon inheriting the spirit of the 1998 Nagano Winter Olympics, first held in 1999. The 42.195km course passes through Olympic venues including M-Wave, White Ring, and Big Hat, running through the scenic spring landscape of Shinano. JAAF and AIMS certified course. AbbottWMM Wanda Age Group World Rankings qualifying event.",
   "official_url": "https://www.naganomarathon.gr.jp/",
-  "entry_fee": 0,
+  "entry_fee": 14300,
   "entry_fee_by_category": true,
-  "entry_capacity": 0,
-  "entry_start_date": "2025-10-11",
-  "entry_end_date": "2025-10-31",
+  "entry_capacity": 10000,
+  "entry_start_date": "2025-09-13",
+  "entry_end_date": "2025-11-03",
   "reception_type": "none",
   "reception_note_ja": "前日受付なし。アスリートビブス・参加賞は大会2週間〜10日前に事前郵送",
   "reception_note_en": "No on-site registration. Athlete bibs and participation gifts are mailed 10-14 days before the event.",
@@ -285,7 +285,7 @@
   ],
   "result": null,
   "created_at": "2026-03-10T00:00:00Z",
-  "updated_at": "2026-03-10T00:00:00Z",
+  "updated_at": "2026-05-30T06:38:34.647Z",
   "_metadata": {
     "data_source": "公式サイト (naganomarathon.gr.jp) および公開情報から手動転記",
     "data_accuracy_notes": [
@@ -293,9 +293,10 @@
       "エイドステーションの提供内容は過去大会の一般的な内容を参考に記載。正確な内容は大会ごとに異なる",
       "気象データは長野市の4月中旬の実測値ではなく、概算値。正式には気象庁データで要検証",
       "関門時刻は過去大会の情報を参考に記載。第28回の正式な関門時刻は大会要項で要確認",
-      "エントリー開始日・終了日は第28回の実績を反映"
+      "エントリー開始日・終了日は第28回の実績を反映",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-10",
+    "last_verified": "2026-05-30",
     "detail_level": "full"
   },
   "entry_periods": [

--- a/src/data/races/nagoya-womens-marathon-2026.json
+++ b/src/data/races/nagoya-womens-marathon-2026.json
@@ -12,10 +12,10 @@
   "description_ja": "世界最大の女性限定マラソン。完走者全員にティファニーのオリジナルペンダントが贈られる。MGCシリーズ女子G1大会。",
   "description_en": "The world's largest women-only marathon. All finishers receive an original Tiffany pendant. MGC Series Women's G1 event.",
   "official_url": "https://womens-marathon.nagoya",
-  "entry_fee": null,
+  "entry_fee": 18000,
   "entry_fee_by_category": false,
-  "entry_capacity": 20000,
-  "entry_start_date": null,
+  "entry_capacity": 22000,
+  "entry_start_date": "2025-07-02",
   "entry_end_date": null,
   "reception_type": "pre_day",
   "reception_note_ja": "",
@@ -96,13 +96,14 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-03-15T00:00:00Z",
+  "updated_at": "2026-05-30T06:39:00.304Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
-      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力"
+      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-15",
+    "last_verified": "2026-05-30",
     "detail_level": "medium"
   },
   "entry_periods": [],

--- a/src/data/races/naha-marathon-2026.json
+++ b/src/data/races/naha-marathon-2026.json
@@ -12,9 +12,9 @@
   "description_ja": "沖縄・那覇で開催される日本最南端の大規模フルマラソン。南国の温暖な気候で走れる12月の人気大会。制限時間6時間15分。",
   "description_en": "Japan's southernmost large-scale full marathon in Naha, Okinawa. A popular December race in the subtropical climate. 6 hour 15 min time limit.",
   "official_url": "https://www.naha-marathon.jp",
-  "entry_fee": null,
+  "entry_fee": 11000,
   "entry_fee_by_category": true,
-  "entry_capacity": null,
+  "entry_capacity": 30000,
   "entry_start_date": null,
   "entry_end_date": null,
   "reception_type": "pre_day",
@@ -98,14 +98,15 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-03-15T00:00:00Z",
+  "updated_at": "2026-05-30T06:39:09.521Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
       "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
-      "秋冬大会の日程は例年パターンからの推定を含む。正式発表後に要更新"
+      "秋冬大会の日程は例年パターンからの推定を含む。正式発表後に要更新",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-15",
+    "last_verified": "2026-05-30",
     "detail_level": "medium"
   },
   "entry_periods": [],

--- a/src/data/races/nara-marathon-2026.json
+++ b/src/data/races/nara-marathon-2026.json
@@ -12,11 +12,11 @@
   "description_ja": "世界遺産の古都・奈良を走るフルマラソン。東大寺、春日大社などの名所を巡る。アップダウンが多いが、運営の評価が非常に高い人気大会。",
   "description_en": "A full marathon through the ancient World Heritage city of Nara. Pass Todai-ji, Kasuga Shrine, and more. Hilly course but highly rated operations.",
   "official_url": "https://www.nara-marathon.jp",
-  "entry_fee": null,
+  "entry_fee": 15000,
   "entry_fee_by_category": false,
-  "entry_capacity": null,
-  "entry_start_date": null,
-  "entry_end_date": null,
+  "entry_capacity": 11750,
+  "entry_start_date": "2026-06-05",
+  "entry_end_date": "2026-07-09",
   "reception_type": null,
   "reception_note_ja": "",
   "reception_note_en": "",
@@ -96,14 +96,15 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-03-15T00:00:00Z",
+  "updated_at": "2026-05-30T06:39:22.310Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
       "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
-      "秋冬大会の日程は例年パターンからの推定を含む。正式発表後に要更新"
+      "秋冬大会の日程は例年パターンからの推定を含む。正式発表後に要更新",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-15",
+    "last_verified": "2026-05-30",
     "detail_level": "medium"
   },
   "entry_periods": [],

--- a/src/data/races/okayama-marathon-2026.json
+++ b/src/data/races/okayama-marathon-2026.json
@@ -12,9 +12,9 @@
   "description_ja": "岡山城や後楽園を巡る岡山のフルマラソン。",
   "description_en": "A full marathon in Okayama passing Okayama Castle and Korakuen Garden.",
   "official_url": "https://www.okayamamarathon.jp",
-  "entry_fee": 0,
+  "entry_fee": 14000,
   "entry_fee_by_category": true,
-  "entry_capacity": 0,
+  "entry_capacity": 15000,
   "entry_start_date": "2026-04-16",
   "entry_end_date": "2026-05-18",
   "reception_type": "pre_day",
@@ -82,14 +82,15 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-03-15T00:00:00Z",
+  "updated_at": "2026-05-30T06:39:43.610Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
       "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
-      "秋冬大会の日程は例年パターンからの推定を含む。正式発表後に要更新"
+      "秋冬大会の日程は例年パターンからの推定を含む。正式発表後に要更新",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-15",
+    "last_verified": "2026-05-30",
     "detail_level": "medium"
   },
   "entry_periods": [

--- a/src/data/races/okushinano100-2026.json
+++ b/src/data/races/okushinano100-2026.json
@@ -12,9 +12,9 @@
   "description_ja": "長野県奥信濃の豊かな自然の中を走るトレイルランニングレース。「たくさんの方に奥信濃の幸せなトレイルランニングを楽しんでほしい。トレイルランニングと奥信濃が100年続くように」という願いを込めた大会。100km・50km・25km・8kmの4種目。スタートはSBCホテル前（旧木島平スキー場）。",
   "description_en": "A trail running race through the lush natural landscape of Okushinano in Nagano Prefecture. Four distances: 100km, 50km, 25km, and 8km. Start at the former Kijimadaira Ski Resort (SBC Hotel).",
   "official_url": "https://okushinano100.com/",
-  "entry_fee": null,
+  "entry_fee": 31000,
   "entry_fee_by_category": true,
-  "entry_capacity": 0,
+  "entry_capacity": 700,
   "entry_start_date": "2025-12-14",
   "entry_end_date": "2026-05-10",
   "reception_type": "pre_day",
@@ -100,13 +100,14 @@
   "participation_gifts": [],
   "result": null,
   "created_at": "2026-03-30T00:00:00Z",
-  "updated_at": "2026-03-30T00:00:00Z",
+  "updated_at": "2026-05-30T06:40:08.022Z",
   "_metadata": {
     "data_source": "公式サイト（https://okushinano100.com/）・大会概要ページ",
     "data_accuracy_notes": [
-      "基本情報のみ。エントリー開始日は2025年12月。エイド、周辺スポット等は未入力"
+      "基本情報のみ。エントリー開始日は2025年12月。エイド、周辺スポット等は未入力",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-30",
+    "last_verified": "2026-05-30",
     "detail_level": "basic"
   },
   "entry_periods": [

--- a/src/data/races/osaka-marathon-2026.json
+++ b/src/data/races/osaka-marathon-2026.json
@@ -14,9 +14,9 @@
   "official_url": "https://www.osaka-marathon.com",
   "entry_fee": null,
   "entry_fee_by_category": false,
-  "entry_capacity": 31970,
-  "entry_start_date": null,
-  "entry_end_date": null,
+  "entry_capacity": 34000,
+  "entry_start_date": "2025-07-30",
+  "entry_end_date": "2025-08-29",
   "reception_type": "pre_day",
   "reception_note_ja": "EXPO会場にて前日受付",
   "reception_note_en": "Pre-race registration at EXPO venue",
@@ -109,13 +109,14 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-03-15T00:00:00Z",
+  "updated_at": "2026-05-30T06:40:23.729Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
-      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力"
+      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-15",
+    "last_verified": "2026-05-30",
     "detail_level": "medium"
   },
   "entry_periods": [],

--- a/src/data/races/osj-ontake100-2026.json
+++ b/src/data/races/osj-ontake100-2026.json
@@ -12,9 +12,9 @@
   "description_ja": "御嶽山（標高3,067m）麓の通常立入禁止の国有林を特別開放して行われる夜間スタートのロングレース。100Kと100マイルの2種目。深い森と御嶽山の雄大な景色の中を走る。「フィニッシュの感動は格別」と称されるOSJが誇るロングレースシリーズの一戦。",
   "description_en": "A night-start long race through special-access national forest at the foot of Mt. Ontake (3,067m). Two distances: 100K and 100 Miles. Run through deep forest with majestic views of Mt. Ontake. Part of OSJ's premier long-race series, renowned for an exceptional finish experience.",
   "official_url": "https://www.outdoorsportsjapan.com/trail/ontake100/",
-  "entry_fee": 0,
+  "entry_fee": 19000,
   "entry_fee_by_category": true,
-  "entry_capacity": 0,
+  "entry_capacity": 1400,
   "entry_start_date": "2026-02-01",
   "entry_end_date": "2026-06-14",
   "reception_type": "pre_day",
@@ -64,13 +64,14 @@
   "participation_gifts": [],
   "result": null,
   "created_at": "2026-03-30T00:00:00Z",
-  "updated_at": "2026-03-30T00:00:00Z",
+  "updated_at": "2026-05-30T06:40:45.827Z",
   "_metadata": {
     "data_source": "公式サイト（https://www.outdoorsportsjapan.com/trail/ontake100/）・大会概要ページ",
     "data_accuracy_notes": [
-      "基本情報のみ。距離は約163km・約109kmの推定値。エイド、周辺スポット等は未入力"
+      "基本情報のみ。距離は約163km・約109kmの推定値。エイド、周辺スポット等は未入力",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-30",
+    "last_verified": "2026-05-30",
     "detail_level": "basic"
   },
   "entry_periods": [

--- a/src/data/races/saga-sakura-marathon-2026.json
+++ b/src/data/races/saga-sakura-marathon-2026.json
@@ -12,11 +12,11 @@
   "description_ja": "桜の季節に開催される佐賀のフルマラソン。佐賀平野を駆け抜ける。",
   "description_en": "A full marathon in Saga during cherry blossom season. Run across the Saga Plain.",
   "official_url": "https://sagasakura-marathon.jp",
-  "entry_fee": null,
+  "entry_fee": 14500,
   "entry_fee_by_category": false,
-  "entry_capacity": null,
-  "entry_start_date": null,
-  "entry_end_date": null,
+  "entry_capacity": 8500,
+  "entry_start_date": "2025-10-01",
+  "entry_end_date": "2025-10-21",
   "reception_type": null,
   "reception_note_ja": "",
   "reception_note_en": "",
@@ -81,13 +81,14 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-03-15T00:00:00Z",
+  "updated_at": "2026-05-30T06:40:53.342Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
-      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力"
+      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-15",
+    "last_verified": "2026-05-30",
     "detail_level": "medium"
   },
   "entry_periods": [],

--- a/src/data/races/sapporo-marathon-2026.json
+++ b/src/data/races/sapporo-marathon-2026.json
@@ -12,9 +12,9 @@
   "description_ja": "",
   "description_en": "",
   "official_url": "https://satumara.sapporo-sport.jp/index.html",
-  "entry_fee": null,
+  "entry_fee": 8000,
   "entry_fee_by_category": true,
-  "entry_capacity": 0,
+  "entry_capacity": 8000,
   "entry_start_date": "2026-05-23",
   "entry_end_date": "2026-07-11",
   "reception_type": "pre_mail",
@@ -67,7 +67,7 @@
   "nearby_spots": [],
   "result": null,
   "created_at": "2026-05-15T14:40:14.753Z",
-  "updated_at": "2026-05-15T14:40:14.753Z",
+  "updated_at": "2026-05-30T06:41:49.778Z",
   "entry_periods": [
     {
       "start_date": "2026-05-23",
@@ -130,5 +130,11 @@
       "url": "https://satumara.sapporo-sport.jp/faq.html",
       "label": "FAQ"
     }
-  ]
+  ],
+  "_metadata": {
+    "last_verified": "2026-05-30",
+    "data_accuracy_notes": [
+      "2026-05-30: 自動クロールで更新"
+    ]
+  }
 }

--- a/src/data/races/shiga-kogen100-2026.json
+++ b/src/data/races/shiga-kogen100-2026.json
@@ -14,7 +14,7 @@
   "official_url": "https://www.nature-scene.net/shiga100",
   "entry_fee": null,
   "entry_fee_by_category": true,
-  "entry_capacity": 0,
+  "entry_capacity": 700,
   "entry_start_date": "2026-04-05",
   "entry_end_date": "2026-07-27",
   "reception_type": "pre_day",
@@ -69,7 +69,7 @@
   "nearby_spots": [],
   "result": null,
   "created_at": "2026-04-05T06:01:54.559Z",
-  "updated_at": "2026-04-05T06:01:54.559Z",
+  "updated_at": "2026-05-30T06:41:54.953Z",
   "entry_periods": [
     {
       "start_date": "2026-04-05",
@@ -114,5 +114,11 @@
       "url": "https://www.nature-scene.net/shiga100/entry/",
       "label": "エントリー"
     }
-  ]
+  ],
+  "_metadata": {
+    "last_verified": "2026-05-30",
+    "data_accuracy_notes": [
+      "2026-05-30: 自動クロールで更新"
+    ]
+  }
 }

--- a/src/data/races/shinetsu5mountains-trail-100-2026.json
+++ b/src/data/races/shinetsu5mountains-trail-100-2026.json
@@ -12,9 +12,9 @@
   "description_ja": "トレイルランナー石川弘樹氏がプロデュースした、信越五岳を結ぶ全長160kmにも及ぶ山岳エリアと信越高原の各地域を繋いだ壮大なコース設定。\n家族や友人が選手にサポートを提供できるアシスタントポイントの設置、夜間走行となる選手の安全に配慮したぺーサ1名の同行を許可する区間の設定など、選手はじめ、沢山の人々がトレイルランニングの魅力を味わえるレーススタイル",
   "description_en": "",
   "official_url": "https://sfmt100.com",
-  "entry_fee": null,
+  "entry_fee": 35000,
   "entry_fee_by_category": true,
-  "entry_capacity": 0,
+  "entry_capacity": 1300,
   "entry_start_date": "2026-04-08",
   "entry_end_date": "2026-04-15",
   "reception_type": "pre_day",
@@ -59,7 +59,7 @@
   "nearby_spots": [],
   "result": null,
   "created_at": "2026-04-05T07:49:25.657Z",
-  "updated_at": "2026-04-05T07:49:25.657Z",
+  "updated_at": "2026-05-30T06:42:15.502Z",
   "entry_periods": [
     {
       "start_date": "2026-04-08",
@@ -114,5 +114,11 @@
       "url": "https://sfmt100.com/map/",
       "label": "コース情報"
     }
-  ]
+  ],
+  "_metadata": {
+    "last_verified": "2026-05-30",
+    "data_accuracy_notes": [
+      "2026-05-30: 自動クロールで更新"
+    ]
+  }
 }

--- a/src/data/races/soja-kibiji-marathon-2026.json
+++ b/src/data/races/soja-kibiji-marathon-2026.json
@@ -12,9 +12,9 @@
   "description_ja": "岡山県総社市で開催。吉備路の歴史ある風景の中を走るマラソン。五重塔や古墳群を眺めながら走れる。",
   "description_en": "Held in Soja City, Okayama. Run through the historic Kibiji landscape, passing a five-story pagoda and ancient burial mounds.",
   "official_url": "https://soja-kibijimarathon.jp",
-  "entry_fee": null,
+  "entry_fee": 9100,
   "entry_fee_by_category": true,
-  "entry_capacity": null,
+  "entry_capacity": 15000,
   "entry_start_date": "2025-10-01",
   "entry_end_date": "2026-01-03",
   "reception_type": "pre_mail",
@@ -82,14 +82,15 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-03-15T00:00:00Z",
+  "updated_at": "2026-05-30T06:42:39.583Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
       "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
-      "秋冬大会の日程は例年パターンからの推定を含む。正式発表後に要更新"
+      "秋冬大会の日程は例年パターンからの推定を含む。正式発表後に要更新",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-15",
+    "last_verified": "2026-05-30",
     "detail_level": "medium"
   },
   "entry_periods": [

--- a/src/data/races/tamba-sasayama-abc-marathon-2026.json
+++ b/src/data/races/tamba-sasayama-abc-marathon-2026.json
@@ -12,11 +12,11 @@
   "description_ja": "兵庫県丹波篠山で開催。城下町の風情と田園風景の中を走る。制限時間5時間30分。",
   "description_en": "Held in Tamba-Sasayama, Hyogo. Run through a castle town atmosphere and rural landscapes. 5.5-hour time limit.",
   "official_url": "https://tambasasayama-abc-marathon.jp",
-  "entry_fee": null,
+  "entry_fee": 10000,
   "entry_fee_by_category": false,
-  "entry_capacity": null,
-  "entry_start_date": null,
-  "entry_end_date": null,
+  "entry_capacity": 8000,
+  "entry_start_date": "2025-10-01",
+  "entry_end_date": "2026-01-31",
   "reception_type": null,
   "reception_note_ja": "",
   "reception_note_en": "",
@@ -83,14 +83,15 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-03-15T00:00:00Z",
+  "updated_at": "2026-05-30T06:42:47.716Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
       "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
-      "秋冬大会の日程は例年パターンからの推定を含む。正式発表後に要更新"
+      "秋冬大会の日程は例年パターンからの推定を含む。正式発表後に要更新",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-15",
+    "last_verified": "2026-05-30",
     "detail_level": "medium"
   },
   "entry_periods": [],

--- a/src/data/races/tateyama-wakashio-2026.json
+++ b/src/data/races/tateyama-wakashio-2026.json
@@ -12,11 +12,11 @@
   "description_ja": "千葉県館山市の海沿いを走るフルマラソン。温暖な房総の海を眺めながら走れる冬の人気大会。",
   "description_en": "A full marathon along the coast of Tateyama, Chiba. A popular winter race with views of the warm Boso coast.",
   "official_url": "https://tateyama-wakasio.jp",
-  "entry_fee": null,
+  "entry_fee": 9000,
   "entry_fee_by_category": false,
-  "entry_capacity": null,
-  "entry_start_date": null,
-  "entry_end_date": null,
+  "entry_capacity": 5000,
+  "entry_start_date": "2025-09-14",
+  "entry_end_date": "2025-11-13",
   "reception_type": null,
   "reception_note_ja": "",
   "reception_note_en": "",
@@ -94,13 +94,14 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-03-16T00:00:00Z",
+  "updated_at": "2026-05-30T06:42:59.250Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
-      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力"
+      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-16",
+    "last_verified": "2026-05-30",
     "detail_level": "medium"
   },
   "entry_periods": [],

--- a/src/data/races/tazawako-marathon-2026.json
+++ b/src/data/races/tazawako-marathon-2026.json
@@ -12,9 +12,9 @@
   "description_ja": "笑顔も深さも日本一！！～田沢湖ブルーを駆けぬけろ～\n田沢湖マラソンは、1986年、県内初のフルマラソン大会として始まりました。 全国のフルマラソン大会の中でも開催時期が早いことで愛好者からの人気が高く、近年では国内外から3,000人前後が出場しています。 国内でも屈指の難コースといわれる日本一深い神秘の田沢湖を周回することで、国内外に仙北市の魅力を発信し、交流人口の増加を図りたいと考えています。",
   "description_en": "",
   "official_url": "https://tazawako-marathon.com/",
-  "entry_fee": null,
+  "entry_fee": 10000,
   "entry_fee_by_category": true,
-  "entry_capacity": 0,
+  "entry_capacity": 5550,
   "entry_start_date": "2026-04-01",
   "entry_end_date": "2026-05-27",
   "reception_type": "pre_mail",
@@ -80,7 +80,7 @@
   "nearby_spots": [],
   "result": null,
   "created_at": "2026-03-29T11:30:29.091Z",
-  "updated_at": "2026-03-29T11:30:29.091Z",
+  "updated_at": "2026-05-30T06:43:05.830Z",
   "entry_periods": [
     {
       "start_date": "2026-04-01",
@@ -130,5 +130,11 @@
       "url": "https://tazawako-marathon.com/entry/",
       "label": "エントリー"
     }
-  ]
+  ],
+  "_metadata": {
+    "last_verified": "2026-05-30",
+    "data_accuracy_notes": [
+      "2026-05-30: 自動クロールで更新"
+    ]
+  }
 }

--- a/src/data/races/tokushima-marathon-2026.json
+++ b/src/data/races/tokushima-marathon-2026.json
@@ -12,11 +12,11 @@
   "description_ja": "吉野川沿いを走る徳島のフルマラソン。阿波踊りの街を駆け抜ける。",
   "description_en": "A full marathon along the Yoshino River in Tokushima, the city of Awa Odori dance.",
   "official_url": "https://www.tokushima-marathon.jp",
-  "entry_fee": null,
+  "entry_fee": 11000,
   "entry_fee_by_category": false,
   "entry_capacity": null,
-  "entry_start_date": null,
-  "entry_end_date": null,
+  "entry_start_date": "2025-09-30",
+  "entry_end_date": "2025-12-31",
   "reception_type": null,
   "reception_note_ja": "",
   "reception_note_en": "",
@@ -79,13 +79,14 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-03-15T00:00:00Z",
+  "updated_at": "2026-05-30T06:43:19.054Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
-      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力"
+      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-15",
+    "last_verified": "2026-05-30",
     "detail_level": "medium"
   },
   "entry_periods": [],

--- a/src/data/races/tomisato-suikaroad-2026.json
+++ b/src/data/races/tomisato-suikaroad-2026.json
@@ -12,9 +12,9 @@
   "description_ja": "スイカの一大産地・千葉県富里市で毎年6月に開催される人気大会。エイドステーションでスイカを食べながら走れる名物大会。コース沿いのスイカ畑が広がる田園風景の中、7kmと10kmで競う。マイカップ給水対応。",
   "description_en": "A popular race held every June in Tomisato City, Chiba, the top watermelon-producing area in Japan. Famous for eating watermelon at aid stations while running. Race through scenic watermelon fields in 7km and 10km distances. Supports personal cup hydration.",
   "official_url": "https://tomisato-suikaroad.jp/",
-  "entry_fee": null,
+  "entry_fee": 6500,
   "entry_fee_by_category": true,
-  "entry_capacity": 0,
+  "entry_capacity": 7000,
   "entry_start_date": "2026-02-22",
   "entry_end_date": "2026-04-04",
   "reception_type": "race_day",
@@ -83,13 +83,14 @@
   ],
   "result": null,
   "created_at": "2026-03-30T00:00:00Z",
-  "updated_at": "2026-03-30T00:00:00Z",
+  "updated_at": "2026-05-30T06:43:46.887Z",
   "_metadata": {
     "data_source": "公式サイト（https://tomisato-suikaroad.jp/）・大会要項ページ",
     "data_accuracy_notes": [
-      "基本情報のみ。エイド、周辺スポット等は未入力"
+      "基本情報のみ。エイド、周辺スポット等は未入力",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-30",
+    "last_verified": "2026-05-30",
     "detail_level": "basic"
   },
   "entry_periods": [

--- a/src/data/races/tottori-marathon-2026.json
+++ b/src/data/races/tottori-marathon-2026.json
@@ -12,9 +12,9 @@
   "description_ja": "鳥取砂丘に近いコースを走るフルマラソン。日本海沿いの景色を楽しめる。",
   "description_en": "A full marathon near Tottori Sand Dunes. Enjoy views along the Sea of Japan coast.",
   "official_url": "https://tottori-marathon.jp",
-  "entry_fee": 0,
+  "entry_fee": 13000,
   "entry_fee_by_category": true,
-  "entry_capacity": 0,
+  "entry_capacity": 4000,
   "entry_start_date": "2025-10-15",
   "entry_end_date": "2025-12-12",
   "reception_type": "pre_day",
@@ -83,13 +83,14 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-03-15T00:00:00Z",
+  "updated_at": "2026-05-30T06:43:52.495Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
-      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力"
+      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-15",
+    "last_verified": "2026-05-30",
     "detail_level": "medium"
   },
   "entry_periods": [

--- a/src/data/races/toyako-marathon-2026.json
+++ b/src/data/races/toyako-marathon-2026.json
@@ -12,9 +12,9 @@
   "description_ja": "北海道・洞爺湖畔を一周するフルマラソン。羊蹄山と洞爺湖の絶景を楽しめる。新緑の季節に開催。",
   "description_en": "A full marathon circling Lake Toya in Hokkaido. Enjoy magnificent views of Mt. Yotei and Lake Toya in the fresh green season.",
   "official_url": "https://www.toyako-marathon.jp",
-  "entry_fee": 0,
+  "entry_fee": 11500,
   "entry_fee_by_category": true,
-  "entry_capacity": 0,
+  "entry_capacity": 4500,
   "entry_start_date": "2026-02-01",
   "entry_end_date": "2026-03-08",
   "reception_type": "pre_day",
@@ -94,13 +94,14 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-03-15T00:00:00Z",
+  "updated_at": "2026-05-30T06:44:01.797Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
-      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力"
+      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-15",
+    "last_verified": "2026-05-30",
     "detail_level": "medium"
   },
   "entry_periods": [

--- a/src/data/races/toyama-marathon-2026.json
+++ b/src/data/races/toyama-marathon-2026.json
@@ -12,9 +12,9 @@
   "description_ja": "立山連峰を望みながら走るフルマラソン。新湊大橋を渡るコースが特徴。富山湾の景色が美しい。",
   "description_en": "A full marathon with views of the Tateyama mountain range. Features crossing the Shinminato Bridge with beautiful Toyama Bay scenery.",
   "official_url": "https://www.toyamamarathon.com",
-  "entry_fee": null,
+  "entry_fee": 14000,
   "entry_fee_by_category": true,
-  "entry_capacity": 0,
+  "entry_capacity": 13000,
   "entry_start_date": "2026-04-11",
   "entry_end_date": "2026-06-30",
   "reception_type": "pre_day",
@@ -94,14 +94,15 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-03-16T00:00:00Z",
+  "updated_at": "2026-05-30T06:44:11.814Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
       "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
-      "秋冬大会の日程は例年パターンからの推定を含む。正式発表後に要更新"
+      "秋冬大会の日程は例年パターンからの推定を含む。正式発表後に要更新",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-16",
+    "last_verified": "2026-05-30",
     "detail_level": "medium"
   },
   "entry_periods": [

--- a/src/data/races/tsukuba-marathon-2026.json
+++ b/src/data/races/tsukuba-marathon-2026.json
@@ -78,10 +78,9 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "medal",
         "tshirt"
       ],
-      "description_ja": "大会Tシャツ、完走メダル",
+      "description_ja": "大会Tシャツ",
       "description_en": "Race T-shirt, Finisher medal",
       "image": null
     }

--- a/src/data/races/tsukuba-marathon-2026.json
+++ b/src/data/races/tsukuba-marathon-2026.json
@@ -81,7 +81,7 @@
         "tshirt"
       ],
       "description_ja": "大会Tシャツ",
-      "description_en": "Race T-shirt, Finisher medal",
+      "description_en": "Race T-shirt",
       "image": null
     }
   ],

--- a/src/data/races/yokohama-marathon-2026.json
+++ b/src/data/races/yokohama-marathon-2026.json
@@ -16,7 +16,7 @@
   "entry_fee_by_category": true,
   "entry_capacity": 0,
   "entry_start_date": "2026-04-08",
-  "entry_end_date": "2026-05-08",
+  "entry_end_date": "2026-05-17",
   "reception_type": "pre_day",
   "reception_note_ja": "ローソンWEB",
   "reception_note_en": "",
@@ -95,14 +95,15 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-03-16T00:00:00Z",
+  "updated_at": "2026-05-30T06:44:28.893Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
       "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
-      "秋冬大会の日程は例年パターンからの推定を含む。正式発表後に要更新"
+      "秋冬大会の日程は例年パターンからの推定を含む。正式発表後に要更新",
+      "2026-05-30: 自動クロールで更新"
     ],
-    "last_verified": "2026-03-16",
+    "last_verified": "2026-05-30",
     "detail_level": "medium"
   },
   "entry_periods": [

--- a/src/data/races/yokohama-marathon-2026.json
+++ b/src/data/races/yokohama-marathon-2026.json
@@ -111,7 +111,7 @@
       "label_ja": "一般エントリー",
       "label_en": "General Entry",
       "start_date": "2026-04-08",
-      "end_date": "2026-05-08",
+      "end_date": "2026-05-17",
       "entry_fee": null
     }
   ],

--- a/tools/admin-server.js
+++ b/tools/admin-server.js
@@ -199,11 +199,10 @@ async function fetchOfficialContent(officialUrl, infoUrls = []) {
       'User-Agent': 'Mozilla/5.0 (compatible; HASHIRUBot/1.0)',
       'Accept-Language': 'ja,en;q=0.9',
     },
-    signal: AbortSignal.timeout(15000),
   };
 
   // メインページ取得
-  const mainRes = await fetch(officialUrl, FETCH_OPTS);
+  const mainRes = await fetch(officialUrl, { ...FETCH_OPTS, signal: AbortSignal.timeout(15000) });
   if (!mainRes.ok) throw new Error(`HTTPエラー: ${mainRes.status} ${officialUrl}`);
   const mainHtml = await mainRes.text();
 
@@ -215,7 +214,7 @@ async function fetchOfficialContent(officialUrl, infoUrls = []) {
 
   for (const url of subUrls) {
     try {
-      const res = await fetch(url, FETCH_OPTS);
+      const res = await fetch(url, { ...FETCH_OPTS, signal: AbortSignal.timeout(15000) });
       if (res.ok) {
         const html = await res.text();
         pages.push({ url, text: cleanHtml(html) });

--- a/tools/crawl/checksums.json
+++ b/tools/crawl/checksums.json
@@ -1,0 +1,1747 @@
+{
+  "https://www.abashiri-marathon.jp/outline/": {
+    "hash": "91fff2f513a6e920e41faf6bbdc1ea92c4f4af653b9c9493d4e761aab15d8406",
+    "last_checked": "2026-05-31T13:51:06.215Z",
+    "race_id": "abashiri-marathon-2026"
+  },
+  "https://www.abashiri-marathon.jp/entry/": {
+    "hash": "518f61990bfb00fe5fc1484e38f4110cbf1d5ff8f592485b672561a3afb91626",
+    "last_checked": "2026-05-31T13:51:06.306Z",
+    "race_id": "abashiri-marathon-2026"
+  },
+  "https://www.abashiri-marathon.jp/course/": {
+    "hash": "524bf485c0c884ea094a068dfbd0f17da14038d6ced4f63fbdb4b8138a70692f",
+    "last_checked": "2026-05-31T13:51:06.387Z",
+    "race_id": "abashiri-marathon-2026"
+  },
+  "https://www.abashiri-marathon.jp/contact/": {
+    "hash": "4d85fecfd42c89832ba9116770d13e6f2c613ae42a7c6a0365b195e6aa50420c",
+    "last_checked": "2026-05-31T13:51:06.470Z",
+    "race_id": "abashiri-marathon-2026"
+  },
+  "https://www.abashiri-marathon.jp/feed/": {
+    "hash": "2822fd2d2f1a766f8979255a99128a77a9fac13689b663ceac100ad408ccd2a0",
+    "last_checked": "2026-05-25T01:16:23.473Z",
+    "race_id": "abashiri-marathon-2026"
+  },
+  "https://aomori-sakuramarathon.com/category/infomation/": {
+    "hash": "f9839eabbaa68dd93eab5eb9ae6cec4afb22f4c5afce112d56f09f61f9fe4860",
+    "last_checked": "2026-05-31T13:51:07.147Z",
+    "race_id": "aomori-sakura-marathon-2026"
+  },
+  "https://aomori-sakuramarathon.com/guide/": {
+    "hash": "f61b5c0c637d2e498751a06f6977ab6139c882c7d4208756aa7951f6076aca9d",
+    "last_checked": "2026-05-31T13:51:07.563Z",
+    "race_id": "aomori-sakura-marathon-2026"
+  },
+  "https://aomori-sakuramarathon.com/entry/": {
+    "hash": "762dc4f312dcd115652fbd22397e25786413266480210b93723ed9cd3b76d403",
+    "last_checked": "2026-05-31T13:51:07.901Z",
+    "race_id": "aomori-sakura-marathon-2026"
+  },
+  "https://aomori-sakuramarathon.com/course/": {
+    "hash": "9de8204c22fcf7a43a428c338e4a91d07f800b298028e8233a6c6f60ec9a9561",
+    "last_checked": "2026-05-31T13:51:08.292Z",
+    "race_id": "aomori-sakura-marathon-2026"
+  },
+  "https://aomori-sakuramarathon.com/qa/": {
+    "hash": "00fe9d265e8a95df85ae6e4e93b05ec592d59395694f730683f5cd5ef03590bc",
+    "last_checked": "2026-05-31T13:51:08.665Z",
+    "race_id": "aomori-sakura-marathon-2026"
+  },
+  "https://www.asahikawa-half-marathon.jp/outline/": {
+    "hash": "47bf70698f75e9773f0d62dd66104d2a62d6c0a46dbbd5e5432a31e5cb2f067c",
+    "last_checked": "2026-05-31T13:51:09.376Z",
+    "race_id": "asahikawa-half-marathon-2026"
+  },
+  "https://www.asahikawa-half-marathon.jp/course/": {
+    "hash": "ac5b1580e8a0f3746e06825503c72d4483e3644da174851c7744325029488c0c",
+    "last_checked": "2026-05-31T13:51:09.517Z",
+    "race_id": "asahikawa-half-marathon-2026"
+  },
+  "https://www.asahikawa-half-marathon.jp/entry/": {
+    "hash": "0bb52c00d86a87e10a0156c3afa929892e2ce9f518b4bc6a1a0bf04e1ad4dae0",
+    "last_checked": "2026-05-31T13:51:09.657Z",
+    "race_id": "asahikawa-half-marathon-2026"
+  },
+  "https://www.betsudai.com/outline/": {
+    "hash": "ba5d06d6001a87b52a3f6b3acb26014122145b0be3df21e6b3df2a812b746b3e",
+    "last_checked": "2026-05-31T13:51:09.833Z",
+    "race_id": "beppu-oita-marathon-2026"
+  },
+  "https://www.betsudai.com/outline/flow/": {
+    "hash": "1afe6f26ac5ba16f3fa4511026e2f719b7b728678809ec3aaeaac655755f2fac",
+    "last_checked": "2026-05-31T13:51:09.903Z",
+    "race_id": "beppu-oita-marathon-2026"
+  },
+  "https://www.betsudai.com/outline/course/": {
+    "hash": "12eb3ac0b00f41b4f4ded05771e9ea319459feb86f44c0c506bac38e2f6eed6d",
+    "last_checked": "2026-05-31T13:51:10.017Z",
+    "race_id": "beppu-oita-marathon-2026"
+  },
+  "https://www.betsudai.com/question/": {
+    "hash": "83398aaeaa0331deab4c6d4db6335e4176b73779ec67c8735939e27dd6778cc1",
+    "last_checked": "2026-05-31T13:51:10.083Z",
+    "race_id": "beppu-oita-marathon-2026"
+  },
+  "https://biwako-marathon.com/outline-marathon/": {
+    "hash": "80eaeb12202c49ab21ab909492fc9f8864a95b90cb0955afb6f3958849387450",
+    "last_checked": "2026-05-31T13:51:10.336Z",
+    "race_id": "biwako-marathon-2026"
+  },
+  "https://biwako-marathon.com/entry/": {
+    "hash": "ff417bbf223f6c982d5d9c967e2a5c41608ebc066d68e096cc1a2c8dca39c615",
+    "last_checked": "2026-05-31T13:51:10.394Z",
+    "race_id": "biwako-marathon-2026"
+  },
+  "https://biwako-marathon.com/course/": {
+    "hash": "3bdce9f981b374e91105a05aa8b990f89b158c9214c20031803284d12d1f7046",
+    "last_checked": "2026-05-31T13:51:10.454Z",
+    "race_id": "biwako-marathon-2026"
+  },
+  "https://biwako-marathon.com/traffic_regulation/": {
+    "hash": "fd5bd185b8321031b8596a703c333ecca913a5288113c8b292a951d7a8831d7e",
+    "last_checked": "2026-05-31T13:51:10.516Z",
+    "race_id": "biwako-marathon-2026"
+  },
+  "https://biwako-marathon.com/feed/": {
+    "hash": "24ed0c8b1dcb0c81925e2feb04b25f0e4c51df6f310a769ed3e53677e1e9cdff",
+    "last_checked": "2026-05-25T01:16:27.441Z",
+    "race_id": "biwako-marathon-2026"
+  },
+  "https://www.r-wellness.com/fuji5/participant-info/": {
+    "hash": "266eb373d5f7dee2aa4866a58e0b49cab963a90fd068d98f05097b59f1d8c13a",
+    "last_checked": "2026-05-31T13:51:10.910Z",
+    "race_id": "challenge-fuji5lakes-2026"
+  },
+  "https://www.r-wellness.com/fuji5/course/": {
+    "hash": "fdbb2054b500145a2e7f1894e6298d5bd901dd4095ea0a2d2f4349b94818465e",
+    "last_checked": "2026-05-31T13:51:11.230Z",
+    "race_id": "challenge-fuji5lakes-2026"
+  },
+  "https://www.r-wellness.com/fuji5/access/": {
+    "hash": "bdb641d9f83202ae9a56b3534d94684c59238edee36f647a7ad843941a5e122f",
+    "last_checked": "2026-05-31T13:51:11.559Z",
+    "race_id": "challenge-fuji5lakes-2026"
+  },
+  "https://www.r-wellness.com/fuji5/entry/": {
+    "hash": "d026e418928b077798ff62a960290b19fbd9d7af5960c9fa3968b4d6e24524e4",
+    "last_checked": "2026-05-31T13:51:11.860Z",
+    "race_id": "challenge-fuji5lakes-2026"
+  },
+  "https://www.r-wellness.com/fuji5/faq/": {
+    "hash": "3c2f0764c3a9a0e03adde57da20e67aafa5445a5fc15097d671e9ea5da6ecbaa",
+    "last_checked": "2026-05-31T13:51:12.207Z",
+    "race_id": "challenge-fuji5lakes-2026"
+  },
+  "https://chiba-aqualine-marathon.com/tournament/": {
+    "hash": "572569cfd895df9788bbb43e1e306f327fc2df96c9ba4f748c5a7b8ee9669754",
+    "last_checked": "2026-05-31T13:51:12.277Z",
+    "race_id": "chiba-aqualine-marathon-2026"
+  },
+  "https://ehimemarathon.jp/outline/": {
+    "hash": "61a9c9c22412ad6fac59f7ad2a48539ea60314286d4e0eda194295b3bb47aef4",
+    "last_checked": "2026-05-31T13:51:13.234Z",
+    "race_id": "ehime-marathon-2026"
+  },
+  "https://ehimemarathon.jp/entry/": {
+    "hash": "92fd6f607a34d0ac4b5b6cbf22f335a3ce8ff51a2c16cbcf5f30be379eb0a6e6",
+    "last_checked": "2026-05-31T13:51:13.250Z",
+    "race_id": "ehime-marathon-2026"
+  },
+  "https://ehimemarathon.jp/about-volunteer/": {
+    "hash": "1f7fe4d6d4fa980262f6dce63bebed1ba52e5ea585fb627c5c5e0a661ea58bc2",
+    "last_checked": "2026-05-31T13:51:13.940Z",
+    "race_id": "ehime-marathon-2026"
+  },
+  "https://ehimemarathon.jp/course/": {
+    "hash": "35764bbc6ca78a2dbfc2138d7ddfc0cfb262197d78cb854257c221a4c1166b6e",
+    "last_checked": "2026-05-31T13:51:13.956Z",
+    "race_id": "ehime-marathon-2026"
+  },
+  "https://ehimemarathon.jp/access/": {
+    "hash": "0094e763c91fdb971775b6240a9333df0340e660100b8fd2cdb2f343b7d44b83",
+    "last_checked": "2026-05-31T13:51:14.632Z",
+    "race_id": "ehime-marathon-2026"
+  },
+  "https://fujimountainrace.city.fujiyoshida.yamanashi.jp/outline/": {
+    "hash": "11b53a19485dc6b3a6f369aa82950c125dbfcb78c3161a84e1b1295af5bc65eb",
+    "last_checked": "2026-05-31T13:51:14.795Z",
+    "race_id": "fuji-mountain-race-2026"
+  },
+  "https://fujimountainrace.city.fujiyoshida.yamanashi.jp/entry/": {
+    "hash": "663102edbfa4b982ffff2cd10e17a1c96373b8ffadb9b98378a7639d0b81e348",
+    "last_checked": "2026-05-31T13:51:14.845Z",
+    "race_id": "fuji-mountain-race-2026"
+  },
+  "https://fujimountainrace.city.fujiyoshida.yamanashi.jp/course/": {
+    "hash": "6eee351362ff3e9e79355b794fb2828af2f525ca2ca74d2c0210f01385292d69",
+    "last_checked": "2026-05-31T13:51:14.897Z",
+    "race_id": "fuji-mountain-race-2026"
+  },
+  "https://fujimountainrace.city.fujiyoshida.yamanashi.jp/access/": {
+    "hash": "f1ad26062f183f3c2d0b62cd7b3071e545a1d776415f86cd73db8b9b40bd86e4",
+    "last_checked": "2026-05-31T13:51:14.944Z",
+    "race_id": "fuji-mountain-race-2026"
+  },
+  "https://fujimountainrace.city.fujiyoshida.yamanashi.jp/2026/wp-content/uploads/2026/04/info-sponsors.pdf": {
+    "hash": "9c68961564530716e0c619e88a9e9026cf86635e36c3c79f4969a5672f39d048",
+    "last_checked": "2026-05-31T13:51:15.140Z",
+    "race_id": "fuji-mountain-race-2026"
+  },
+  "https://mtfujimarathon.com/info/": {
+    "hash": "c94562cf3b6201db95c50966a1b01417b6e4cb3594cd14e94638bbbd6b061e77",
+    "last_checked": "2026-05-31T13:51:15.368Z",
+    "race_id": "fujisan-marathon-2026"
+  },
+  "https://mtfujimarathon.com/entry-front/": {
+    "hash": "830d57a09e22148d55be3a735f229839c8330d0ef26c4db049395ccf59506311",
+    "last_checked": "2026-05-31T13:51:15.438Z",
+    "race_id": "fujisan-marathon-2026"
+  },
+  "https://mtfujimarathon.com/outline/": {
+    "hash": "9798446b2dfd1740a550b16aa37fa0e52d8e7cf86d22b86d6f86a56c5ffd0825",
+    "last_checked": "2026-05-31T13:51:15.504Z",
+    "race_id": "fujisan-marathon-2026"
+  },
+  "https://mtfujimarathon.com/course/": {
+    "hash": "24e42984514c3e8a3482555b5746b2e315590c3b93a0fd54d6b2885888a7d88c",
+    "last_checked": "2026-05-31T13:51:15.568Z",
+    "race_id": "fujisan-marathon-2026"
+  },
+  "https://mtfujimarathon.com/access/": {
+    "hash": "1a0d4147dd56d54a67ef214b84f4b935a28c7b5aa161375facd9d3faf60f9a96",
+    "last_checked": "2026-05-31T13:51:15.630Z",
+    "race_id": "fujisan-marathon-2026"
+  },
+  "https://fukuchiyama-marathon.com/outline/": {
+    "hash": "23a1fe802ea958ce21b76bc59708c49fc9fc563935b51c8be799ef13aeb880d0",
+    "last_checked": "2026-05-31T13:51:15.957Z",
+    "race_id": "fukuchiyama-marathon-2026"
+  },
+  "https://fukuchiyama-marathon.com/course-map/": {
+    "hash": "696f2ae7b4956c16047a1e980bda1d0e2a6cd97455a1a478bfb4b940fa30965d",
+    "last_checked": "2026-05-31T13:51:16.258Z",
+    "race_id": "fukuchiyama-marathon-2026"
+  },
+  "https://fukuchiyama-marathon.com/entry/": {
+    "hash": "1e0654e527c3e2c2225bb831114c2b0f129fb43cd441681a6fbaca17718958f8",
+    "last_checked": "2026-05-31T13:51:16.499Z",
+    "race_id": "fukuchiyama-marathon-2026"
+  },
+  "https://fukuchiyama-marathon.com/access/": {
+    "hash": "4f02496ed49a983fdc59039ce30493f9260d32a8ae594df9f9061254a7907bdb",
+    "last_checked": "2026-05-31T13:51:16.872Z",
+    "race_id": "fukuchiyama-marathon-2026"
+  },
+  "https://www.fukui-sakura-marathon.jp/about/": {
+    "hash": "286a640c4ca7f67a89751b2f1c757c8e9aa1f77e40d2f05aa6be0d75c86d166d",
+    "last_checked": "2026-05-27T14:55:12.153Z",
+    "race_id": "fukui-sakura-marathon-2026"
+  },
+  "https://www.fukui-sakura-marathon.jp/about/course/": {
+    "hash": "7391fd03a8bab5e25e8773c25b0dfd376340a24a25dd86693d34b01e18ab4d43",
+    "last_checked": "2026-05-27T14:55:12.280Z",
+    "race_id": "fukui-sakura-marathon-2026"
+  },
+  "https://www.fukui-sakura-marathon.jp/about/concept/": {
+    "hash": "929bbff1aafca2072c64f7140ee6556d67b210db2c94ec57da44a1e8ec2d4dc2",
+    "last_checked": "2026-05-27T14:55:12.378Z",
+    "race_id": "fukui-sakura-marathon-2026"
+  },
+  "https://www.fukui-sakura-marathon.jp/runner/": {
+    "hash": "b5a31baafc0cc34097e06ee73988bc2bed97023b2809889f30db03e310d3a044",
+    "last_checked": "2026-05-31T13:51:20.847Z",
+    "race_id": "fukui-sakura-marathon-2026"
+  },
+  "https://www.fukui-sakura-marathon.jp/stay/": {
+    "hash": "2a3684337854065102cbddd6f28ce04eda18c67ec10aac97a88bded2d127b907",
+    "last_checked": "2026-05-27T14:55:12.582Z",
+    "race_id": "fukui-sakura-marathon-2026"
+  },
+  "https://www.fukuoka-international-marathon.jp/": {
+    "hash": "e12347327a274d88673287e85b99cc281d3a7a9fa97327c5c7dcae73cbe8be00",
+    "last_checked": "2026-05-31T13:51:22.085Z",
+    "race_id": "fukuoka-international-marathon-2026"
+  },
+  "https://www.f-marathon.jp/about/": {
+    "hash": "3e747a96247c8a5365b12b389ea9e129991d834eafd3d0e4c97619193ffa5eb4",
+    "last_checked": "2026-05-31T13:51:22.244Z",
+    "race_id": "fukuoka-marathon-2026"
+  },
+  "https://www.f-marathon.jp/about/course.php/": {
+    "hash": "dd8fae002d56f403ccbab850a7f76ae0e4110908cf366cde9811f60568f9555f",
+    "last_checked": "2026-05-25T01:16:36.125Z",
+    "race_id": "fukuoka-marathon-2026"
+  },
+  "https://www.f-marathon.jp/about/logo.php/": {
+    "hash": "8f745677779ecb72eafa2daf2d802a4d4f1c5a9149c90c41851cdb6fbcd08c8a",
+    "last_checked": "2026-05-25T01:16:36.165Z",
+    "race_id": "fukuoka-marathon-2026"
+  },
+  "https://www.f-marathon.jp/runner/apply.php/": {
+    "hash": "3c1f6848f46e2963dfb1790c7c2ba3fc8ca89f83e4701a60c70790ba0054c079",
+    "last_checked": "2026-05-25T01:16:36.215Z",
+    "race_id": "fukuoka-marathon-2026"
+  },
+  "https://www.f-marathon.jp/traffic/": {
+    "hash": "12a577c5cb1d39d6280c0882ba428d033405e03aec6c83eabdd71ce5bd06faa2",
+    "last_checked": "2026-05-31T13:51:22.568Z",
+    "race_id": "fukuoka-marathon-2026"
+  },
+  "https://www.g-marathon.com/about-guide/": {
+    "hash": "a404e7fbd25fa389a86adae5744954fc219f923d7533dfdfd196ef79bb22d8c7",
+    "last_checked": "2026-05-31T13:51:23.541Z",
+    "race_id": "gunma-marathon-2026"
+  },
+  "https://www.g-marathon.com/course-full/": {
+    "hash": "4d6a0b3e45226f859614450f34d4b9d33ad4e425b2a0bfe854df26a67de457ff",
+    "last_checked": "2026-05-31T13:51:24.354Z",
+    "race_id": "gunma-marathon-2026"
+  },
+  "https://www.kumagera.ne.jp/a100km/course.html": {
+    "hash": "0400379c8d34d45b491e7e99362434403713d8af8276834a2611a90cd40bbf36",
+    "last_checked": "2026-05-31T13:51:06.563Z",
+    "race_id": "akita-nairiku-ultra-2026"
+  },
+  "https://www.kumagera.ne.jp/a100km/entry.html": {
+    "hash": "ffa03b9ae7dde88a07c6b1cae1a61e529dd0d3d9d63ac3dda0b4b1dfe00b2fe2",
+    "last_checked": "2026-05-31T13:51:06.581Z",
+    "race_id": "akita-nairiku-ultra-2026"
+  },
+  "https://www.kumagera.ne.jp/a100km/essentia-point.html": {
+    "hash": "85867aa1f1ca55f12cd112adabd2af0d5fa5272678c75a46a6d8efbe8ee0a45b",
+    "last_checked": "2026-05-31T13:51:06.601Z",
+    "race_id": "akita-nairiku-ultra-2026"
+  },
+  "https://www.kumagera.ne.jp/a100km/access.html": {
+    "hash": "76fe52037b53f163dcfb97d86fb19e2b7e45986c3a598c8d14d500161b1559dc",
+    "last_checked": "2026-05-31T13:51:06.621Z",
+    "race_id": "akita-nairiku-ultra-2026"
+  },
+  "https://www.kumagera.ne.jp/a100km/question.html": {
+    "hash": "51387e4c0186c96d06ecce0c4f9155d1e8234d09da0b82e31dc989d539ae0b13",
+    "last_checked": "2026-05-31T13:51:06.641Z",
+    "race_id": "akita-nairiku-ultra-2026"
+  },
+  "https://www.betsudai.com/wp-content/themes/betsudai/pdf/74/kou.pdf": {
+    "hash": "f81fd537033822b64e8d4a11cc1e6c3ce2dbb2b44c607fb0330ac2b37bbc04e2",
+    "last_checked": "2026-05-31T13:51:10.189Z",
+    "race_id": "beppu-oita-marathon-2026"
+  },
+  "https://chiba-aqualine-marathon.com/tournament/course.html": {
+    "hash": "818904fa46bac2ecffbdcdf3a4b12c11a40ff15716511b0f72771910a34a599c",
+    "last_checked": "2026-05-31T13:51:12.293Z",
+    "race_id": "chiba-aqualine-marathon-2026"
+  },
+  "https://chiba-aqualine-marathon.com/runner/entry.html": {
+    "hash": "429693e258eab5613fd496a8bc42ba302c740c61b65fcc913a09ef39f6226bf8",
+    "last_checked": "2026-05-31T13:51:12.309Z",
+    "race_id": "chiba-aqualine-marathon-2026"
+  },
+  "https://chiba-aqualine-marathon.com/runner/guidelines.html": {
+    "hash": "297422860c7f3a5b7609bf8af9dc56f958dfb2f84ea27721f9f5696a87d0d0a1",
+    "last_checked": "2026-05-31T13:51:12.326Z",
+    "race_id": "chiba-aqualine-marathon-2026"
+  },
+  "https://www.f-marathon.jp/about/course.php": {
+    "hash": "abdb32d74aadb1ff6d7a7bd914deda4dbfb21fa79900bec0cf91a31eee4df10b",
+    "last_checked": "2026-05-31T13:51:22.318Z",
+    "race_id": "fukuoka-marathon-2026"
+  },
+  "https://www.f-marathon.jp/about/logo.php": {
+    "hash": "92ea171f071945d44dd536a5d0655c1607f010e9ae40cca610b9ffaaddab63f2",
+    "last_checked": "2026-05-31T13:51:22.394Z",
+    "race_id": "fukuoka-marathon-2026"
+  },
+  "https://www.f-marathon.jp/runner/apply.php": {
+    "hash": "31a8dff411aef34c5cb1a2e03d5a9f45dca51e12081dfb2ff4b417c39ed99a86",
+    "last_checked": "2026-05-31T13:51:22.497Z",
+    "race_id": "fukuoka-marathon-2026"
+  },
+  "https://www.g-marathon.com/access/": {
+    "hash": "ce82fdecda2f4a42974c310137af637b3a407d4d4b08817842770792694f4f71",
+    "last_checked": "2026-05-31T13:51:24.996Z",
+    "race_id": "gunma-marathon-2026"
+  },
+  "https://www.g-marathon.com/faq_runner/": {
+    "hash": "0e400128b4c88af4237c2c970761ee28c4dc08ce8f5b639eaaeac60b805bc44f",
+    "last_checked": "2026-05-31T13:51:25.814Z",
+    "race_id": "gunma-marathon-2026"
+  },
+  "https://www.g-marathon.com/info/": {
+    "hash": "ea3eac2eb3ae7dafb4b6957f5545ffc580a618b3287237177322fef41cffeffd",
+    "last_checked": "2026-05-31T13:51:25.827Z",
+    "race_id": "gunma-marathon-2026"
+  },
+  "https://www.sakuranbo-m.jp/overview/": {
+    "hash": "6bff5b397d9836fe8f6aca4ce74d28d672d822f9dbc82198ee15f1b3959fe869",
+    "last_checked": "2026-05-31T13:51:26.716Z",
+    "race_id": "higashine-sakuranbo-marathon-2026"
+  },
+  "https://www.sakuranbo-m.jp/course/": {
+    "hash": "53feebaff16b36b31512acb795d83c6af843ea87a1e8d284b5b5ffbd05332a4c",
+    "last_checked": "2026-05-31T13:51:27.233Z",
+    "race_id": "higashine-sakuranbo-marathon-2026"
+  },
+  "https://www.sakuranbo-m.jp/access/": {
+    "hash": "e92698b69de443d006052e4b80b5021bd69e954ebaef6dcd03ac0837dc9c66dc",
+    "last_checked": "2026-05-31T13:51:27.661Z",
+    "race_id": "higashine-sakuranbo-marathon-2026"
+  },
+  "https://www.sakuranbo-m.jp/archives/2173/": {
+    "hash": "aa765f38237b6086ebd7555c1def65589fb856cd17285d3250afb582bcf9a09f",
+    "last_checked": "2026-05-31T13:51:28.160Z",
+    "race_id": "higashine-sakuranbo-marathon-2026"
+  },
+  "https://www.sakuranbo-m.jp/qa/": {
+    "hash": "8d23bfe85adfaeb122ceeb88c24f6d56dbb083986fc2764ac08d10cd4eabd38c",
+    "last_checked": "2026-05-31T13:51:28.576Z",
+    "race_id": "higashine-sakuranbo-marathon-2026"
+  },
+  "https://www.runningkanagawa.com/faq/": {
+    "hash": "63935af3a0f578e2869fac1cfdd540efb4d99ad3dc63f3f5d101ed45d5e3da06",
+    "last_checked": "2026-05-31T13:51:29.018Z",
+    "race_id": "higashinipon-half-marathon-2026"
+  },
+  "https://www.runningkanagawa.com/legal/": {
+    "hash": "8159d901841289fde530de8f85396d20fedd869d19de748a544daba3b6e45376",
+    "last_checked": "2026-05-31T13:51:29.321Z",
+    "race_id": "higashinipon-half-marathon-2026"
+  },
+  "https://www.himeji-marathon.jp/outline/index.html": {
+    "hash": "f4265f62438cef80de0b6d9fd7d6db52669dcb138161eab099a69e239cd8f3c8",
+    "last_checked": "2026-05-31T13:51:29.442Z",
+    "race_id": "himeji-castle-marathon-2026"
+  },
+  "https://www.himeji-marathon.jp/course/index.html": {
+    "hash": "99b79419961cc1b2ce864e8352c1cf43d0e386517caabdc69e701998ede72777",
+    "last_checked": "2026-05-31T13:51:29.463Z",
+    "race_id": "himeji-castle-marathon-2026"
+  },
+  "https://www.himeji-marathon.jp/access/index.html": {
+    "hash": "20b518940c53f9845c33d60ddbcb5921785c0a4b3c0389d8e0a51224a4dbab91",
+    "last_checked": "2026-05-31T13:51:29.480Z",
+    "race_id": "himeji-castle-marathon-2026"
+  },
+  "https://www.himeji-marathon.jp/application/index.html": {
+    "hash": "325abeb65e34f714433391b5013286ef730bb78e021ddef73ccd3036b3302be0",
+    "last_checked": "2026-05-31T13:51:29.499Z",
+    "race_id": "himeji-castle-marathon-2026"
+  },
+  "https://www.himeji-marathon.jp/participation/index.html": {
+    "hash": "94472310f81f82d3051e646768bf4417949a75f5ed690c3fd54ffdc9a4c35e43",
+    "last_checked": "2026-05-31T13:51:29.517Z",
+    "race_id": "himeji-castle-marathon-2026"
+  },
+  "https://hitachi-marathon.jp/outline/": {
+    "hash": "1774273bb3e5340439db1d09e4a6b7cc611aa8f8cf348872a347adae1d07c953",
+    "last_checked": "2026-05-31T13:51:29.676Z",
+    "race_id": "hitachi-seaside-marathon-2026"
+  },
+  "https://hitachi-marathon.jp/entry/": {
+    "hash": "05abd320046072b14a51de9711b6b07c1f001d28e4457feb131770a5c188bbe1",
+    "last_checked": "2026-05-31T13:51:29.721Z",
+    "race_id": "hitachi-seaside-marathon-2026"
+  },
+  "https://hitachi-marathon.jp/2026/feature/": {
+    "hash": "8ff0161771af9927f36ccfa125cd1ca5d27c54991e52bdea98ef52e303d7a418",
+    "last_checked": "2026-05-31T13:51:29.840Z",
+    "race_id": "hitachi-seaside-marathon-2026"
+  },
+  "https://hitachi-marathon.jp/2025/wp-content/uploads/2025/08/roadclosure2025.pdf": {
+    "hash": "d6ddb860e55b36cf6d22086e51a9c87e2dc0aa7611109770a5866f8fabb00cc6",
+    "last_checked": "2026-05-31T13:51:29.907Z",
+    "race_id": "hitachi-seaside-marathon-2026"
+  },
+  "https://hofu-yomiuri.jp/outline/": {
+    "hash": "3d696182f5129ad601b3c231e8488bc22b33ebc3f300eee22e893dbaac0082b8",
+    "last_checked": "2026-05-31T13:51:29.964Z",
+    "race_id": "hofu-yomiuri-marathon-2026"
+  },
+  "https://hofu-yomiuri.jp/course/": {
+    "hash": "9a56add2a5a74e404469451d23db66c065fd29028af459ac5020815b63cdb433",
+    "last_checked": "2026-05-31T13:51:30.347Z",
+    "race_id": "hofu-yomiuri-marathon-2026"
+  },
+  "https://hokkaido-marathon.com/overview/": {
+    "hash": "4ff966ee685292b2831ca3b3071009c52df4d9c4493caa4baad6a8ffe7aff7c7",
+    "last_checked": "2026-05-31T13:51:30.496Z",
+    "race_id": "hokkaido-marathon-2026"
+  },
+  "https://hokkaido-marathon.com/course/": {
+    "hash": "0b27405d8aeff05f5e9a8e2abf028781b9472d0fcd7f8f9e031b96c5d6d6c090",
+    "last_checked": "2026-05-31T13:51:30.507Z",
+    "race_id": "hokkaido-marathon-2026"
+  },
+  "https://hokkaido-marathon.com/entry/": {
+    "hash": "5a4e9010b50ebd663da2256a337f561abed37cbd016b4229d131bb3a52414e1e",
+    "last_checked": "2026-05-31T13:51:30.518Z",
+    "race_id": "hokkaido-marathon-2026"
+  },
+  "https://hokkaido-marathon.com/faq/": {
+    "hash": "53e768d977eede0a86a4e828933ac8bd2d48ff5eb74329e3d96c4189690a94d7",
+    "last_checked": "2026-05-31T13:51:31.023Z",
+    "race_id": "hokkaido-marathon-2026"
+  },
+  "https://hokkaido-marathon.com/info/12731/": {
+    "hash": "5d24d37cfaf16e21b82a39307b6cda237f1a9272c4ead5cf66cd4166702c7354",
+    "last_checked": "2026-05-31T13:51:31.389Z",
+    "race_id": "hokkaido-marathon-2026"
+  },
+  "https://ibusuki-nanohana.com/overview/": {
+    "hash": "defba7ef1dcddcea85422b34d802e9a9a2732a6ff68c030763da8702e318eebf",
+    "last_checked": "2026-05-31T13:51:32.013Z",
+    "race_id": "ibusuki-nanohana-2026"
+  },
+  "https://ibusuki-nanohana.com/essentials/": {
+    "hash": "b632a78b7efd51dc85cdfeee467a9bf2e7f2eef7189b4daf1a0782f48d3b284e",
+    "last_checked": "2026-05-31T13:51:32.112Z",
+    "race_id": "ibusuki-nanohana-2026"
+  },
+  "https://ibusuki-nanohana.com/question/": {
+    "hash": "e954c4299a0b8aba04e5791e97f974807c62180d3754a188aacad21b16180c35",
+    "last_checked": "2026-05-31T13:51:32.216Z",
+    "race_id": "ibusuki-nanohana-2026"
+  },
+  "https://ibusuki-nanohana.com/course/": {
+    "hash": "cd7318f060acdafb86ec761bc6a9c66e9f9b7448fe10aaade6c73324933d9d2d",
+    "last_checked": "2026-05-31T13:51:32.306Z",
+    "race_id": "ibusuki-nanohana-2026"
+  },
+  "https://ibusuki-nanohana.com/entry/": {
+    "hash": "82dc3f79aeac37e1ea01ca71faa9a7d93725f3729bb45a82f46c048b332e5968",
+    "last_checked": "2026-05-31T13:51:32.406Z",
+    "race_id": "ibusuki-nanohana-2026"
+  },
+  "https://ichinoseki-half.jp/outline/": {
+    "hash": "49e77c91c32552db83c8133a90b677287ad8b89e689eb631462c1aac1a731b1b",
+    "last_checked": "2026-05-31T13:51:32.525Z",
+    "race_id": "ichinoseki-half-marathon-2026"
+  },
+  "https://ichinoseki-half.jp/entry/": {
+    "hash": "ab36f06c5e0842074308760f27038b5fa2d5e0893a1752a8f344a3fd84882891",
+    "last_checked": "2026-05-31T13:51:32.578Z",
+    "race_id": "ichinoseki-half-marathon-2026"
+  },
+  "https://ichinoseki-half.jp/course/": {
+    "hash": "65211a2ce1e80346d8c7e9c1f0bab51a81c20e872d64f92ba2e4f37d2b0efdb8",
+    "last_checked": "2026-05-31T13:51:32.640Z",
+    "race_id": "ichinoseki-half-marathon-2026"
+  },
+  "https://iki-ultra.jp/about/": {
+    "hash": "b2c74817edce1aafa651d2562121a5e6a70cdc9d1a897ac217d4839566f06782",
+    "last_checked": "2026-05-31T13:51:32.811Z",
+    "race_id": "iki-ultra-marathon-2026"
+  },
+  "https://iki-ultra.jp/qa/": {
+    "hash": "2b639f644ee41e39d2ae352745dace53b49fe6887554d9d1eb0b3e320ccd0bf9",
+    "last_checked": "2026-05-31T13:51:32.887Z",
+    "race_id": "iki-ultra-marathon-2026"
+  },
+  "https://iki-ultra.jp/entry/": {
+    "hash": "528ad6b5a6df859619219e0bdbe26b628cfa45bcd1e3944a6fedc2bfece96d50",
+    "last_checked": "2026-05-31T13:51:32.972Z",
+    "race_id": "iki-ultra-marathon-2026"
+  },
+  "https://iki-ultra.jp/course/": {
+    "hash": "bba52a6c44494bbabcb87f774aa243042812eb0271606aff4a6f6b6c48bd695d",
+    "last_checked": "2026-05-31T13:51:33.050Z",
+    "race_id": "iki-ultra-marathon-2026"
+  },
+  "https://iki-ultra.jp/access/": {
+    "hash": "3300e81c396f040ce77ab7c11468354185d2cabdca60655fd610dbe266620838",
+    "last_checked": "2026-05-31T13:51:33.129Z",
+    "race_id": "iki-ultra-marathon-2026"
+  },
+  "https://i-c-m.jp/guideline/": {
+    "hash": "216ae96c96b6540073978c91ba78a343159573c4c97e195ab372e8beafd0bdcd",
+    "last_checked": "2026-05-31T13:51:33.269Z",
+    "race_id": "itabashi-city-marathon-2026"
+  },
+  "https://i-c-m.jp/entry/": {
+    "hash": "9b5219e7e4bca0d0785847567d832f069a7df4211556cf4a4e6b578a4560a559",
+    "last_checked": "2026-05-31T13:51:33.321Z",
+    "race_id": "itabashi-city-marathon-2026"
+  },
+  "https://i-c-m.jp/access/": {
+    "hash": "bb525451e3829df4092f24b46bc09ce8ddd55ef02e22176e7b91a660ea47ee66",
+    "last_checked": "2026-05-31T13:51:33.373Z",
+    "race_id": "itabashi-city-marathon-2026"
+  },
+  "https://i-c-m.jp/faq/": {
+    "hash": "b0c5af3dd2a08b7240ef527fd7dab2590a5a6c6ed9f08282bf66240e2a71d812",
+    "last_checked": "2026-05-31T13:51:33.425Z",
+    "race_id": "itabashi-city-marathon-2026"
+  },
+  "https://iwaki-marathon.jp/outline/": {
+    "hash": "bb98d886599ab97f707c706d5a10c742a48c019a2570516f1e13ecfe08776b5a",
+    "last_checked": "2026-05-31T13:51:34.088Z",
+    "race_id": "iwaki-sunshine-marathon-2026"
+  },
+  "https://iwaki-marathon.jp/course/": {
+    "hash": "d3118111019574b94649b3faf7c00f66edcf2f3daa0b6aa8b086d0d98b6bbcb5",
+    "last_checked": "2026-05-31T13:51:34.597Z",
+    "race_id": "iwaki-sunshine-marathon-2026"
+  },
+  "https://iwaki-marathon.jp/outline/schedule/": {
+    "hash": "4392299ffbdc6239e2bf95ee4993668cecc3df4cd77dc6e911a9a4bf1a1300fb",
+    "last_checked": "2026-05-31T13:51:35.037Z",
+    "race_id": "iwaki-sunshine-marathon-2026"
+  },
+  "https://iwaki-marathon.jp/entry/": {
+    "hash": "17671528b77b1f1c8e9648310837ad60e3864fa318f0d0f1b7ab9a44a7b12643",
+    "last_checked": "2026-05-31T13:51:35.724Z",
+    "race_id": "iwaki-sunshine-marathon-2026"
+  },
+  "https://iwaki-marathon.jp/access/": {
+    "hash": "53d7bbd146f99fd62617ca661af90b6557c4d516e0d4a3d88d879d9a5c3b192f",
+    "last_checked": "2026-05-31T13:51:36.171Z",
+    "race_id": "iwaki-sunshine-marathon-2026"
+  },
+  "https://iwate-morioka-city-marathon.jp/outline/": {
+    "hash": "229bf534c98eb6f95e648273bf3999f8c2219c3e21d09d81e0d5d40574dd594e",
+    "last_checked": "2026-05-31T13:51:36.368Z",
+    "race_id": "iwate-morioka-city-marathon-2026"
+  },
+  "https://iwate-morioka-city-marathon.jp/concept/": {
+    "hash": "2588dbfd7634fd83f29228dcf742b52bddf268498f5ad0f07e0c79cc9dc8d624",
+    "last_checked": "2026-05-31T13:51:36.427Z",
+    "race_id": "iwate-morioka-city-marathon-2026"
+  },
+  "https://iwate-morioka-city-marathon.jp/entry/": {
+    "hash": "0f07583eefeb1a25e034cd25c2bfe9bbff0006600143e707234dbf20bae23deb",
+    "last_checked": "2026-05-31T13:51:36.489Z",
+    "race_id": "iwate-morioka-city-marathon-2026"
+  },
+  "https://iwate-morioka-city-marathon.jp/course/": {
+    "hash": "e0fe1713e0f146992dbbef44aa3e76b4ddf250aa2d6313a6949d2ea1030b9d28",
+    "last_checked": "2026-05-31T13:51:36.546Z",
+    "race_id": "iwate-morioka-city-marathon-2026"
+  },
+  "https://iwate-morioka-city-marathon.jp/faq_reception/": {
+    "hash": "2107423f0385571e83fcc39bfd73848c8e6034e05da1d7ec871d035e5ebc1d62",
+    "last_checked": "2026-05-31T13:51:36.607Z",
+    "race_id": "iwate-morioka-city-marathon-2026"
+  },
+  "https://oshukirameki.jp/outline/": {
+    "hash": "8debce1fe793af8a48186a926514b618a5caa11a179a2516b4b85157492fb8b7",
+    "last_checked": "2026-05-31T13:51:36.901Z",
+    "race_id": "iwate-oshu-kirameki-marathon-2026"
+  },
+  "https://oshukirameki.jp/entry/": {
+    "hash": "a1fce03205b6d3ee10c3479fb64c69a4555667e5ff7b8a15231b8d3224e43b4c",
+    "last_checked": "2026-05-31T13:51:37.151Z",
+    "race_id": "iwate-oshu-kirameki-marathon-2026"
+  },
+  "https://oshukirameki.jp/info/": {
+    "hash": "e242be2cfc9be6db1f6d272e65e7b321c3e1dc7ac84be91038af5e7ac60e7ed9",
+    "last_checked": "2026-05-31T13:51:37.343Z",
+    "race_id": "iwate-oshu-kirameki-marathon-2026"
+  },
+  "https://oshukirameki.jp/course/": {
+    "hash": "5f44be2e5330715d2054b3195db180c2ed595e52988a1af8daa106bafb596542",
+    "last_checked": "2026-05-31T13:51:37.492Z",
+    "race_id": "iwate-oshu-kirameki-marathon-2026"
+  },
+  "https://kagawa-marathon.com/faq/": {
+    "hash": "32d35c836557a971f3624d7782a70b92a159763ff0f5baa34fdab9eb3a32b4c4",
+    "last_checked": "2026-05-31T13:51:37.694Z",
+    "race_id": "kagawa-marathon-2026"
+  },
+  "https://kagawa-marathon.com/information/essentials/": {
+    "hash": "2f9c04002f6cb0320613db5cfa0afbcdb481f8778c6bf797073decc821d1ab9d",
+    "last_checked": "2026-05-31T13:51:37.736Z",
+    "race_id": "kagawa-marathon-2026"
+  },
+  "https://kagawa-marathon.com/information/access/": {
+    "hash": "158f17ad86cc0d588844719cbbb3fdd3940a02106b40319c4d7153ed4dfd618d",
+    "last_checked": "2026-05-31T13:51:37.780Z",
+    "race_id": "kagawa-marathon-2026"
+  },
+  "https://kagawa-marathon.com/information/course/": {
+    "hash": "a1511435390f5bbbf1aed2aa00a252cf5d43a517ed23056825509f6c0bc56813",
+    "last_checked": "2026-05-31T13:51:37.822Z",
+    "race_id": "kagawa-marathon-2026"
+  },
+  "https://kagawa-marathon.com/information/concept/": {
+    "hash": "fb0e511b2676814f53d5df988545636805110e882501e0faa282a37504d342ea",
+    "last_checked": "2026-05-31T13:51:37.860Z",
+    "race_id": "kagawa-marathon-2026"
+  },
+  "https://www.kagoshima-marathon.jp/about/": {
+    "hash": "56f3fd660bc2d83dd14f2a9d051828280f0402bba0960022ceb79c5d3fc244e0",
+    "last_checked": "2026-05-31T13:51:38.254Z",
+    "race_id": "kagoshima-marathon-2026"
+  },
+  "https://www.kagoshima-marathon.jp/about/course/course-guidelines.html": {
+    "hash": "3a4572c2ce99351475d03aaf5719d6f583d599a404e2a97a99394edbe6c4131c",
+    "last_checked": "2026-05-31T13:51:38.298Z",
+    "race_id": "kagoshima-marathon-2026"
+  },
+  "https://www.kagoshima-marathon.jp/entry/": {
+    "hash": "0b6b63ee0e7f3bd3b42720f70f6b2b8720b46ea6ff8ba1079009579da3601333",
+    "last_checked": "2026-05-31T13:51:38.312Z",
+    "race_id": "kagoshima-marathon-2026"
+  },
+  "https://www.kagoshima-marathon.jp/traffic/index-mk.html": {
+    "hash": "edc904b9af6099ad7cd335baa4fed449d43ce73b5bb240aff0a3820240d1387b",
+    "last_checked": "2026-05-31T13:51:38.325Z",
+    "race_id": "kagoshima-marathon-2026"
+  },
+  "https://www.kagoshima-marathon.jp/faq/": {
+    "hash": "b6961a98180e0b6afe34fabc1d65550c9aac95d17f4d00d6ff9116dbfca5d730",
+    "last_checked": "2026-05-31T13:51:38.436Z",
+    "race_id": "kagoshima-marathon-2026"
+  },
+  "https://kaikyomarathon.jp/outline/": {
+    "hash": "e5fd3c2b788a85e0d5da3e437c7531a8a60c5933ba68f822bf90d2dd02525852",
+    "last_checked": "2026-05-31T13:51:39.132Z",
+    "race_id": "kaikyo-marathon-2026"
+  },
+  "https://kaikyomarathon.jp/entry/": {
+    "hash": "e90328d9a97947bfd6af49871cd5c5f7c500939acb022dd35f72e11ad3e36fbc",
+    "last_checked": "2026-05-31T13:51:39.146Z",
+    "race_id": "kaikyo-marathon-2026"
+  },
+  "https://kaikyomarathon.jp/course/": {
+    "hash": "2ded800f3383e5f19a8b0911b3ddf50d29d8ca8d637a001682880a68d237058d",
+    "last_checked": "2026-05-31T13:51:39.157Z",
+    "race_id": "kaikyo-marathon-2026"
+  },
+  "https://kaikyomarathon.jp/access/": {
+    "hash": "46ce85a8af0f0397cf02b8b4bbc33f320b2b5024db430d5d54701bac65858f26",
+    "last_checked": "2026-05-31T13:51:39.169Z",
+    "race_id": "kaikyo-marathon-2026"
+  },
+  "https://kaikyomarathon.jp/qa/": {
+    "hash": "3d2245dcce554aa1752f4ec1ea0736b6b5b63b3b0250c775b212f08458e78fbb",
+    "last_checked": "2026-05-31T13:51:39.181Z",
+    "race_id": "kaikyo-marathon-2026"
+  },
+  "https://www.kanazawa-marathon.jp/outline/index.html?": {
+    "hash": "f5dc074da74a2bd12fff700d9fb2f12352727c5f6aa70da28ffec178dc4d2304",
+    "last_checked": "2026-05-31T13:51:39.391Z",
+    "race_id": "kanazawa-marathon-2026"
+  },
+  "https://www.kanazawa-marathon.jp/course/index.html?": {
+    "hash": "dabb288991ad21d39e878c8227e134db008fc273d2c9065be1991b54788a0103",
+    "last_checked": "2026-05-31T13:51:39.513Z",
+    "race_id": "kanazawa-marathon-2026"
+  },
+  "https://www.kanazawa-marathon.jp/point/index.html?": {
+    "hash": "11bb369cc76a17d1933351cedebb561179acd1f50aeaf5a889d2aca069fc850e",
+    "last_checked": "2026-05-31T13:51:39.531Z",
+    "race_id": "kanazawa-marathon-2026"
+  },
+  "https://www.kanazawa-marathon.jp/entry/index.html?": {
+    "hash": "56037b0c226dfaf4c848b79e6697ace2caf00eec75dea2bb9e95c1b51e74d5a3",
+    "last_checked": "2026-05-31T13:51:39.563Z",
+    "race_id": "kanazawa-marathon-2026"
+  },
+  "https://www.kanazawa-marathon.jp/qanda/index.html?": {
+    "hash": "30aae79b340cd527232a09b090b65fb6367e59626d691999e8726eb1c36bda14",
+    "last_checked": "2026-05-31T13:51:39.628Z",
+    "race_id": "kanazawa-marathon-2026"
+  },
+  "https://www.kasa-mara.jp/outline/": {
+    "hash": "fb1817a2b2fca702440b155028e0682a8a321d1693484c220457712697b3a9cf",
+    "last_checked": "2026-05-31T13:51:41.089Z",
+    "race_id": "kasama-togeinosato-half-2025-2025"
+  },
+  "https://www.kasa-mara.jp/entry/": {
+    "hash": "66897f1ac5277fc3eae15d0581854fbc6390e9507f9c306ff3dddd62f20768a9",
+    "last_checked": "2026-05-31T13:51:41.176Z",
+    "race_id": "kasama-togeinosato-half-2025-2025"
+  },
+  "https://www.kasa-mara.jp/course/": {
+    "hash": "485d60868eb012cd0ada5c378a8276da552b3f9393955894166cd7ab6a995a47",
+    "last_checked": "2026-05-31T13:51:41.293Z",
+    "race_id": "kasama-togeinosato-half-2025-2025"
+  },
+  "https://www.kasumigaura-marathon.jp/outline/": {
+    "hash": "1f479d4161c530310c7d01bbb1acf2c3f147bd55a981523d0d022c167cff6131",
+    "last_checked": "2026-05-31T13:51:41.858Z",
+    "race_id": "kasumigaura-marathon-2026"
+  },
+  "https://www.kasumigaura-marathon.jp/access/": {
+    "hash": "7a73df84d4d25b3c4b078ab10ed11145d094f883f3432cd4017840bc4aed10d8",
+    "last_checked": "2026-05-31T13:51:42.630Z",
+    "race_id": "kasumigaura-marathon-2026"
+  },
+  "https://www.kasumigaura-marathon.jp/course/": {
+    "hash": "7a26d8bc432157870a2937a404adfc7b8863bd21094a6612f563bab8344320c8",
+    "last_checked": "2026-05-31T13:51:43.183Z",
+    "race_id": "kasumigaura-marathon-2026"
+  },
+  "https://www.kasumigaura-marathon.jp/entry/": {
+    "hash": "3bb27b7b801b5bec3469eddaf3b210124709ce0abe15a8afa7a04d3f7357d6a2",
+    "last_checked": "2026-05-31T13:51:43.799Z",
+    "race_id": "kasumigaura-marathon-2026"
+  },
+  "https://www.kasumigaura-marathon.jp/faq/": {
+    "hash": "ed80ca675ad7db58513e7aa64ab4e0479ad120a43615b2296e903f45c71ff0ab",
+    "last_checked": "2026-05-31T13:51:44.743Z",
+    "race_id": "kasumigaura-marathon-2026"
+  },
+  "https://katsutamarathon.jp/info/abbott/": {
+    "hash": "0099aa7f010f9c4a7d3165c4de590e8b81da9b90369bb73aff492635c949dc50",
+    "last_checked": "2026-05-31T13:51:44.803Z",
+    "race_id": "katsuta-marathon-2026"
+  },
+  "https://katsutamarathon.jp/outline/": {
+    "hash": "9af275615d3cfb49b64c74489a082aabb3574d7893fea486e247fe80bc8a3232",
+    "last_checked": "2026-05-31T13:51:45.579Z",
+    "race_id": "katsuta-marathon-2026"
+  },
+  "https://katsutamarathon.jp/entry/": {
+    "hash": "81506c2122b5699287da98f29d042bff8b81d1502a721ebada63e6ce62114128",
+    "last_checked": "2026-05-31T13:51:46.450Z",
+    "race_id": "katsuta-marathon-2026"
+  },
+  "https://katsutamarathon.jp/course/": {
+    "hash": "b6cf1944daaab596a5e80ca87718050b1cd6e003bd7df9dc77f1d2d28dbbc59f",
+    "last_checked": "2026-05-31T13:51:46.931Z",
+    "race_id": "katsuta-marathon-2026"
+  },
+  "https://kitakyushu-marathon.jp/about/": {
+    "hash": "b4e70364017579c4a0f5c6f4ab6ddc41133f247a5c9557f9750f72e01e3f1f17",
+    "last_checked": "2026-05-31T13:51:46.986Z",
+    "race_id": "kitakyushu-marathon-2026"
+  },
+  "https://kitakyushu-marathon.jp/course/": {
+    "hash": "013c36cae722db2701a1214d67ce9be05b36bac710dc9211b55492ce3caaee3b",
+    "last_checked": "2026-05-31T13:51:47.772Z",
+    "race_id": "kitakyushu-marathon-2026"
+  },
+  "https://kitakyushu-marathon.jp/step/": {
+    "hash": "71577bf4364bcb9a613e420eb6f1423c48c08046710b54b5ee7604c9fc1cd148",
+    "last_checked": "2026-05-31T13:51:48.499Z",
+    "race_id": "kitakyushu-marathon-2026"
+  },
+  "https://kitakyushu-marathon.jp/access/": {
+    "hash": "03b74889f2b98ab2a04db648e2b1458e87c754264adad2423a4218ea34039807",
+    "last_checked": "2026-05-31T13:51:48.511Z",
+    "race_id": "kitakyushu-marathon-2026"
+  },
+  "https://kitakyushu-marathon.jp/qa/": {
+    "hash": "9acca89a0c670920f964f68cc39c675c96f270986708f87c9ed99b3d6ef79cf6",
+    "last_checked": "2026-05-31T13:51:49.336Z",
+    "race_id": "kitakyushu-marathon-2026"
+  },
+  "http://www.senshu-marathon.jp/guidance/": {
+    "hash": "5c0ac11e9602730c077fb11fd708e1e7fb499db74540e30990c529e55c98e0d0",
+    "last_checked": "2026-05-31T13:51:49.771Z",
+    "race_id": "kix-senshu-marathon-2026"
+  },
+  "http://www.senshu-marathon.jp/course/": {
+    "hash": "953caa09fdead77e470b1f425b4f0f8deba73defbc34d5067b090fd2375cf53e",
+    "last_checked": "2026-05-31T13:51:50.092Z",
+    "race_id": "kix-senshu-marathon-2026"
+  },
+  "http://www.senshu-marathon.jp/access/": {
+    "hash": "6f49540972eb159c0f03d6bdf1675229540632609030c81d37a24908eec04f12",
+    "last_checked": "2026-05-31T13:51:50.417Z",
+    "race_id": "kix-senshu-marathon-2026"
+  },
+  "http://www.senshu-marathon.jp/entry/": {
+    "hash": "98c45e422ce4f851cf88540ddc8bdc21a9c8d2e093f00a692d83b18d59936d43",
+    "last_checked": "2026-05-31T13:51:50.741Z",
+    "race_id": "kix-senshu-marathon-2026"
+  },
+  "https://www.kobe-marathon.net/2026/faq/": {
+    "hash": "41992b478f4985f47e747155226cc054068593898f4ba38a17a8255698c7b797",
+    "last_checked": "2026-05-31T13:51:50.852Z",
+    "race_id": "kobe-marathon-2026"
+  },
+  "https://www.kobe-marathon.net/2026/race/essentials/": {
+    "hash": "cbe9655629abaa6758c4b0380c6ea26bc4b2b3edaa8b1ea99abd233062ff0493",
+    "last_checked": "2026-05-31T13:51:50.938Z",
+    "race_id": "kobe-marathon-2026"
+  },
+  "https://www.kobe-marathon.net/2026/runner/entry/": {
+    "hash": "cad9d77eae4217cc5b9ae6ae4b91aa1ad93bdf2cd023197635b2d93a04cc734a",
+    "last_checked": "2026-05-31T13:51:50.956Z",
+    "race_id": "kobe-marathon-2026"
+  },
+  "https://www.kobe-marathon.net/2026/runner/course/": {
+    "hash": "6130de09f3f36b9bbe09031aad7548fbfd6f87d40bbb3e71f50b65bdefd7176d",
+    "last_checked": "2026-05-31T13:51:50.970Z",
+    "race_id": "kobe-marathon-2026"
+  },
+  "https://www.kobe-marathon.net/2026/support/expo/expoinfo/": {
+    "hash": "fe5358f1a3279a8d2a1cc1a41de727b2fe526730a77ef78cba4d6c45f074b8ea",
+    "last_checked": "2026-05-31T13:51:50.984Z",
+    "race_id": "kobe-marathon-2026"
+  },
+  "https://ryoma-marathon.jp/outline/": {
+    "hash": "9836f1380ec76512810c1d5a781d047e27f935e730efaa2411ea3db0e8ea1ecb",
+    "last_checked": "2026-05-31T13:51:51.055Z",
+    "race_id": "kochi-ryoma-marathon-2026"
+  },
+  "https://ryoma-marathon.jp/entry/": {
+    "hash": "1636f9991c30603d1763425caf97781e83ef456de606122f7f40fc553979fb0e",
+    "last_checked": "2026-05-31T13:51:51.069Z",
+    "race_id": "kochi-ryoma-marathon-2026"
+  },
+  "https://ryoma-marathon.jp/course/": {
+    "hash": "c9cb2d37a7b1417d68625d9446ddc4d52e5a6a19081fd7151b44a549bbdedec2",
+    "last_checked": "2026-05-31T13:51:51.945Z",
+    "race_id": "kochi-ryoma-marathon-2026"
+  },
+  "https://ryoma-marathon.jp/access/": {
+    "hash": "0842a59d4804bd172bfb7a8e63816cfd4555d8613f79deecccbf0febe58ef833",
+    "last_checked": "2026-05-31T13:51:52.771Z",
+    "race_id": "kochi-ryoma-marathon-2026"
+  },
+  "https://ryoma-marathon.jp/faq/": {
+    "hash": "f4cdec5ea4058a725228f2750d45d016422d9398637ce340b7a67cc50b374da8",
+    "last_checked": "2026-05-31T13:51:52.787Z",
+    "race_id": "kochi-ryoma-marathon-2026"
+  },
+  "https://kumamotojyo-marathon.jp/outline.php": {
+    "hash": "acb7d4a238df284eee725b04c725be725cdf059180781cfa40426094b44cab44",
+    "last_checked": "2026-05-31T13:51:52.918Z",
+    "race_id": "kumamoto-castle-marathon-2026"
+  },
+  "https://kumamotojyo-marathon.jp/course.php": {
+    "hash": "4ef74d49c904af43be3e9fcab5131f8e3a0ab430f0c430640a15b7e49f6ddfd0",
+    "last_checked": "2026-05-31T13:51:52.992Z",
+    "race_id": "kumamoto-castle-marathon-2026"
+  },
+  "https://kumamotojyo-marathon.jp/entry.php": {
+    "hash": "b32650e2835ef9192b6a4816d992a770c30289cd4800a342b45c32c4423e62b5",
+    "last_checked": "2026-05-31T13:51:53.086Z",
+    "race_id": "kumamoto-castle-marathon-2026"
+  },
+  "https://kumamotojyo-marathon.jp/volunteer.php": {
+    "hash": "0c14a2f9ee4ca22d9ff432b0547582fc93317189cf1fd53500f45b3329b5adce",
+    "last_checked": "2026-05-31T13:51:53.158Z",
+    "race_id": "kumamoto-castle-marathon-2026"
+  },
+  "https://kumamotojyo-marathon.jp/traffic.php": {
+    "hash": "053dd1c0feb6c15482bdaddc8dc41938a6724a4f0c9750f3b8efe8122c5c7772",
+    "last_checked": "2026-05-31T13:51:53.228Z",
+    "race_id": "kumamoto-castle-marathon-2026"
+  },
+  "https://kyoto-marathon.com/info/": {
+    "hash": "17e5dacca08c61d2962225bb5ff1170c043f20c83ca7f0540f724f2b1b8c3938",
+    "last_checked": "2026-05-31T13:51:53.494Z",
+    "race_id": "kyoto-marathon-2026"
+  },
+  "https://kyoto-marathon.com/info/course/": {
+    "hash": "bdc76aed482d9f1fc7bcffa36302d4b362ff31d09dcf9e3511f1a6bbc4a3ea5c",
+    "last_checked": "2026-05-31T13:51:53.512Z",
+    "race_id": "kyoto-marathon-2026"
+  },
+  "https://kyoto-marathon.com/info/concept/": {
+    "hash": "bc76a1067c3a5c16c6d6eebc4fa2006f776c44b0fdacd20ade297e2c3132ac14",
+    "last_checked": "2026-05-31T13:51:53.532Z",
+    "race_id": "kyoto-marathon-2026"
+  },
+  "https://kyoto-marathon.com/traffic/": {
+    "hash": "caf662409795744c95cc853024bbe137f7b666aed374e76bae1f5e1467d6c5a0",
+    "last_checked": "2026-05-31T13:51:53.544Z",
+    "race_id": "kyoto-marathon-2026"
+  },
+  "https://kyoto-marathon.com/faq/": {
+    "hash": "e4c70a12acb9b63a8fa9c70fa5294fece4b106b730be3e632dec69f6c7199792",
+    "last_checked": "2026-05-31T13:51:53.562Z",
+    "race_id": "kyoto-marathon-2026"
+  },
+  "https://mie-matsusaka-marathon.jp/essential/": {
+    "hash": "a1db4271a485817dee805af6adfffa335953752f8fd2897d7f99dc18cdcda860",
+    "last_checked": "2026-05-31T13:51:53.996Z",
+    "race_id": "mie-matsusaka-marathon-2026"
+  },
+  "https://mie-matsusaka-marathon.jp/course/": {
+    "hash": "2dfedf56133bcd66cf58b3a3a156d8be1e8c53fbbf6d6dafb2b5f0d217a3d869",
+    "last_checked": "2026-05-31T13:51:54.371Z",
+    "race_id": "mie-matsusaka-marathon-2026"
+  },
+  "https://mie-matsusaka-marathon.jp/charm/": {
+    "hash": "603de64a43fae421068a298ca91e0d852c6fe99af1402cbdd91e8d1c5392c733",
+    "last_checked": "2026-05-31T13:51:54.733Z",
+    "race_id": "mie-matsusaka-marathon-2026"
+  },
+  "https://mie-matsusaka-marathon.jp/venue/": {
+    "hash": "206d53735f5f447c5258e9ae29d386beec2f9b4fbd5b49cca99f67c651982c7c",
+    "last_checked": "2026-05-31T13:51:55.165Z",
+    "race_id": "mie-matsusaka-marathon-2026"
+  },
+  "https://mie-matsusaka-marathon.jp/runner/": {
+    "hash": "77c60b13d41eaf28c312c7d0bb7e630cd047ac1c7a89eaaff78ffc20cb594f3e",
+    "last_checked": "2026-05-31T13:51:55.513Z",
+    "race_id": "mie-matsusaka-marathon-2026"
+  },
+  "https://www.mitokomon-manyu-marathon.com/about/index.html": {
+    "hash": "d60193c591ac914f4572868cb1ab0e16ee1e3b79b68155247941aa360a92dc81",
+    "last_checked": "2026-05-31T13:51:55.654Z",
+    "race_id": "mito-komon-manyu-marathon-2026"
+  },
+  "https://www.mitokomon-manyu-marathon.com/entry/index.html": {
+    "hash": "63f848299bf346c13fd36ba25a34ad186e46fc0505bbd8f9eb92cb1a61cab28c",
+    "last_checked": "2026-05-31T13:51:55.687Z",
+    "race_id": "mito-komon-manyu-marathon-2026"
+  },
+  "https://www.mitokomon-manyu-marathon.com/venue/index.html": {
+    "hash": "b793acc13403ae0235a4a6f016e62e1fd0a80e3453930b9fcbeddec67fc03e70",
+    "last_checked": "2026-05-31T13:51:55.723Z",
+    "race_id": "mito-komon-manyu-marathon-2026"
+  },
+  "https://www.mitokomon-manyu-marathon.com/venue/supply.html": {
+    "hash": "48f47cd1afd670d299c7191e49377ea11e4ba07d9df2fdf33eec5b6308aecad4",
+    "last_checked": "2026-05-31T13:51:55.761Z",
+    "race_id": "mito-komon-manyu-marathon-2026"
+  },
+  "https://www.mitokomon-manyu-marathon.com/qa/index.html": {
+    "hash": "23223633579cc240853e1992107a87d74a79741f28104fbc5a621b515c0f6f5d",
+    "last_checked": "2026-05-31T13:51:55.795Z",
+    "race_id": "mito-komon-manyu-marathon-2026"
+  },
+  "https://mtfujiclimbrun.com/outline/": {
+    "hash": "9c94cce401b77d366a24aab247386bf1cff010d365878f310bb6ac2dfcf97c36",
+    "last_checked": "2026-05-31T13:51:55.931Z",
+    "race_id": "mtfuji-climb-run-2026"
+  },
+  "https://mtfujiclimbrun.com/entry/": {
+    "hash": "ee412df38b1ebd4a291e6b43531599ad3ccc76af72ffc7c0974197ab55e2470a",
+    "last_checked": "2026-05-31T13:51:55.978Z",
+    "race_id": "mtfuji-climb-run-2026"
+  },
+  "https://mtfujiclimbrun.com/course/": {
+    "hash": "a90c469339bb28024bfe42de49b583a7f3961a1440e278de562f9fc97fdd9aa2",
+    "last_checked": "2026-05-31T13:51:56.025Z",
+    "race_id": "mtfuji-climb-run-2026"
+  },
+  "https://mtfujiclimbrun.com/access/": {
+    "hash": "8620b12134b60c1a2a6ecb958580fb5026c1f96814fd0cd923e7ea6856eb3fb7",
+    "last_checked": "2026-05-31T13:51:56.075Z",
+    "race_id": "mtfuji-climb-run-2026"
+  },
+  "https://mtfujiclimbrun.com/qa/": {
+    "hash": "64cfec35516f89c29a8fb9491c6f662ca1d099e51115a8b0633d9f5c5c44f62f",
+    "last_checked": "2026-05-31T13:51:56.127Z",
+    "race_id": "mtfuji-climb-run-2026"
+  },
+  "https://nagai-marathon.jp/news-cat/infomartion/": {
+    "hash": "b99f9c33ceb159536a0ea7973c5be2f46bbf150215e0de6dced39cc42c94d77f",
+    "last_checked": "2026-05-30T06:33:59.195Z",
+    "race_id": "nagai-marathon-2026"
+  },
+  "https://nagai-marathon.jp/news/2026/402/": {
+    "hash": "e0b08746783e05297da628f89f074be5d53e61e224dc803f6796c3d04da5eca6",
+    "last_checked": "2026-05-30T06:34:01.442Z",
+    "race_id": "nagai-marathon-2026"
+  },
+  "https://nagai-marathon.jp/wp/wp-content/themes/source_tcd045-child/pdf/nagaimararhon2026_yoko.pdf": {
+    "hash": "1938ce85ae6df77df6ca317164b19d4e45ca2b44275d3d713d4142c93d5fbe97",
+    "last_checked": "2026-05-31T13:52:28.353Z",
+    "race_id": "nagai-marathon-2026"
+  },
+  "https://www.naganomarathon.gr.jp/information/": {
+    "hash": "011e0f8077b6f9fdbec943ca44e3fe1a364faefe10fd21e2c8b97577012d37d6",
+    "last_checked": "2026-05-31T13:52:28.646Z",
+    "race_id": "nagano-marathon-2026"
+  },
+  "https://www.naganomarathon.gr.jp/information/course/": {
+    "hash": "51eb789edc47152c37e9f72c6097cd696c1e186a64deaaf965192f1fe9098d70",
+    "last_checked": "2026-05-31T13:52:28.835Z",
+    "race_id": "nagano-marathon-2026"
+  },
+  "https://www.naganomarathon.gr.jp/entry/": {
+    "hash": "9f131012d4a2f0b3a87abcb7dedefbf880afe3e1f038c6a31b2a88b14d240088",
+    "last_checked": "2026-05-31T13:52:29.016Z",
+    "race_id": "nagano-marathon-2026"
+  },
+  "https://www.naganomarathon.gr.jp/entrant/requirements/": {
+    "hash": "a2e369f983c0009dd5bd7faa1d1c65db5792cfd0bfb1053c226f622f311497c2",
+    "last_checked": "2026-05-31T13:52:29.204Z",
+    "race_id": "nagano-marathon-2026"
+  },
+  "https://www.naganomarathon.gr.jp/stay/": {
+    "hash": "303e2ad9e99c91054226adb505e792848e54f41589d1c56454eded37fd46e5f1",
+    "last_checked": "2026-05-31T13:52:29.387Z",
+    "race_id": "nagano-marathon-2026"
+  },
+  "https://womens-marathon.nagoya/en/outline/chinese1/": {
+    "hash": "c67c635bc70c94306a040acacde7710db38c2a018e1a5fe9c68f00c2a73d434e",
+    "last_checked": "2026-05-31T13:52:29.529Z",
+    "race_id": "nagoya-womens-marathon-2026"
+  },
+  "https://womens-marathon.nagoya/outline/": {
+    "hash": "bfe07baed6571937be166d72ba76d9456bc083eeb92d650ccf2de9651640c3aa",
+    "last_checked": "2026-05-31T13:52:29.584Z",
+    "race_id": "nagoya-womens-marathon-2026"
+  },
+  "https://womens-marathon.nagoya/faq/": {
+    "hash": "199f8fd39a6f81cf4fdf61d0f1939e8a0f9adbd698646323f011483a26518527",
+    "last_checked": "2026-05-31T13:52:29.609Z",
+    "race_id": "nagoya-womens-marathon-2026"
+  },
+  "https://womens-marathon.nagoya/entry/": {
+    "hash": "7a6ff2045fed1c740a7fb1a00915636b22dc91f4f32fe493bb0df549c129f930",
+    "last_checked": "2026-05-31T13:52:29.637Z",
+    "race_id": "nagoya-womens-marathon-2026"
+  },
+  "https://womens-marathon.nagoya/course/": {
+    "hash": "3fde8087647db5939e3068889260771935c1bb762200154f56fce084f3709774",
+    "last_checked": "2026-05-31T13:52:29.651Z",
+    "race_id": "nagoya-womens-marathon-2026"
+  },
+  "https://naha-marathon.jp/info/": {
+    "hash": "6677bab9cfd1971588456cdad4fc6cdeb99e8495ee9c439c8f395dbf336e4892",
+    "last_checked": "2026-05-31T13:52:29.888Z",
+    "race_id": "naha-marathon-2026"
+  },
+  "https://naha-marathon.jp/entry/": {
+    "hash": "93e383846b1fd11980cac4a89075ca79cf0121bbec4c570cc98d357e6910d48c",
+    "last_checked": "2026-05-31T13:52:29.994Z",
+    "race_id": "naha-marathon-2026"
+  },
+  "https://naha-marathon.jp/course/": {
+    "hash": "6c6218cb3c09f3d0640d77ef37bf627557410df0e937f49fa71658fad3a6b07b",
+    "last_checked": "2026-05-31T13:52:30.099Z",
+    "race_id": "naha-marathon-2026"
+  },
+  "https://naha-marathon.jp/contact/": {
+    "hash": "8ff3ff83d883a8cbd74179fdd0ad3705947e73e1ab4718ecec0fc582dc2c1991",
+    "last_checked": "2026-05-31T13:52:30.220Z",
+    "race_id": "naha-marathon-2026"
+  },
+  "https://www.nara-marathon.jp/guidelines.html": {
+    "hash": "3116b11412e15b5beec6a8a6757a90fe08b338e794af0af3d01eb340cdc2b8dc",
+    "last_checked": "2026-05-31T13:52:30.291Z",
+    "race_id": "nara-marathon-2026"
+  },
+  "https://www.nara-marathon.jp/course.html": {
+    "hash": "42f6a5a227474ec7a868cf073fa46378530425880f66451a41f78ed8a047c640",
+    "last_checked": "2026-05-31T13:52:30.304Z",
+    "race_id": "nara-marathon-2026"
+  },
+  "https://www.nara-marathon.jp/access.html": {
+    "hash": "a69244f7c57824566e3d6024f2b588b9ed668cbd7332c3c9d7a03943b664d506",
+    "last_checked": "2026-05-31T13:52:30.318Z",
+    "race_id": "nara-marathon-2026"
+  },
+  "https://www.nara-marathon.jp/qa.html": {
+    "hash": "3f782debca2a69e1d3b17a5b5601217ab456b6fe945bf0055274e3430e9123e9",
+    "last_checked": "2026-05-31T13:52:30.336Z",
+    "race_id": "nara-marathon-2026"
+  },
+  "https://www.nara-marathon.jp/entry.html": {
+    "hash": "6fa5164882da7a88a1223afac5b29b8d44d75a3bd801c67b53ddf1b0493863f2",
+    "last_checked": "2026-05-31T13:52:30.356Z",
+    "race_id": "nara-marathon-2026"
+  },
+  "https://runfes-niigata.com/requirements/": {
+    "hash": "7402b1518c9dd8f527f93314aaae32a4ba2accbb8ebba6844f01e0784a26f7c4",
+    "last_checked": "2026-05-31T13:52:30.605Z",
+    "race_id": "niigata-city-marathon-2026"
+  },
+  "https://runfes-niigata.com/2026/05/19/%e3%80%8c%e3%83%95%e3%82%a1%e3%83%b3%e3%83%a9%e3%83%b3%e3%80%8d%e3%82%a8%e3%83%b3%e3%83%88%e3%83%aa%e3%83%bc%e7%b7%a0%e3%82%81%e5%88%87%e3%82%8a%e3%81%ae%e3%81%8a%e7%9f%a5%e3%82%89%e3%81%9b/": {
+    "hash": "abdf0c053b8e0c9b2460713bd8adf602636bad9e03e41c027f28c47df8264bfc",
+    "last_checked": "2026-05-31T13:52:30.710Z",
+    "race_id": "niigata-city-marathon-2026"
+  },
+  "https://nishio-marathon.jp": {
+    "hash": "34d37129992991d0866661e4482a76fdf9f1df216ff807dabb36e0bed3153182",
+    "last_checked": "2026-05-31T13:52:31.362Z",
+    "race_id": "nishio-marathon-2026"
+  },
+  "https://www.okayamamarathon.jp/event-information/guideline/": {
+    "hash": "1e59e8fe3fee88d5a83b6269a48d3ab6eb6335b9bafd2cf49497c6d562974958",
+    "last_checked": "2026-05-31T13:52:31.480Z",
+    "race_id": "okayama-marathon-2026"
+  },
+  "https://www.okayamamarathon.jp/event-information/access/": {
+    "hash": "850474ea9e49b6f1484cf002bd25404b492e3ed071a82da3a3f17fe72c57905b",
+    "last_checked": "2026-05-31T13:52:31.509Z",
+    "race_id": "okayama-marathon-2026"
+  },
+  "https://www.okayamamarathon.jp/event-information/course/": {
+    "hash": "6b48f3504e102108fdbeccb47cffd118b22047496409ee8b03d33f4488e9bb65",
+    "last_checked": "2026-05-31T13:52:31.536Z",
+    "race_id": "okayama-marathon-2026"
+  },
+  "https://www.okayamamarathon.jp/runner/entry/": {
+    "hash": "c65ef7e854f9c6f3cdaa1766fdcf0fe163c3bc7ece36f2f446ab303dbf265aa1",
+    "last_checked": "2026-05-31T13:52:31.566Z",
+    "race_id": "okayama-marathon-2026"
+  },
+  "https://www.okayamamarathon.jp/faq/": {
+    "hash": "8535ca8d4660b5fa374e1d12645aef02130c8959ab6771c6732aae96d98f1f49",
+    "last_checked": "2026-05-31T13:52:31.597Z",
+    "race_id": "okayama-marathon-2026"
+  },
+  "https://okushinano100.com/concept/": {
+    "hash": "e0d258d0323d91a33bd17f27b12dea6c9c793b3e0ffcf9fb7e34f013ee072bf4",
+    "last_checked": "2026-05-31T13:52:31.727Z",
+    "race_id": "okushinano100-2026"
+  },
+  "https://okushinano100.com/coursemap/": {
+    "hash": "bf765055dda4034652be0700f76372cea55129dd7741b941046cedfe0ab18e1b",
+    "last_checked": "2026-05-31T13:52:31.837Z",
+    "race_id": "okushinano100-2026"
+  },
+  "https://okushinano100.com/access/": {
+    "hash": "9808349de7f90e60a8a45bf536f18a1c7b167571f0f99d08417e84bc77e9d16c",
+    "last_checked": "2026-05-31T13:52:31.869Z",
+    "race_id": "okushinano100-2026"
+  },
+  "https://okushinano100.com/faq/": {
+    "hash": "481cb1770f91bf5e19bf8eebc41744d24f8908d8ae993606e01049c56694d20b",
+    "last_checked": "2026-05-31T13:52:31.897Z",
+    "race_id": "okushinano100-2026"
+  },
+  "https://okushinano100.com/entry/": {
+    "hash": "a5aa6234acf781ba12136f9a8104f5c9af3f34ee49faf8927e0cf925b78f3243",
+    "last_checked": "2026-05-31T13:52:31.927Z",
+    "race_id": "okushinano100-2026"
+  },
+  "https://www.osaka-marathon.com/2026/info/gist/": {
+    "hash": "33f0001647e867edaf5b93c99654db3c28a1c05ed83c02e9439f5510ef35cee7",
+    "last_checked": "2026-05-31T13:52:32.037Z",
+    "race_id": "osaka-marathon-2026"
+  },
+  "https://www.osaka-marathon.com/2026/info/sponsor/": {
+    "hash": "e771e0f5a2d27646b9cafcdd64a8a1086e12ef14a98b56f25962085e6f298e13",
+    "last_checked": "2026-05-31T13:52:32.056Z",
+    "race_id": "osaka-marathon-2026"
+  },
+  "https://www.osaka-marathon.com/2026/info/course/": {
+    "hash": "a0a91f8f6cb5bc88fc6976abf5cc16e4041b31420c92cfbd4f9002e0742dba19",
+    "last_checked": "2026-05-31T13:52:32.076Z",
+    "race_id": "osaka-marathon-2026"
+  },
+  "https://www.osaka-marathon.com/2026/runner/entry/": {
+    "hash": "97588ad876f3bf2facf4d2329e03d8e04d4039624ae2be792776d2e791a90f88",
+    "last_checked": "2026-05-31T13:52:32.097Z",
+    "race_id": "osaka-marathon-2026"
+  },
+  "https://www.osaka-marathon.com/2026/expo/outline/": {
+    "hash": "4d1bb8d513d5d668ea2b2910f59160635e29239a7e16170023d0875f666e53fd",
+    "last_checked": "2026-05-31T13:52:32.114Z",
+    "race_id": "osaka-marathon-2026"
+  },
+  "https://www.osaka42195.com/category/info/": {
+    "hash": "33d53b2c6c389f34d5e96614367d1f786b2c1011604187c5de0e23d51c226416",
+    "last_checked": "2026-05-31T13:52:32.405Z",
+    "race_id": "osaka-yodo-river-citizens-marathon-2026"
+  },
+  "https://www.osaka42195.com/category/traffic/": {
+    "hash": "a1b2e1f3311e534776fabc7e772611ffe702bda6b85ebac0f5d9a05b63447a8a",
+    "last_checked": "2026-05-31T13:52:32.543Z",
+    "race_id": "osaka-yodo-river-citizens-marathon-2026"
+  },
+  "https://www.osaka42195.com/event/about/": {
+    "hash": "6ca3e33eb85f465f46352804949164ea8af62ade3af8f6313e44310fcc1aa2c0",
+    "last_checked": "2026-05-31T13:52:32.701Z",
+    "race_id": "osaka-yodo-river-citizens-marathon-2026"
+  },
+  "https://www.osaka42195.com/event/couse/": {
+    "hash": "e3cc5de4eb018347d5fc05cd27e5e3ac39054b16bc6cb53bf2fdc9e060bb5b60",
+    "last_checked": "2026-05-31T13:52:32.741Z",
+    "race_id": "osaka-yodo-river-citizens-marathon-2026"
+  },
+  "https://www.osaka42195.com/runner/entry/": {
+    "hash": "e3d4b9b8622410b503c8dbfe98afca6a31100ae716667d234bdfdeb49355bb19",
+    "last_checked": "2026-05-31T13:52:32.784Z",
+    "race_id": "osaka-yodo-river-citizens-marathon-2026"
+  },
+  "https://www.outdoorsportsjapan.com/trail/ontake100/race-ontake100/": {
+    "hash": "07949b6945563e7a82a7ffdeb91b97f9ad119f271f652d43960bc33cf82658ce",
+    "last_checked": "2026-05-31T13:52:33.397Z",
+    "race_id": "osj-ontake100-2026"
+  },
+  "https://www.outdoorsportsjapan.com/trail/ontake100/course-ontake100/": {
+    "hash": "a93a8bc1e9ac8651d2b37f89c3d8e878fd8636c3b498a8ed3bcee8e21941bd84",
+    "last_checked": "2026-05-31T13:52:33.900Z",
+    "race_id": "osj-ontake100-2026"
+  },
+  "https://www.outdoorsportsjapan.com/trail/ontake100/access-ontake100/": {
+    "hash": "1805704262cb7d5afa47f73ee56f280d445a9cda01d0ba32db53d3f1586d155f",
+    "last_checked": "2026-05-31T13:52:34.374Z",
+    "race_id": "osj-ontake100-2026"
+  },
+  "https://www.outdoorsportsjapan.com/trail/ontake100/entry-list-ontake100/": {
+    "hash": "86f03565d5ec514bdb7b9d1de2183162b87c7585e617b0befb4f33655af0f6b8",
+    "last_checked": "2026-05-31T13:52:34.797Z",
+    "race_id": "osj-ontake100-2026"
+  },
+  "https://sagasakura-marathon.jp/outline/": {
+    "hash": "22c7f89f56a7c3a955955e4367aaf421bf4b44dd2aab5fe092f3132917477e30",
+    "last_checked": "2026-05-31T13:52:35.284Z",
+    "race_id": "saga-sakura-marathon-2026"
+  },
+  "https://sagasakura-marathon.jp/entry/": {
+    "hash": "74e11e0d4e069b619b2689bce2c0fec9a196e67ef30924e4d538e532eda46127",
+    "last_checked": "2026-05-31T13:52:35.839Z",
+    "race_id": "saga-sakura-marathon-2026"
+  },
+  "https://sagasakura-marathon.jp/info/medical-runner/": {
+    "hash": "710ff45b0d3885d6ed545760072ea49c6d663d0322b9f888a4d3a36695330000",
+    "last_checked": "2026-05-31T13:52:36.502Z",
+    "race_id": "saga-sakura-marathon-2026"
+  },
+  "https://sagasakura-marathon.jp/course/": {
+    "hash": "98bb5e73d7c0c71ea77ccfa988d93196cd1e7aad6d49219463f1cf7019ae3153",
+    "last_checked": "2026-05-31T13:52:37.272Z",
+    "race_id": "saga-sakura-marathon-2026"
+  },
+  "https://sagasakura-marathon.jp/traffic/": {
+    "hash": "87204d59063e2836bec6b3a67400f57efbb92d535cd611afd2fc8bafbb524618",
+    "last_checked": "2026-05-31T13:52:38.054Z",
+    "race_id": "saga-sakura-marathon-2026"
+  },
+  "https://saitama-marathon.jp/about/": {
+    "hash": "416f339b85a55a4d5aa06318e44ae2e891004832e67881b26f6f01646c77d7d9",
+    "last_checked": "2026-05-31T13:52:39.669Z",
+    "race_id": "saitama-marathon-2026"
+  },
+  "https://saitama-marathon.jp/about/guest/": {
+    "hash": "dd57eb27fd558e1d7874df06b108830650c6fc4439caf67d73892bebd7a4d98e",
+    "last_checked": "2026-05-31T13:52:41.450Z",
+    "race_id": "saitama-marathon-2026"
+  },
+  "https://saitama-marathon.jp/about/map/": {
+    "hash": "37710abeb349f411af96953955714dcc5e9578b06f72b0ee4f9f68bd09f9d56f",
+    "last_checked": "2026-05-31T13:52:43.300Z",
+    "race_id": "saitama-marathon-2026"
+  },
+  "https://saitama-marathon.jp/entry/": {
+    "hash": "d56a3a91cbb4528d636eb17258671efb6ccb2ab1daca22bd740990f02557a27b",
+    "last_checked": "2026-05-31T13:52:51.725Z",
+    "race_id": "saitama-marathon-2026"
+  },
+  "https://satumara.sapporo-sport.jp/outline.html": {
+    "hash": "33a46956bd04b987ab0c253693ebafea7cdc4b982c1db3047e6591ff8ca475cd",
+    "last_checked": "2026-05-31T13:52:51.809Z",
+    "race_id": "sapporo-marathon-2026"
+  },
+  "https://satumara.sapporo-sport.jp/entry.html": {
+    "hash": "c61a1eded25849140b14d2097c75bb8abdb6b8f09e5ee9d8529a92a16caaebb9",
+    "last_checked": "2026-05-31T13:52:51.823Z",
+    "race_id": "sapporo-marathon-2026"
+  },
+  "https://satumara.sapporo-sport.jp/course.html": {
+    "hash": "9cfc60def5ada24037497fc12689864e3d92cdd083a7d56d3c152e4e197eb049",
+    "last_checked": "2026-05-31T13:52:51.834Z",
+    "race_id": "sapporo-marathon-2026"
+  },
+  "https://satumara.sapporo-sport.jp/access.html": {
+    "hash": "035282e4c28ede9ddd982bf845a42f5c3125cf0312d970b900a99a19f7baa6bc",
+    "last_checked": "2026-05-31T13:52:51.853Z",
+    "race_id": "sapporo-marathon-2026"
+  },
+  "https://satumara.sapporo-sport.jp/faq.html": {
+    "hash": "8eca143d1f48aa455751a691e4fc3c5fc256dcaa3eb002e4b8e41f3e706eb4f8",
+    "last_checked": "2026-05-31T13:52:51.867Z",
+    "race_id": "sapporo-marathon-2026"
+  },
+  "https://www.nature-scene.net/shiga100/concept/": {
+    "hash": "f7dd772c5571530f47c34ed1a1b9d6c952ba62439cd9712ac63c808f535817bd",
+    "last_checked": "2026-05-31T13:52:54.045Z",
+    "race_id": "shiga-kogen100-2026"
+  },
+  "https://www.nature-scene.net/shiga100/coursemap/": {
+    "hash": "0a43e00575391080216506e63838e9f74be417cec6f799e3ad32edd714f3d80e",
+    "last_checked": "2026-05-31T13:52:54.201Z",
+    "race_id": "shiga-kogen100-2026"
+  },
+  "https://www.nature-scene.net/shiga100/entry/": {
+    "hash": "968f4e2fc8a2affc0295797b246ff3053acd864973a8f7e7e6c44152a318a58c",
+    "last_checked": "2026-05-31T13:52:54.276Z",
+    "race_id": "shiga-kogen100-2026"
+  },
+  "https://www.shimada-marathon.jp/m-information/course.html": {
+    "hash": "0d6e07f07d44d95f920dc9cc12682dfefebb7e9b63d283498cc49eb00aa45ad5",
+    "last_checked": "2026-05-31T13:52:54.386Z",
+    "race_id": "shimada-oigawa-marathon-2026"
+  },
+  "https://www.shimada-marathon.jp/entry.html": {
+    "hash": "637c5c2648b98a41ae3caedc1c4e8803bc4cea45ea5e776585b12462aa441c3e",
+    "last_checked": "2026-05-31T13:52:54.416Z",
+    "race_id": "shimada-oigawa-marathon-2026"
+  },
+  "https://www.shimada-marathon.jp/access.html": {
+    "hash": "85f00455b40002189ca89bc14c43b7c14e81a30097ed4d4c79a3aabbd05f98db",
+    "last_checked": "2026-05-31T13:52:54.445Z",
+    "race_id": "shimada-oigawa-marathon-2026"
+  },
+  "https://www.shimada-marathon.jp/faq.html": {
+    "hash": "ba844b07d52e1fd2815868a03d975b56f3a758ad2a32c695253eacc9109f893f",
+    "last_checked": "2026-05-31T13:52:54.477Z",
+    "race_id": "shimada-oigawa-marathon-2026"
+  },
+  "https://sfmt100.com/about-shinetsu/": {
+    "hash": "125298f93fed9cef622f2b9a008e1d3b2d87f2b3f97b5eb68cc5807f64cf67b3",
+    "last_checked": "2026-05-31T13:52:55.042Z",
+    "race_id": "shinetsu5mountains-trail-100-2026"
+  },
+  "https://sfmt100.com/access/": {
+    "hash": "3a13709290275e8f8034142e919ce7411f5b25f8c8b693017b185455f4a42492",
+    "last_checked": "2026-05-31T13:52:55.223Z",
+    "race_id": "shinetsu5mountains-trail-100-2026"
+  },
+  "https://sfmt100.com/about/outline/": {
+    "hash": "5469a2c13a3d33651eee0a167782ded8d690929f688b99649883d8ce5c0c71bb",
+    "last_checked": "2026-05-31T13:52:55.432Z",
+    "race_id": "shinetsu5mountains-trail-100-2026"
+  },
+  "https://sfmt100.com/about/entry/": {
+    "hash": "631d49b450599cf5b61f174dfd3d583ed3120027e6285b7f16c7cda2548d47df",
+    "last_checked": "2026-05-31T13:52:55.620Z",
+    "race_id": "shinetsu5mountains-trail-100-2026"
+  },
+  "https://sfmt100.com/map/": {
+    "hash": "7a156309f239ef68a43c53fbdeafef3850815a71b23b963053dc5ac463dbe28c",
+    "last_checked": "2026-05-31T13:52:55.755Z",
+    "race_id": "shinetsu5mountains-trail-100-2026"
+  },
+  "https://www.shizuoka-marathon.com/2026/info": {
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "last_checked": "2026-05-31T13:52:56.062Z",
+    "race_id": "shizuoka-marathon-2026"
+  },
+  "https://www.shizuoka-marathon.com/2026/entry": {
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "last_checked": "2026-05-31T13:52:56.275Z",
+    "race_id": "shizuoka-marathon-2026"
+  },
+  "https://www.shizuoka-marathon.com/2026/info/course": {
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "last_checked": "2026-05-31T13:53:00.415Z",
+    "race_id": "shizuoka-marathon-2026"
+  },
+  "https://www.shizuoka-marathon.com/2026/faq": {
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "last_checked": "2026-05-31T13:53:00.668Z",
+    "race_id": "shizuoka-marathon-2026"
+  },
+  "https://www.shizuoka-marathon.com/2026/info/feature": {
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "last_checked": "2026-05-31T13:53:00.818Z",
+    "race_id": "shizuoka-marathon-2026"
+  },
+  "https://www.shonan-kokusai.jp/entry/": {
+    "hash": "aadc7f3547eb73af39aeb7c8c26bfac266274aeb3d94fe876c3f5cc4a84fa367",
+    "last_checked": "2026-05-31T13:53:01.008Z",
+    "race_id": "shonan-international-marathon-2026"
+  },
+  "https://www.shonan-kokusai.jp/outline/": {
+    "hash": "f45ccc52c735ff242653d2c797ee63b28cd9b16489eed36ed848851e19603d93",
+    "last_checked": "2026-05-31T13:53:01.064Z",
+    "race_id": "shonan-international-marathon-2026"
+  },
+  "https://www.shonan-kokusai.jp/access/": {
+    "hash": "dc3b6a8ae9af852c089341491d42c96be9c8145c191c21dba82ae8dd28034816",
+    "last_checked": "2026-05-31T13:53:01.085Z",
+    "race_id": "shonan-international-marathon-2026"
+  },
+  "https://www.shonan-kokusai.jp/course/": {
+    "hash": "2af35078bcb84fa109ccd728e6b828c22d0092dd5000705187e94fd03b4cf984",
+    "last_checked": "2026-05-31T13:53:01.204Z",
+    "race_id": "shonan-international-marathon-2026"
+  },
+  "https://www.shonan-kokusai.jp/faq/": {
+    "hash": "9940b498a4f2487087089cc2f2b10053424f30b72607ed6e7d92ddd886c4760b",
+    "last_checked": "2026-05-31T13:53:01.338Z",
+    "race_id": "shonan-international-marathon-2026"
+  },
+  "https://soja-kibijimarathon.jp/wp/event-details/": {
+    "hash": "8c6d7dba04772bad25e6abab71a827c8b44ef88ba96f69f692c842ef7ac3eb5f",
+    "last_checked": "2026-05-31T13:53:01.861Z",
+    "race_id": "soja-kibiji-marathon-2026"
+  },
+  "https://soja-kibijimarathon.jp/wp/course/": {
+    "hash": "077dd87bf021a5a392e87578c96129aa1ad36b8f8a97791a20393994b904760e",
+    "last_checked": "2026-05-31T13:53:02.235Z",
+    "race_id": "soja-kibiji-marathon-2026"
+  },
+  "https://soja-kibijimarathon.jp/wp/entry/": {
+    "hash": "be1117250ae729a13c6a919235a60368b3e89451c00bf2ef86fe228babebf5ba",
+    "last_checked": "2026-05-31T13:53:02.606Z",
+    "race_id": "soja-kibiji-marathon-2026"
+  },
+  "https://soja-kibijimarathon.jp/wp/qa/": {
+    "hash": "5dab1b0c87ecc900e33181b67df17d99034edd5570cf9e483733e3d3cbaa9bea",
+    "last_checked": "2026-05-31T13:53:02.975Z",
+    "race_id": "soja-kibiji-marathon-2026"
+  },
+  "https://soja-kibijimarathon.jp/wp/access/": {
+    "hash": "b5f15817639961453dc8f05b38d5287a037a6ec60d1986eeb9fe3955a3e31a7d",
+    "last_checked": "2026-05-31T13:53:03.304Z",
+    "race_id": "soja-kibiji-marathon-2026"
+  },
+  "https://tambasasayama-abc-marathon.jp/outline/": {
+    "hash": "176947ebdda404c3c18c74d58c1440cef1bf4aeeb5a71a4bea5b2dce5e97db81",
+    "last_checked": "2026-05-31T13:53:03.610Z",
+    "race_id": "tamba-sasayama-abc-marathon-2026"
+  },
+  "https://tambasasayama-abc-marathon.jp/course/": {
+    "hash": "1dd67da3dc2f0c48df3649ae72bbe12bb97f32f183eb6a259caff44d8b873702",
+    "last_checked": "2026-05-31T13:53:03.869Z",
+    "race_id": "tamba-sasayama-abc-marathon-2026"
+  },
+  "https://tambasasayama-abc-marathon.jp/entry/": {
+    "hash": "a7358ef735b8e3aeeb4bf06f45aa0e59678e36a8b6246fcf6d9c15cac1297d81",
+    "last_checked": "2026-05-31T13:53:04.055Z",
+    "race_id": "tamba-sasayama-abc-marathon-2026"
+  },
+  "https://tambasasayama-abc-marathon.jp/faq/": {
+    "hash": "23b3dfe2b7eaf2bac73a1219a1a9633a326fc5121a6e454bbc03cd6f8e75f26e",
+    "last_checked": "2026-05-31T13:53:04.244Z",
+    "race_id": "tamba-sasayama-abc-marathon-2026"
+  },
+  "https://tateyama-wakasio.jp/outline/": {
+    "hash": "fe46356565add6c88c181cb01d5124f0cef5a0a62de81a76139f7019a9630eea",
+    "last_checked": "2026-05-31T13:53:04.405Z",
+    "race_id": "tateyama-wakashio-2026"
+  },
+  "https://tateyama-wakasio.jp/course/": {
+    "hash": "d8fd69ddb615417018e88d0c195189c2d43491a1c9fe21608122ef84f8cf96fb",
+    "last_checked": "2026-05-31T13:53:04.457Z",
+    "race_id": "tateyama-wakashio-2026"
+  },
+  "https://tateyama-wakasio.jp/entry/": {
+    "hash": "2e1051f06670c87d065281490fad61ebd5e0a7291e0e71d93ff20d5c255ac1c9",
+    "last_checked": "2026-05-31T13:53:04.510Z",
+    "race_id": "tateyama-wakashio-2026"
+  },
+  "https://tateyama-wakasio.jp/faq/": {
+    "hash": "d39b8637a06a2f2b012cf05895161da7e95d00abd68c30514f1be37e3b809d7a",
+    "last_checked": "2026-05-31T13:53:04.565Z",
+    "race_id": "tateyama-wakashio-2026"
+  },
+  "https://tazawako-marathon.com/info/": {
+    "hash": "5c6a64a767f3531f93c9d5dbf51f0a06df5011d2c0b414ee168be054b41cee88",
+    "last_checked": "2026-05-31T13:53:04.661Z",
+    "race_id": "tazawako-marathon-2026"
+  },
+  "https://tazawako-marathon.com/track/": {
+    "hash": "fbf506f30667799be4fc0e92a164fe27204480daf0bcb54833273ad8513d1875",
+    "last_checked": "2026-05-31T13:53:04.678Z",
+    "race_id": "tazawako-marathon-2026"
+  },
+  "https://tazawako-marathon.com/concept/": {
+    "hash": "2e211f42f118de4effc53d67d99ed041791997d1d51c369b8c5cea79910e2b03",
+    "last_checked": "2026-05-31T13:53:04.696Z",
+    "race_id": "tazawako-marathon-2026"
+  },
+  "https://tazawako-marathon.com/question/": {
+    "hash": "a4b671289ae3e557936a1390cf51c4fbda1a47dc35ac125543e07d1196437914",
+    "last_checked": "2026-05-31T13:53:04.713Z",
+    "race_id": "tazawako-marathon-2026"
+  },
+  "https://tazawako-marathon.com/entry/": {
+    "hash": "2b45223e6ea89491a9d9da8f14c2087fb29c18c761cda60818c06cc6f40fd54d",
+    "last_checked": "2026-05-31T13:53:04.730Z",
+    "race_id": "tazawako-marathon-2026"
+  },
+  "https://www.tokushima-marathon.jp/info/": {
+    "hash": "d640a96739f16d8cccca5d8c44043383bc2cf21a1815f4828993de79bac0563a",
+    "last_checked": "2026-05-31T13:53:04.847Z",
+    "race_id": "tokushima-marathon-2026"
+  },
+  "https://www.tokushima-marathon.jp/info/course.html": {
+    "hash": "bfb8da0d0b20b069626904436e7cd902ac4cf1b4ca0c384def7786bedc293515",
+    "last_checked": "2026-05-31T13:53:05.148Z",
+    "race_id": "tokushima-marathon-2026"
+  },
+  "https://www.tokushima-marathon.jp/info/guest.html": {
+    "hash": "30d2f36d9315c9aee93e5f58bbc0c77724a4ebb53e78c8416ea9d3436870b51d",
+    "last_checked": "2026-05-31T13:53:05.200Z",
+    "race_id": "tokushima-marathon-2026"
+  },
+  "https://www.tokushima-marathon.jp/join/entry.html": {
+    "hash": "c029dbde773166f9a203f6d840954b00968014d70ecdddbd6f2a067d2238469e",
+    "last_checked": "2026-05-31T13:53:05.345Z",
+    "race_id": "tokushima-marathon-2026"
+  },
+  "https://www.tokushima-marathon.jp/regulation/": {
+    "hash": "c5fdd6254250c413c38c0800b8e47fecf586b5b2360e87783048446520cad58c",
+    "last_checked": "2026-05-31T13:53:05.396Z",
+    "race_id": "tokushima-marathon-2026"
+  },
+  "https://legacyhalf.tokyo/volunteer/index.html": {
+    "hash": "2b09ad0ea4d05c02317e23682d385ab152b8c16815d87397f87fc04434a4685d",
+    "last_checked": "2026-05-31T13:53:05.505Z",
+    "race_id": "tokyo-legacy-half-2026"
+  },
+  "https://legacyhalf.tokyo/about/main-visual/index.html": {
+    "hash": "610f81fc7778168608f815de743bc5168feb39be160869a4b0bfeafdd9c49749",
+    "last_checked": "2026-05-31T13:53:05.550Z",
+    "race_id": "tokyo-legacy-half-2026"
+  },
+  "https://legacyhalf.tokyo/news/detail/news_0248.html": {
+    "hash": "9e837ebdb5a88cf1cbef114c3fcaeb7d0cc47d1f7a5849e17eb7d18470839d5d",
+    "last_checked": "2026-05-31T13:53:05.585Z",
+    "race_id": "tokyo-legacy-half-2026"
+  },
+  "https://www.marathon.tokyo/volunteer/about/": {
+    "hash": "588d0191897b0e7a40ac7b878cad4400f9ac0d82d14ed16e19cf833f50a37186",
+    "last_checked": "2026-05-31T13:53:05.844Z",
+    "race_id": "tokyo-marathon-2027"
+  },
+  "https://www.marathon.tokyo/faq/": {
+    "hash": "12ac4fc60950104df618ee16b8406a98efa734f8c08d83583975df1f308929d9",
+    "last_checked": "2026-05-31T13:53:05.859Z",
+    "race_id": "tokyo-marathon-2027"
+  },
+  "https://www.marathon.tokyo/about/outline/": {
+    "hash": "545d035d467d32c2249c7c0c87941292f5dc9b0e42dc2b8a77e12e35661f498c",
+    "last_checked": "2026-05-31T13:53:05.872Z",
+    "race_id": "tokyo-marathon-2027"
+  },
+  "https://www.marathon.tokyo/about/course/": {
+    "hash": "d815090006a2aa883dc2584f0b2c15517e641480e73380757c7a31b56743c5cf",
+    "last_checked": "2026-05-31T13:53:05.884Z",
+    "race_id": "tokyo-marathon-2027"
+  },
+  "https://www.marathon.tokyo/participants/": {
+    "hash": "a1d233818c13b682ae95eb1248dc2d9ac0e26b0ae2e1e32a1539f0d04fbde4f1",
+    "last_checked": "2026-05-31T13:53:05.896Z",
+    "race_id": "tokyo-marathon-2027"
+  },
+  "https://tomisato-suikaroad.jp/outline/": {
+    "hash": "9016035e995739ad8940039c9628518098009e847265f45ec6c48f0fa0d6f7ad",
+    "last_checked": "2026-05-31T13:53:06.451Z",
+    "race_id": "tomisato-suikaroad-2026"
+  },
+  "https://tomisato-suikaroad.jp/course/": {
+    "hash": "0afcccc5bc9c8aee8189ba87612d0e1cfc28493dabc57fc4bddf8666b687e649",
+    "last_checked": "2026-05-31T13:53:06.627Z",
+    "race_id": "tomisato-suikaroad-2026"
+  },
+  "https://tomisato-suikaroad.jp/entry/": {
+    "hash": "ea75feedaf5949979c4c712aa3c459e6ee4b41403730e4e0a92a1bca5ac65a8f",
+    "last_checked": "2026-05-31T13:53:06.800Z",
+    "race_id": "tomisato-suikaroad-2026"
+  },
+  "https://tomisato-suikaroad.jp/mycapinfo/": {
+    "hash": "7d8b5e192f3152ed288f3bd059d18d4104c3269eb04926083fd1924880035032",
+    "last_checked": "2026-05-31T13:53:06.967Z",
+    "race_id": "tomisato-suikaroad-2026"
+  },
+  "https://tomisato-suikaroad.jp/archives/770/": {
+    "hash": "adf118b7c29536c7761e790f4d5adeadbe4066ea75dc84e43bb990fd800e2569",
+    "last_checked": "2026-05-31T13:53:07.130Z",
+    "race_id": "tomisato-suikaroad-2026"
+  },
+  "https://tottori-marathon.jp/about/": {
+    "hash": "422987f6177a0c01e7f54bf6c37a1e753d6a859eeeb6171764f1ed813ed94ba2",
+    "last_checked": "2026-05-31T13:53:07.360Z",
+    "race_id": "tottori-marathon-2026"
+  },
+  "https://tottori-marathon.jp/course/": {
+    "hash": "128018a29b74c3a846d065276e9ecc4b8606abce9ee747ff25ab853675ab1409",
+    "last_checked": "2026-05-31T13:53:07.578Z",
+    "race_id": "tottori-marathon-2026"
+  },
+  "https://tottori-marathon.jp/access/": {
+    "hash": "b08bee856b5be4eb9100542912c4bc087d74d65e8e1204041a41ee08e6760e7a",
+    "last_checked": "2026-05-31T13:53:07.722Z",
+    "race_id": "tottori-marathon-2026"
+  },
+  "https://tottori-marathon.jp/faq/": {
+    "hash": "07787ac0390148f131be079c0f150d43ba34d4fe1e9528e76b5bf302a1511f0f",
+    "last_checked": "2026-05-31T13:53:07.854Z",
+    "race_id": "tottori-marathon-2026"
+  },
+  "https://www.toyako-marathon.jp/outline/": {
+    "hash": "04aae16ca12370f252f99e7fbb6f3edfa00df10c2851e891fa061f5c447a2f1c",
+    "last_checked": "2026-05-31T13:53:08.168Z",
+    "race_id": "toyako-marathon-2026"
+  },
+  "https://www.toyako-marathon.jp/entry/": {
+    "hash": "8a251f00105de0a7168106bb47c8993ef20cab5d49eb74c0bfc81e5af5193ee5",
+    "last_checked": "2026-05-31T13:53:08.415Z",
+    "race_id": "toyako-marathon-2026"
+  },
+  "https://www.toyako-marathon.jp/course/": {
+    "hash": "5aff71c01fbc2b0dd9d81f816c006d68582e525068d28040fbf07e151c07f561",
+    "last_checked": "2026-05-31T13:53:08.583Z",
+    "race_id": "toyako-marathon-2026"
+  },
+  "https://www.toyamamarathon.com/about/": {
+    "hash": "b1254929d0589b941171517ce14be55c509e42d38a5187fd3a935d75858dee58",
+    "last_checked": "2026-05-31T13:53:09.853Z",
+    "race_id": "toyama-marathon-2026"
+  },
+  "https://www.toyamamarathon.com/about/course/": {
+    "hash": "d61f6db801518bd190cbb678d39336906bd8b1f3e96b2ebbea7e8a1b80cd8cf2",
+    "last_checked": "2026-05-31T13:53:10.005Z",
+    "race_id": "toyama-marathon-2026"
+  },
+  "https://www.toyamamarathon.com/runner/stayplan/": {
+    "hash": "6c3b81bafc5a175ca20bdb9d17fd5b15212c0d877555c07b0e56a9bdfa8541c8",
+    "last_checked": "2026-05-31T13:53:10.186Z",
+    "race_id": "toyama-marathon-2026"
+  },
+  "https://www.toyamamarathon.com/traffic/": {
+    "hash": "9c42f72abda73179e3d00137461c0a23e1b8989853b65b79a67c7eee49aaf866",
+    "last_checked": "2026-05-31T13:53:10.359Z",
+    "race_id": "toyama-marathon-2026"
+  },
+  "https://www.toyamamarathon.com/faq/": {
+    "hash": "39a9b94de32b82a90dccde9b3c519fa6460650e7ad4515371d335f67e0f374c3",
+    "last_checked": "2026-05-31T13:53:10.554Z",
+    "race_id": "toyama-marathon-2026"
+  },
+  "https://www.tsukuba-marathon.com/page/dir000007.html": {
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "last_checked": "2026-05-31T13:53:10.601Z",
+    "race_id": "tsukuba-marathon-2026"
+  },
+  "https://www.tsukuba-marathon.com/faq.php": {
+    "hash": "65524ba36bb60fc7d724f43b20a95152b20ed2c8e66759b5aceaa72ea28c5e9f",
+    "last_checked": "2026-05-31T13:53:10.655Z",
+    "race_id": "tsukuba-marathon-2026"
+  },
+  "https://www.tsukuba-marathon.com/page/page000280.html": {
+    "hash": "6c2f8519a88761a574373882ea94799a81922a2830ee617784e0150e89465b2e",
+    "last_checked": "2026-05-31T13:53:10.670Z",
+    "race_id": "tsukuba-marathon-2026"
+  },
+  "https://www.tsukuba-marathon.com/page/page000276.html": {
+    "hash": "0c04b04971c9a39c815751e532f23fa1da3c880bb68afacb334986acb779948a",
+    "last_checked": "2026-05-31T13:53:10.685Z",
+    "race_id": "tsukuba-marathon-2026"
+  },
+  "https://www.tsukuba-marathon.com/sitemap.php": {
+    "hash": "707ed1388fd493134ed99c6f3463e92f2f313f1141cc636caa4dd4f8d596f592",
+    "last_checked": "2026-05-31T13:53:10.745Z",
+    "race_id": "tsukuba-marathon-2026"
+  },
+  "https://wakkanai-marathon.jp/outline/": {
+    "hash": "059aa7367199eb98d28771738753fe9f367e2f3efe4fe6b6e0369890589b2638",
+    "last_checked": "2026-05-31T13:53:11.059Z",
+    "race_id": "wakkanai-peace-marathon-2026"
+  },
+  "https://wakkanai-marathon.jp/entry/": {
+    "hash": "7472d8abd68e3a252d7a3b3c31170772b89a8a732958e4301fda629645e0891d",
+    "last_checked": "2026-05-31T13:53:11.332Z",
+    "race_id": "wakkanai-peace-marathon-2026"
+  },
+  "https://wakkanai-marathon.jp/course/": {
+    "hash": "eb9901f04f6362ba9e0d34a7896c897581291ed27bde884605fc5a14af50b02a",
+    "last_checked": "2026-05-31T13:53:11.517Z",
+    "race_id": "wakkanai-peace-marathon-2026"
+  },
+  "https://yokohamamarathon.jp/outline/": {
+    "hash": "ed1d40424bb33f6766319c8b7f3b071633baa11843cf4b3df539b9b57a3bc0f6",
+    "last_checked": "2026-05-31T13:53:12.434Z",
+    "race_id": "yokohama-marathon-2026"
+  },
+  "https://yokohamamarathon.jp/entrystart/": {
+    "hash": "016b3b8ce61c04ca9bc50104153edb1f9d814712d2df2ee781e1c0a4b4acd010",
+    "last_checked": "2026-05-31T13:53:13.239Z",
+    "race_id": "yokohama-marathon-2026"
+  },
+  "https://yokohamamarathon.jp/volunteerqa/": {
+    "hash": "0228126f60ba144b7258c88dc92c50292861f88a997fd2eb97d9804654b320a9",
+    "last_checked": "2026-05-31T13:53:14.077Z",
+    "race_id": "yokohama-marathon-2026"
+  }
+}

--- a/tools/crawl/index.js
+++ b/tools/crawl/index.js
@@ -26,7 +26,6 @@ const FETCH_OPTS = {
     'User-Agent': 'Mozilla/5.0 (compatible; HASHIRUBot/1.0; +https://hashiru.run)',
     'Accept-Language': 'ja,en;q=0.9',
   },
-  signal: AbortSignal.timeout(15000),
 };
 
 // ── 純粋関数（テスト対象） ────────────────────────────────────────
@@ -93,7 +92,7 @@ function cleanHtml(html) {
 }
 
 async function fetchPageText(url) {
-  const res = await fetch(url, FETCH_OPTS);
+  const res = await fetch(url, { ...FETCH_OPTS, signal: AbortSignal.timeout(15000) });
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   return cleanHtml(await res.text());
 }


### PR DESCRIPTION
## 問題

`FETCH_OPTS` の `signal` に `AbortSignal.timeout(15000)` を定数として格納していたため、プロセス起動から15秒後に Signal が発火し、それ以降の全 `fetch` が即座に abort されていた。

結果として、クロール実行時に先頭の数レース（アルファベット順で a〜f 相当）は成功するが、15秒経過後の h 以降のレースがすべて `The operation was aborted due to timeout` エラーになっていた。

## 原因

```js
// 修正前: モジュールロード時に1回だけ生成 → 15秒後に全リクエストがabort
const FETCH_OPTS = {
  headers: { ... },
  signal: AbortSignal.timeout(15000),  // ← ここが問題
};
```

## 修正

`fetchPageText` 内でリクエストごとに新規 Signal を生成するよう変更。

```js
const res = await fetch(url, { ...FETCH_OPTS, signal: AbortSignal.timeout(15000) });
```

## 確認

- テスト全件パス（`node --test tools/crawl/index.test.js`）
- 修正後は個別テストで問題なかった各URLが連続クロールでも正常に取得できることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * ページ取得のタイムアウト処理を改善しました（取得の安定性向上）。
* **Chores**
  * 大量の大会データを更新しました：参加費・定員・応募期間・受取物の説明などを最新化。
  * 参加賞の表記変更（例：筑波マラソンは「メダル」表記を削除しTシャツのみに）。
  * 一部大会の応募締切日を更新（例：横浜マラソンの終了日延長）。
  * クロール関連メタデータとチェックサムを再生成しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->