### PR TITLE
fix: 管理ツール項目見直し (#73)

### DIFF
--- a/docs/er-diagram.drawio
+++ b/docs/er-diagram.drawio
@@ -593,6 +593,65 @@
           <mxGeometry x="40" width="220" height="30" as="geometry" />
         </mxCell>
 
+        <!-- ===== completion_gifts ===== -->
+        <mxCell id="cgift_title" value="completion_gifts" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;fontSize=14;fillColor=#d5e8d4;strokeColor=#82b366;" vertex="1" parent="1">
+          <mxGeometry x="40" y="1330" width="260" height="210" as="geometry" />
+        </mxCell>
+        <mxCell id="cgift_r0" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=1;" vertex="1" parent="cgift_title">
+          <mxGeometry y="30" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="cgift_r0_k" value="PK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=1;overflow=hidden;" vertex="1" parent="cgift_r0">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="cgift_r0_v" value="id (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="cgift_r0">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="cgift_r1" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="cgift_title">
+          <mxGeometry y="60" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="cgift_r1_k" value="FK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=2;overflow=hidden;" vertex="1" parent="cgift_r1">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="cgift_r1_v" value="race_id (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="cgift_r1">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="cgift_r2" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="cgift_title">
+          <mxGeometry y="90" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="cgift_r2_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="cgift_r2">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="cgift_r2_v" value="gift_categories (TEXT/JSON)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="cgift_r2">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="cgift_r3" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="cgift_title">
+          <mxGeometry y="120" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="cgift_r3_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="cgift_r3">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="cgift_r3_v" value="description_ja / _en (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="cgift_r3">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="cgift_r4" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="cgift_title">
+          <mxGeometry y="150" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="cgift_r4_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="cgift_r4">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="cgift_r4_v" value="image (TEXT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="cgift_r4">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="cgift_r5" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;top=0;left=0;right=0;bottom=0;" vertex="1" parent="cgift_title">
+          <mxGeometry y="180" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="cgift_r5_k" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="cgift_r5">
+          <mxGeometry width="40" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="cgift_r5_v" value="sort_order (INT)" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;overflow=hidden;" vertex="1" parent="cgift_r5">
+          <mxGeometry x="40" width="220" height="30" as="geometry" />
+        </mxCell>
+
         <!-- ===== race_course_highlights ===== -->
         <mxCell id="rch_title" value="race_course_highlights" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;fontSize=14;fillColor=#d5e8d4;strokeColor=#82b366;" vertex="1" parent="1">
           <mxGeometry x="900" y="40" width="280" height="270" as="geometry" />
@@ -1808,6 +1867,11 @@
 
         <!-- participation_gifts.race_id → races.id -->
         <mxCell id="rel_pgift_races" style="edgeStyle=entityRelationEdgeStyle;endArrow=ERmanyToOne;startArrow=ERmanyToOne;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="pgift_r0" target="races_r0" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- completion_gifts.race_id → races.id -->
+        <mxCell id="rel_cgift_races" style="edgeStyle=entityRelationEdgeStyle;endArrow=ERmanyToOne;startArrow=ERmanyToOne;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="cgift_r0" target="races_r0" parent="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -179,6 +179,22 @@ ER図は `docs/er-diagram.drawio` で管理しています。[draw.io](https://a
 
 ---
 
+### completion_gifts
+
+| カラム | 型 | NULL | デフォルト | 備考 |
+|---|---|---|---|---|
+| id | integer | NO | autoincrement | PK |
+| race_id | text | NO | — | FK → races.id（CASCADE） |
+| gift_categories | text | NO | `"[]"` | JSON: `GiftCategoryId[]` |
+| description_ja | text | NO | `""` | |
+| description_en | text | NO | `""` | |
+| image | text | YES | — | |
+| sort_order | integer | NO | `0` | |
+
+> `participation_gifts` と同構造。`medal` など完走者のみ受け取れる賞を格納する。
+
+---
+
 ### race_series
 
 | カラム | 型 | NULL | デフォルト | 備考 |
@@ -402,3 +418,4 @@ ER図は `docs/er-diagram.drawio` で管理しています。[draw.io](https://a
 | `migrations/0008_stormy_reavers.sql` | race_voices に quote_en カラムを追加（英語対応） |
 | `migrations/0007_yielding_obadiah_stane.sql` | race_course_highlights に category_id カラムを追加（FK ON DELETE 句なし ← 0010 で修正） |
 | `migrations/0010_fix_course_highlights_fk.sql` | race_course_highlights.category_id FK を ON DELETE CASCADE に修正（schema.ts との整合） |
+| `migrations/0009_shallow_captain_stacy.sql` | completion_gifts テーブルを追加（Issue #73）。medal 等の完走賞を participation_gifts から分離 |

--- a/docs/update-history.md
+++ b/docs/update-history.md
@@ -646,3 +646,21 @@
 
 ### ドキュメント
 - `README.md`: `tools/` ディレクトリ構成・クローラー使い方を更新
+
+## 2026-06-07 管理ツール項目見直し (issue #73)
+
+### バグ修正
+- `tools/admin/app.js`: `bindEvents()` のセレクターを `.form-body` 内に限定し、サイドバー検索・データチェックフィルター操作で「未保存」ポップアップが誤表示される問題を修正
+
+### 機能追加
+- `tools/admin/index.html`: 「完走賞」セクションを「参加賞」の直後に追加
+- `tools/admin/app.js`: `renderCompletionGifts` / `addCompletionGiftRow` / `collectCompletionGifts` を追加
+
+### 機能削除
+- `tools/admin/index.html`: 「コース」セクション（GPXファイル名フィールド）を削除（カテゴリ別GPXに統一）
+- `tools/admin/app.js`: エントリー期間の「参加費（円）」フィールドを削除（カテゴリ別参加費に統一）
+
+### データ移行
+- `scripts/migrate-medal-gifts.js`: メダル移行スクリプトを追加
+- `src/data/races/*.json`: 51件の `participation_gifts` からメダルを `completion_gifts` に移行
+- `migrations/seed-races-all.sql`: 移行後のJSONから再生成

--- a/docs/update-history.md
+++ b/docs/update-history.md
@@ -664,3 +664,17 @@
 - `scripts/migrate-medal-gifts.js`: メダル移行スクリプトを追加
 - `src/data/races/*.json`: 51件の `participation_gifts` からメダルを `completion_gifts` に移行
 - `migrations/seed-races-all.sql`: 移行後のJSONから再生成
+
+### 完走賞フルスタック対応（CodeRabbit対応）
+- `src/lib/types.ts`: `CompletionGift` 型エイリアス追加、`Race` に `completion_gifts` フィールド追加
+- `src/lib/db/schema.ts`: `completion_gifts` テーブル追加（`participation_gifts` と同構造）
+- `migrations/0009_shallow_captain_stacy.sql`: `completion_gifts` テーブルのマイグレーション生成・適用
+- `src/lib/data.ts`: 全クエリ関数に `completion_gifts` 取得・組み立てを追加
+- `src/lib/utils.ts`: `filterRaces()` の `giftCategories` フィルタを `completion_gifts` も含めて検索するよう修正
+- `src/app/[locale]/races/[id]/page.tsx`: 「参加賞・完走賞」セクションに `completion_gifts` 表示を追加
+- `scripts/generate-seed-races.js`: `completion_gifts` のSQL生成を追加
+- `migrations/seed-races-all.sql`: `completion_gifts` データを含めて再生成・ローカルDB適用
+- `docs/schema.md`: `completion_gifts` テーブル定義・マイグレーション履歴を追記
+- `scripts/migrate-medal-gifts.js`: `image: null` → `gift.image ?? null` バグ修正（CodeRabbit指摘）
+- `src/lib/__tests__/fixtures.ts`: `makeCompletionGift` ファクトリ追加、`makeRace` に `completion_gifts: []` 追加
+- `src/lib/__tests__/utils.filter.test.ts`: `completion_gifts` を含む `giftCategories` フィルタのテスト追加

--- a/migrations/0009_shallow_captain_stacy.sql
+++ b/migrations/0009_shallow_captain_stacy.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `completion_gifts` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`race_id` text NOT NULL,
+	`gift_categories` text DEFAULT '[]' NOT NULL,
+	`description_ja` text DEFAULT '' NOT NULL,
+	`description_en` text DEFAULT '' NOT NULL,
+	`image` text,
+	`sort_order` integer DEFAULT 0 NOT NULL,
+	FOREIGN KEY (`race_id`) REFERENCES `races`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `completion_gifts_race_id_idx` ON `completion_gifts` (`race_id`);

--- a/migrations/meta/0009_snapshot.json
+++ b/migrations/meta/0009_snapshot.json
@@ -1,0 +1,2608 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "2536c4a5-bce0-4f0e-be88-8db2672c06bb",
+  "prevId": "cd47e99e-e1c3-42fe-b485-2113e4968b21",
+  "tables": {
+    "access_points": {
+      "name": "access_points",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "station_name_ja": {
+          "name": "station_name_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "station_name_en": {
+          "name": "station_name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "station_code": {
+          "name": "station_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "transport_to_venue_ja": {
+          "name": "transport_to_venue_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "transport_to_venue_en": {
+          "name": "transport_to_venue_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "access_points_race_id_idx": {
+          "name": "access_points_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "access_points_race_id_races_id_fk": {
+          "name": "access_points_race_id_races_id_fk",
+          "tableFrom": "access_points",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "aid_stations": {
+      "name": "aid_stations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "distance_km": {
+          "name": "distance_km",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "offerings_ja": {
+          "name": "offerings_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "offerings_en": {
+          "name": "offerings_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "aid_stations_race_id_idx": {
+          "name": "aid_stations_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "aid_stations_race_id_races_id_fk": {
+          "name": "aid_stations_race_id_races_id_fk",
+          "tableFrom": "aid_stations",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "checkpoints": {
+      "name": "checkpoints",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "distance_km": {
+          "name": "distance_km",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "closing_time": {
+          "name": "closing_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "checkpoints_race_id_idx": {
+          "name": "checkpoints_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "checkpoints_race_id_races_id_fk": {
+          "name": "checkpoints_race_id_races_id_fk",
+          "tableFrom": "checkpoints",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "completion_gifts": {
+      "name": "completion_gifts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gift_categories": {
+          "name": "gift_categories",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "description_ja": {
+          "name": "description_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description_en": {
+          "name": "description_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "completion_gifts_race_id_idx": {
+          "name": "completion_gifts_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "completion_gifts_race_id_races_id_fk": {
+          "name": "completion_gifts_race_id_races_id_fk",
+          "tableFrom": "completion_gifts",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "contact_submissions": {
+      "name": "contact_submissions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "contact_submissions_status_idx": {
+          "name": "contact_submissions_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "contact_submissions_created_at_idx": {
+          "name": "contact_submissions_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "contact_submissions_user_id_user_id_fk": {
+          "name": "contact_submissions_user_id_user_id_fk",
+          "tableFrom": "contact_submissions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gift_categories": {
+      "name": "gift_categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_ja": {
+          "name": "name_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_en": {
+          "name": "name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "nearby_spots": {
+      "name": "nearby_spots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_ja": {
+          "name": "name_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_en": {
+          "name": "name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description_ja": {
+          "name": "description_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description_en": {
+          "name": "description_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "distance_from_venue": {
+          "name": "distance_from_venue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "nearby_spots_race_id_idx": {
+          "name": "nearby_spots_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "nearby_spots_race_id_races_id_fk": {
+          "name": "nearby_spots_race_id_races_id_fk",
+          "tableFrom": "nearby_spots",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "participation_gifts": {
+      "name": "participation_gifts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gift_categories": {
+          "name": "gift_categories",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "description_ja": {
+          "name": "description_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description_en": {
+          "name": "description_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "participation_gifts_race_id_idx": {
+          "name": "participation_gifts_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "participation_gifts_race_id_races_id_fk": {
+          "name": "participation_gifts_race_id_races_id_fk",
+          "tableFrom": "participation_gifts",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkey": {
+      "name": "passkey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "webAuthnUserID": {
+          "name": "webAuthnUserID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deviceType": {
+          "name": "deviceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backedUp": {
+          "name": "backedUp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "passkey_userId_user_id_fk": {
+          "name": "passkey_userId_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prefectures": {
+      "name": "prefectures",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_en": {
+          "name": "name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region_en": {
+          "name": "region_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lat": {
+          "name": "lat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lng": {
+          "name": "lng",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_categories": {
+      "name": "race_categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "distance_type": {
+          "name": "distance_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "distance_km": {
+          "name": "distance_km",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "time_limit_minutes": {
+          "name": "time_limit_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "entry_fee": {
+          "name": "entry_fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_fee_u25": {
+          "name": "entry_fee_u25",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name_ja": {
+          "name": "name_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name_en": {
+          "name": "name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description_ja": {
+          "name": "description_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description_en": {
+          "name": "description_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "eligibility_ja": {
+          "name": "eligibility_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "eligibility_en": {
+          "name": "eligibility_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "course_gpx_file": {
+          "name": "course_gpx_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "waves": {
+          "name": "waves",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "race_categories_race_id_idx": {
+          "name": "race_categories_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_categories_race_id_races_id_fk": {
+          "name": "race_categories_race_id_races_id_fk",
+          "tableFrom": "race_categories",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_course_highlights": {
+      "name": "race_course_highlights",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "km": {
+          "name": "km",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name_ja": {
+          "name": "name_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_en": {
+          "name": "name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note_ja": {
+          "name": "note_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note_en": {
+          "name": "note_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "race_course_highlights_race_id_idx": {
+          "name": "race_course_highlights_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_course_highlights_race_id_races_id_fk": {
+          "name": "race_course_highlights_race_id_races_id_fk",
+          "tableFrom": "race_course_highlights",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "race_course_highlights_category_id_race_categories_id_fk": {
+          "name": "race_course_highlights_category_id_race_categories_id_fk",
+          "tableFrom": "race_course_highlights",
+          "tableTo": "race_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_entry_links": {
+      "name": "race_entry_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "race_entry_links_race_id_idx": {
+          "name": "race_entry_links_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_entry_links_race_id_races_id_fk": {
+          "name": "race_entry_links_race_id_races_id_fk",
+          "tableFrom": "race_entry_links",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_entry_periods": {
+      "name": "race_entry_periods",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "label_ja": {
+          "name": "label_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'一般エントリー'"
+        },
+        "label_en": {
+          "name": "label_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'General Entry'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entry_fee": {
+          "name": "entry_fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "race_entry_periods_race_id_idx": {
+          "name": "race_entry_periods_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_entry_periods_race_id_races_id_fk": {
+          "name": "race_entry_periods_race_id_races_id_fk",
+          "tableFrom": "race_entry_periods",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "race_entry_periods_category_id_race_categories_id_fk": {
+          "name": "race_entry_periods_category_id_race_categories_id_fk",
+          "tableFrom": "race_entry_periods",
+          "tableTo": "race_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_gallery": {
+      "name": "race_gallery",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "src": {
+          "name": "src",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caption_ja": {
+          "name": "caption_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "caption_en": {
+          "name": "caption_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "race_gallery_race_id_idx": {
+          "name": "race_gallery_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_gallery_race_id_races_id_fk": {
+          "name": "race_gallery_race_id_races_id_fk",
+          "tableFrom": "race_gallery",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_results": {
+      "name": "race_results",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "participants_count": {
+          "name": "participants_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finishers_count": {
+          "name": "finishers_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finisher_rate_pct": {
+          "name": "finisher_rate_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "weather_condition_ja": {
+          "name": "weather_condition_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "weather_condition_en": {
+          "name": "weather_condition_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "temperature_c": {
+          "name": "temperature_c",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_temp_c": {
+          "name": "max_temp_c",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "min_temp_c": {
+          "name": "min_temp_c",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "wind_speed_ms": {
+          "name": "wind_speed_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "humidity_pct": {
+          "name": "humidity_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes_ja": {
+          "name": "notes_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes_en": {
+          "name": "notes_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avg_time": {
+          "name": "avg_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "race_results_race_id_idx": {
+          "name": "race_results_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_results_race_id_races_id_fk": {
+          "name": "race_results_race_id_races_id_fk",
+          "tableFrom": "race_results",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_series": {
+      "name": "race_series",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_ja": {
+          "name": "name_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_en": {
+          "name": "name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_held_year": {
+          "name": "first_held_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_time_buckets": {
+      "name": "race_time_buckets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pct": {
+          "name": "pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "race_time_buckets_race_id_idx": {
+          "name": "race_time_buckets_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_time_buckets_race_id_races_id_fk": {
+          "name": "race_time_buckets_race_id_races_id_fk",
+          "tableFrom": "race_time_buckets",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_voices": {
+      "name": "race_voices",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quote_ja": {
+          "name": "quote_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quote_en": {
+          "name": "quote_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "race_voices_race_id_idx": {
+          "name": "race_voices_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_voices_race_id_races_id_fk": {
+          "name": "race_voices_race_id_races_id_fk",
+          "tableFrom": "race_voices",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "races": {
+      "name": "races",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_ja": {
+          "name": "name_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_en": {
+          "name": "name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "full_name_ja": {
+          "name": "full_name_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "full_name_en": {
+          "name": "full_name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "edition": {
+          "name": "edition",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prefecture": {
+          "name": "prefecture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "city_ja": {
+          "name": "city_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "city_en": {
+          "name": "city_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description_ja": {
+          "name": "description_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description_en": {
+          "name": "description_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "official_url": {
+          "name": "official_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "entry_fee": {
+          "name": "entry_fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_fee_by_category": {
+          "name": "entry_fee_by_category",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "entry_capacity": {
+          "name": "entry_capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "entry_start_date": {
+          "name": "entry_start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_end_date": {
+          "name": "entry_end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_closed": {
+          "name": "entry_closed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "reception_type": {
+          "name": "reception_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'race_day'"
+        },
+        "reception_note_ja": {
+          "name": "reception_note_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "reception_note_en": {
+          "name": "reception_note_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "course_gpx_file": {
+          "name": "course_gpx_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "course_max_elevation_m": {
+          "name": "course_max_elevation_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "course_min_elevation_m": {
+          "name": "course_min_elevation_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "course_elevation_diff_m": {
+          "name": "course_elevation_diff_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "course_surface": {
+          "name": "course_surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'road'"
+        },
+        "course_certification": {
+          "name": "course_certification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "course_highlights_ja": {
+          "name": "course_highlights_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "course_highlights_en": {
+          "name": "course_highlights_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "course_notes_ja": {
+          "name": "course_notes_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "course_notes_en": {
+          "name": "course_notes_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "motif": {
+          "name": "motif",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "motif_color": {
+          "name": "motif_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "motif_romaji": {
+          "name": "motif_romaji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tagline_ja": {
+          "name": "tagline_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tagline_en": {
+          "name": "tagline_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hero_image_url": {
+          "name": "hero_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hero_caption_ja": {
+          "name": "hero_caption_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hero_caption_en": {
+          "name": "hero_caption_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "races_date_idx": {
+          "name": "races_date_idx",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        },
+        "races_prefecture_idx": {
+          "name": "races_prefecture_idx",
+          "columns": [
+            "prefecture"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "races_series_id_race_series_id_fk": {
+          "name": "races_series_id_race_series_id_fk",
+          "tableFrom": "races",
+          "tableTo": "race_series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_races": {
+      "name": "user_races",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_planning": {
+          "name": "is_planning",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "planning_category_id": {
+          "name": "planning_category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_reminder_period_ids": {
+          "name": "entry_reminder_period_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_races_user_id_idx": {
+          "name": "user_races_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "user_races_race_id_idx": {
+          "name": "user_races_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        },
+        "user_races_user_race_idx": {
+          "name": "user_races_user_race_idx",
+          "columns": [
+            "user_id",
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_races_user_id_user_id_fk": {
+          "name": "user_races_user_id_user_id_fk",
+          "tableFrom": "user_races",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_races_race_id_races_id_fk": {
+          "name": "user_races_race_id_races_id_fk",
+          "tableFrom": "user_races",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_races_planning_category_id_race_categories_id_fk": {
+          "name": "user_races_planning_category_id_race_categories_id_fk",
+          "tableFrom": "user_races",
+          "tableTo": "race_categories",
+          "columnsFrom": [
+            "planning_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "weather_history": {
+      "name": "weather_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avg_temp": {
+          "name": "avg_temp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "max_temp": {
+          "name": "max_temp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "min_temp": {
+          "name": "min_temp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "humidity_pct": {
+          "name": "humidity_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "precipitation_mm": {
+          "name": "precipitation_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "wind_speed_ms": {
+          "name": "wind_speed_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "weather_history_race_id_idx": {
+          "name": "weather_history_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "weather_history_race_id_races_id_fk": {
+          "name": "weather_history_race_id_races_id_fk",
+          "tableFrom": "weather_history",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1778362006747,
       "tag": "0008_stormy_reavers",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1780842017864,
+      "tag": "0009_shallow_captain_stacy",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/seed-races-all.sql
+++ b/migrations/seed-races-all.sql
@@ -1,5 +1,5 @@
 -- 自動生成: generate-seed-races.js
--- 生成日時: 2026-06-07T06:16:42.994Z
+-- 生成日時: 2026-06-07T14:20:37.173Z
 -- 対象ファイル数: 80 件（既存 2 件はskip）
 
 -- ==================
@@ -13,6 +13,7 @@ DELETE FROM access_points WHERE race_id = 'abashiri-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'abashiri-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'abashiri-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'abashiri-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'abashiri-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'abashiri-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'abashiri-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'abashiri-marathon-2026';
@@ -80,6 +81,8 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
   ('abashiri-marathon-2026', 'full', 42.195, 390, '08:45', 2600, 12000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('abashiri-marathon-2026', '["goods"]', 'YAMAtune製オリジナルソックス、ランニンググローブ、おもてなしブース飲食券', '', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('abashiri-marathon-2026', '["medal"]', 'YAMAtune製オリジナルソックス、ランニンググローブ、おもてなしブース飲食券', '', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('abashiri-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-01', '2026-07-16', NULL, 0);
 
@@ -94,6 +97,7 @@ DELETE FROM access_points WHERE race_id = 'akita-nairiku-ultra-2026';
 DELETE FROM nearby_spots WHERE race_id = 'akita-nairiku-ultra-2026';
 DELETE FROM weather_history WHERE race_id = 'akita-nairiku-ultra-2026';
 DELETE FROM participation_gifts WHERE race_id = 'akita-nairiku-ultra-2026';
+DELETE FROM completion_gifts WHERE race_id = 'akita-nairiku-ultra-2026';
 DELETE FROM race_entry_links WHERE race_id = 'akita-nairiku-ultra-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'akita-nairiku-ultra-2026';
 DELETE FROM race_results WHERE race_id = 'akita-nairiku-ultra-2026';
@@ -183,6 +187,7 @@ DELETE FROM access_points WHERE race_id = 'aomori-sakura-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'aomori-sakura-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'aomori-sakura-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'aomori-sakura-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'aomori-sakura-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'aomori-sakura-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'aomori-sakura-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'aomori-sakura-marathon-2026';
@@ -256,6 +261,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('aomori-sakura-marathon-2026', '観光地', '弘前城・弘前公園', 'Hirosaki Castle & Park', '日本屈指の桜の名所。4月下旬は桜まつりの時期と重なる可能性あり。', 'One of Japan''s top cherry blossom spots. Late April may coincide with the cherry blossom festival.', '青森市から車約1時間', NULL, 40.6072, 140.4639);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('aomori-sakura-marathon-2026', '["tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('aomori-sakura-marathon-2026', '["medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('aomori-sakura-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-11-01', '2026-01-30', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -276,6 +283,7 @@ DELETE FROM access_points WHERE race_id = 'asahikawa-half-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'asahikawa-half-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'asahikawa-half-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'asahikawa-half-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'asahikawa-half-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'asahikawa-half-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'asahikawa-half-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'asahikawa-half-marathon-2026';
@@ -359,6 +367,7 @@ DELETE FROM access_points WHERE race_id = 'beppu-oita-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'beppu-oita-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'beppu-oita-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'beppu-oita-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'beppu-oita-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'beppu-oita-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'beppu-oita-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'beppu-oita-marathon-2026';
@@ -448,6 +457,7 @@ DELETE FROM access_points WHERE race_id = 'biwako-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'biwako-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'biwako-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'biwako-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'biwako-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'biwako-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'biwako-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'biwako-marathon-2026';
@@ -535,6 +545,7 @@ DELETE FROM access_points WHERE race_id = 'chiba-aqualine-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'chiba-aqualine-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'chiba-aqualine-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'chiba-aqualine-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'chiba-aqualine-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'chiba-aqualine-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'chiba-aqualine-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'chiba-aqualine-marathon-2026';
@@ -604,6 +615,8 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
   ('chiba-aqualine-marathon-2026', 'half', 21.0975, 205, '09:45', 5000, 13500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 1);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('chiba-aqualine-marathon-2026', '["tshirt"]', '参加賞Tシャツ、完走メダル', '', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('chiba-aqualine-marathon-2026', '["medal"]', '参加賞Tシャツ、完走メダル', '', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('chiba-aqualine-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-03-22', '2026-04-12', 16500, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
@@ -626,6 +639,7 @@ DELETE FROM access_points WHERE race_id = 'ehime-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'ehime-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'ehime-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'ehime-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'ehime-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'ehime-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'ehime-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'ehime-marathon-2026';
@@ -697,6 +711,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('ehime-marathon-2026', '観光地', '松山城', 'Matsuyama Castle', '現存12天守の一つ。コース上から望める。ロープウェイで天守閣へ。', 'One of Japan''s 12 surviving original castle keeps. Visible from the course. Ropeway access to the keep.', 'コース付近', NULL, 33.8456, 132.7656);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('ehime-marathon-2026', '["tshirt","towel"]', '大会オリジナルTシャツ、完走メダル、今治タオル（完走者）', 'Official race T-shirt, Finisher medal, Imabari towel (finishers)', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('ehime-marathon-2026', '["medal"]', '大会オリジナルTシャツ、完走メダル、今治タオル（完走者）', 'Official race T-shirt, Finisher medal, Imabari towel (finishers)', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('ehime-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-08-01', '2025-08-19', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -715,6 +731,7 @@ DELETE FROM access_points WHERE race_id = 'fuji-mountain-race-2026';
 DELETE FROM nearby_spots WHERE race_id = 'fuji-mountain-race-2026';
 DELETE FROM weather_history WHERE race_id = 'fuji-mountain-race-2026';
 DELETE FROM participation_gifts WHERE race_id = 'fuji-mountain-race-2026';
+DELETE FROM completion_gifts WHERE race_id = 'fuji-mountain-race-2026';
 DELETE FROM race_entry_links WHERE race_id = 'fuji-mountain-race-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'fuji-mountain-race-2026';
 DELETE FROM race_results WHERE race_id = 'fuji-mountain-race-2026';
@@ -804,6 +821,7 @@ DELETE FROM access_points WHERE race_id = 'fujisan-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'fujisan-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'fujisan-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'fujisan-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'fujisan-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'fujisan-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'fujisan-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'fujisan-marathon-2026';
@@ -873,6 +891,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('fujisan-marathon-2026', '温泉', '河口湖温泉', 'Lake Kawaguchi Onsen', '河口湖畔の温泉。富士山を望む露天風呂が魅力。レース後に最適。', 'Hot springs on the shore of Lake Kawaguchi. Open-air baths with Mt. Fuji views.', '会場付近', NULL, 35.51, 138.75);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('fujisan-marathon-2026', '["tshirt","towel"]', '大会Tシャツ、完走メダル、フィニッシャータオル', 'Race T-shirt, Finisher medal, Finisher towel', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('fujisan-marathon-2026', '["medal"]', '大会Tシャツ、完走メダル、フィニッシャータオル', 'Race T-shirt, Finisher medal, Finisher towel', NULL, 0);
 INSERT OR REPLACE INTO race_entry_links (race_id, site_name, url, sort_order) VALUES
   ('fujisan-marathon-2026', 'RUNNET', 'https://runnet.jp/parts/2026/392477/entry2.html', 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
@@ -889,6 +909,7 @@ DELETE FROM access_points WHERE race_id = 'fukuchiyama-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'fukuchiyama-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'fukuchiyama-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'fukuchiyama-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'fukuchiyama-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'fukuchiyama-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'fukuchiyama-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'fukuchiyama-marathon-2026';
@@ -960,6 +981,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('fukuchiyama-marathon-2026', '温泉', '天の湯', 'Ame no Yu Hot Spring', '福知山市内の温泉施設。レース後のリカバリーに利用できる。', 'Hot spring facility in Fukuchiyama. Available for post-race recovery.', '福知山市内', NULL, 35.295, 135.12);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('fukuchiyama-marathon-2026', '["tshirt"]', '完走メダル、大会オリジナルTシャツ（レイト・直前申込を除く）', 'Finisher medal, Official race T-shirt (excluding late/last-minute entries)', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('fukuchiyama-marathon-2026', '["medal"]', '完走メダル、大会オリジナルTシャツ（レイト・直前申込を除く）', 'Finisher medal, Official race T-shirt (excluding late/last-minute entries)', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('fukuchiyama-marathon-2026', NULL, '早割', 'Early Bird', '2026-05-01', '2026-05-31', 10000, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
@@ -978,6 +1001,7 @@ DELETE FROM access_points WHERE race_id = 'fukui-sakura-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'fukui-sakura-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'fukui-sakura-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'fukui-sakura-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'fukui-sakura-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'fukui-sakura-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'fukui-sakura-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'fukui-sakura-marathon-2026';
@@ -1053,6 +1077,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('fukui-sakura-marathon-2026', 'グルメ', '越前おろしそば', 'Echizen Oroshi Soba', '大根おろしとだしで食べる福井名物のそば。レース後のエネルギー補給に。', 'Fukui''s specialty soba with grated radish and broth. For post-race energy.', '福井市内', NULL, 36.0652, 136.2199);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('fukui-sakura-marathon-2026', '["tshirt","towel"]', '大会Tシャツ、完走メダル、フィニッシャータオル', 'Race T-shirt, Finisher medal, Finisher towel', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('fukui-sakura-marathon-2026', '["medal"]', '大会Tシャツ、完走メダル、フィニッシャータオル', 'Race T-shirt, Finisher medal, Finisher towel', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('fukui-sakura-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-09-25', '2025-11-10', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -1071,6 +1097,7 @@ DELETE FROM access_points WHERE race_id = 'fukuoka-international-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'fukuoka-international-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'fukuoka-international-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'fukuoka-international-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'fukuoka-international-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'fukuoka-international-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'fukuoka-international-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'fukuoka-international-marathon-2026';
@@ -1158,6 +1185,7 @@ DELETE FROM access_points WHERE race_id = 'fukuoka-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'fukuoka-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'fukuoka-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'fukuoka-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'fukuoka-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'fukuoka-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'fukuoka-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'fukuoka-marathon-2026';
@@ -1241,6 +1269,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('fukuoka-marathon-2026', '温泉', '二丈温泉きららの湯', 'Nijo Onsen Kirara no Yu', '糸島・二丈エリアの温泉施設。コース沿いでレース後のリカバリーに最適。', 'Hot spring facility in the Itoshima/Nijo area. Ideal for post-race recovery near the course.', '糸島市内', NULL, 33.54, 130.16);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('fukuoka-marathon-2026', '["tshirt"]', '完走メダル、大会オリジナルTシャツ', 'Finisher medal, Official race T-shirt', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('fukuoka-marathon-2026', '["medal"]', '完走メダル、大会オリジナルTシャツ', 'Finisher medal, Official race T-shirt', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('fukuoka-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-20', '2026-05-20', 16000, 0);
 
@@ -1255,6 +1285,7 @@ DELETE FROM access_points WHERE race_id = 'gunma-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'gunma-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'gunma-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'gunma-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'gunma-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'gunma-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'gunma-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'gunma-marathon-2026';
@@ -1340,6 +1371,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
 Translated with DeepL.com (free version)', '', 'https://worldheritage.pref.gunma.jp/whc/', 36.2551968, 138.8850047);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('gunma-marathon-2026', '["tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('gunma-marathon-2026', '["medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('gunma-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-09', '2026-05-13', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -1362,6 +1395,7 @@ DELETE FROM access_points WHERE race_id = 'higashine-sakuranbo-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'higashine-sakuranbo-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'higashine-sakuranbo-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'higashine-sakuranbo-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'higashine-sakuranbo-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'higashine-sakuranbo-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'higashine-sakuranbo-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'higashine-sakuranbo-marathon-2026';
@@ -1451,6 +1485,7 @@ DELETE FROM access_points WHERE race_id = 'higashinipon-half-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'higashinipon-half-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'higashinipon-half-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'higashinipon-half-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'higashinipon-half-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'higashinipon-half-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'higashinipon-half-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'higashinipon-half-marathon-2026';
@@ -1536,6 +1571,7 @@ DELETE FROM access_points WHERE race_id = 'himeji-castle-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'himeji-castle-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'himeji-castle-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'himeji-castle-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'himeji-castle-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'himeji-castle-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'himeji-castle-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'himeji-castle-marathon-2026';
@@ -1605,6 +1641,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('himeji-castle-marathon-2026', '観光地', '姫路城', 'Himeji Castle', '世界遺産・国宝の白鷺城。日本で最も美しい城の一つ。コース上から望める。', 'A World Heritage and National Treasure. One of Japan''s most beautiful castles. Visible from the course.', 'コース上', NULL, 34.8394, 134.6939);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('himeji-castle-marathon-2026', '["tshirt","towel"]', '大会Tシャツ、完走メダル、フィニッシャータオル', 'Race T-shirt, Finisher medal, Finisher towel', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('himeji-castle-marathon-2026', '["medal"]', '大会Tシャツ、完走メダル、フィニッシャータオル', 'Race T-shirt, Finisher medal, Finisher towel', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('himeji-castle-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-08-04', '2025-10-31', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -1621,6 +1659,7 @@ DELETE FROM access_points WHERE race_id = 'hitachi-seaside-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'hitachi-seaside-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'hitachi-seaside-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'hitachi-seaside-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'hitachi-seaside-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'hitachi-seaside-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'hitachi-seaside-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'hitachi-seaside-marathon-2026';
@@ -1696,6 +1735,12 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
 
 完走賞
 （完走メダル）', '', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('hitachi-seaside-marathon-2026', '["medal"]', '出走特典
+（タオル）
+
+完走賞
+（完走メダル）', '', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('hitachi-seaside-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-13', '2026-08-31', 10000, 0);
 
@@ -1710,6 +1755,7 @@ DELETE FROM access_points WHERE race_id = 'hofu-yomiuri-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'hofu-yomiuri-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'hofu-yomiuri-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'hofu-yomiuri-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'hofu-yomiuri-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'hofu-yomiuri-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'hofu-yomiuri-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'hofu-yomiuri-marathon-2026';
@@ -1777,6 +1823,8 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
   ('hofu-yomiuri-marathon-2026', 'full', 42.195, 240, '12:03', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('hofu-yomiuri-marathon-2026', '観光地', '防府天満宮', 'Hofu Tenmangu', '日本三大天神の一つ。学問の神様・菅原道真を祀る。コース付近。', 'One of Japan''s three great Tenmangu shrines. Enshrines Sugawara no Michizane, deity of learning.', 'コース付近', NULL, 34.0478, 131.5711);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('hofu-yomiuri-marathon-2026', '["medal"]', '完走メダル', 'Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
   ('hofu-yomiuri-marathon-2026', NULL, NULL, '防府天満宮付近', 'Near Hofu Tenmangu Shrine', NULL, NULL, 0);
 
@@ -1791,6 +1839,7 @@ DELETE FROM access_points WHERE race_id = 'hokkaido-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'hokkaido-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'hokkaido-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'hokkaido-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'hokkaido-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'hokkaido-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'hokkaido-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'hokkaido-marathon-2026';
@@ -1864,6 +1913,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('hokkaido-marathon-2026', '温泉', '定山渓温泉', 'Jozankei Onsen', '札幌の奥座敷と呼ばれる温泉地。レース翌日の観光に。札幌中心部からバスで約60分。', 'Known as Sapporo''s inner parlor. For sightseeing the day after. About 60 min by bus from central Sapporo.', '札幌中心部からバス約60分', NULL, 42.9694, 141.1667);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('hokkaido-marathon-2026', '["tshirt"]', '大会オリジナルTシャツ、完走メダル', 'Official race T-shirt, Finisher medal', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('hokkaido-marathon-2026', '["medal"]', '大会オリジナルTシャツ、完走メダル', 'Official race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('hokkaido-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-03-29', '2026-04-24', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -1884,6 +1935,7 @@ DELETE FROM access_points WHERE race_id = 'ibusuki-nanohana-2026';
 DELETE FROM nearby_spots WHERE race_id = 'ibusuki-nanohana-2026';
 DELETE FROM weather_history WHERE race_id = 'ibusuki-nanohana-2026';
 DELETE FROM participation_gifts WHERE race_id = 'ibusuki-nanohana-2026';
+DELETE FROM completion_gifts WHERE race_id = 'ibusuki-nanohana-2026';
 DELETE FROM race_entry_links WHERE race_id = 'ibusuki-nanohana-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'ibusuki-nanohana-2026';
 DELETE FROM race_results WHERE race_id = 'ibusuki-nanohana-2026';
@@ -1977,6 +2029,7 @@ DELETE FROM access_points WHERE race_id = 'ichinoseki-half-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'ichinoseki-half-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'ichinoseki-half-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'ichinoseki-half-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'ichinoseki-half-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'ichinoseki-half-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'ichinoseki-half-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'ichinoseki-half-marathon-2026';
@@ -2060,6 +2113,7 @@ DELETE FROM access_points WHERE race_id = 'iki-ultra-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'iki-ultra-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'iki-ultra-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'iki-ultra-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'iki-ultra-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'iki-ultra-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'iki-ultra-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'iki-ultra-marathon-2026';
@@ -2143,6 +2197,7 @@ DELETE FROM access_points WHERE race_id = 'itabashi-city-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'itabashi-city-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'itabashi-city-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'itabashi-city-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'itabashi-city-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'itabashi-city-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'itabashi-city-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'itabashi-city-marathon-2026';
@@ -2214,6 +2269,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('itabashi-city-marathon-2026', '観光地', '荒川河川敷', 'Arakawa Riverbank', 'フラットな河川敷コース。記録を狙うランナーに人気の定番コース。', 'A flat riverbank course. A classic course popular with runners aiming for personal records.', 'コース上', NULL, 35.7917, 139.675);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('itabashi-city-marathon-2026', '["tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('itabashi-city-marathon-2026', '["medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('itabashi-city-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-08-01', '2025-11-24', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -2230,6 +2287,7 @@ DELETE FROM access_points WHERE race_id = 'iwaki-sunshine-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'iwaki-sunshine-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'iwaki-sunshine-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'iwaki-sunshine-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'iwaki-sunshine-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'iwaki-sunshine-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'iwaki-sunshine-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'iwaki-sunshine-marathon-2026';
@@ -2305,6 +2363,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('iwaki-sunshine-marathon-2026', '温泉', 'いわき湯本温泉', 'Iwaki Yumoto Onsen', 'いわき市の歴史ある温泉地。レース後のリカバリーに。', 'A historic hot spring in Iwaki. For post-race recovery.', 'いわき市内', NULL, 36.9744, 140.8456);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('iwaki-sunshine-marathon-2026', '["tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('iwaki-sunshine-marathon-2026', '["medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('iwaki-sunshine-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-09-12', '2025-10-15', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -2321,6 +2381,7 @@ DELETE FROM access_points WHERE race_id = 'iwate-morioka-city-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'iwate-morioka-city-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'iwate-morioka-city-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'iwate-morioka-city-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'iwate-morioka-city-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'iwate-morioka-city-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'iwate-morioka-city-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'iwate-morioka-city-marathon-2026';
@@ -2418,6 +2479,8 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
   ('iwate-morioka-city-marathon-2026', 'full', 42.195, 360, '09:00', 6000, 12000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('iwate-morioka-city-marathon-2026', '["towel"]', '完走賞	フィニッシャータオル、南部鉄器製完走メダル', '', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('iwate-morioka-city-marathon-2026', '["medal"]', '完走賞	フィニッシャータオル、南部鉄器製完走メダル', '', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('iwate-morioka-city-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-01', '2026-07-20', 12000, 0);
 
@@ -2432,6 +2495,7 @@ DELETE FROM access_points WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
@@ -2503,6 +2567,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('iwate-oshu-kirameki-marathon-2026', '観光地', '中尊寺金色堂', 'Chusonji Konjikido', '世界遺産・平泉。奥州藤原氏の栄華を伝える。奥州市から車約30分。', 'World Heritage Hiraizumi. Tells of the glory of the Oshu Fujiwara clan. About 30 min by car from Oshu.', '奥州市から車約30分', NULL, 39, 141.1);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('iwate-oshu-kirameki-marathon-2026', '["tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('iwate-oshu-kirameki-marathon-2026', '["medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('iwate-oshu-kirameki-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-11-28', '2026-02-28', NULL, 0);
 
@@ -2517,6 +2583,7 @@ DELETE FROM access_points WHERE race_id = 'izu-oshima-2026';
 DELETE FROM nearby_spots WHERE race_id = 'izu-oshima-2026';
 DELETE FROM weather_history WHERE race_id = 'izu-oshima-2026';
 DELETE FROM participation_gifts WHERE race_id = 'izu-oshima-2026';
+DELETE FROM completion_gifts WHERE race_id = 'izu-oshima-2026';
 DELETE FROM race_entry_links WHERE race_id = 'izu-oshima-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'izu-oshima-2026';
 DELETE FROM race_results WHERE race_id = 'izu-oshima-2026';
@@ -2611,6 +2678,8 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
   ('izu-oshima-2026', 'half', 21.0975, 180, '08:20', 0, 7400, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 1);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('izu-oshima-2026', '10k', 10, 100, '09:00', 0, 5400, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 2);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('izu-oshima-2026', '["medal"]', 'オリジナル完走メダル', '', NULL, 0);
 INSERT OR REPLACE INTO race_entry_links (race_id, site_name, url, sort_order) VALUES
   ('izu-oshima-2026', 'RUNNET', 'https://runnet.jp/entry/runtes/user/pc/competitionDetailAction.do?raceId=392378&div=1', 0);
 INSERT OR REPLACE INTO race_entry_links (race_id, site_name, url, sort_order) VALUES
@@ -2631,6 +2700,7 @@ DELETE FROM access_points WHERE race_id = 'kagawa-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'kagawa-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'kagawa-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'kagawa-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'kagawa-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'kagawa-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'kagawa-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'kagawa-marathon-2026';
@@ -2716,6 +2786,7 @@ DELETE FROM access_points WHERE race_id = 'kagoshima-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'kagoshima-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'kagoshima-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'kagoshima-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'kagoshima-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'kagoshima-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'kagoshima-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'kagoshima-marathon-2026';
@@ -2787,6 +2858,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('kagoshima-marathon-2026', '温泉', '指宿温泉', 'Ibusuki Onsen', '砂むし温泉で有名。鹿児島市から特急で約1時間。レース翌日の遠足に。', 'Famous for sand steam baths. About 1 hour by express from Kagoshima. Day trip the day after.', '鹿児島市から特急約1時間', NULL, 31.25, 130.65);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('kagoshima-marathon-2026', '["tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('kagoshima-marathon-2026', '["medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kagoshima-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-08-08', '2025-11-16', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -2805,6 +2878,7 @@ DELETE FROM access_points WHERE race_id = 'kaikyo-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'kaikyo-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'kaikyo-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'kaikyo-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'kaikyo-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'kaikyo-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'kaikyo-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'kaikyo-marathon-2026';
@@ -2878,6 +2952,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('kaikyo-marathon-2026', 'グルメ', 'ふくの里', 'Fuku no Sato', '下関名物のふぐ料理を堪能できるエリア。レース後のご褒美食事に最適。', 'Area to enjoy Shimonoseki''s famous fugu cuisine. Perfect post-race reward.', '下関市内', NULL, 33.955, 130.945);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('kaikyo-marathon-2026', '["tshirt"]', '完走メダル、大会オリジナルTシャツ', 'Finisher medal, Official race T-shirt', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('kaikyo-marathon-2026', '["medal"]', '完走メダル、大会オリジナルTシャツ', 'Finisher medal, Official race T-shirt', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kaikyo-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-05-15', '2026-07-12', 12000, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -2898,6 +2974,7 @@ DELETE FROM access_points WHERE race_id = 'kanazawa-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'kanazawa-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'kanazawa-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'kanazawa-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'kanazawa-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'kanazawa-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'kanazawa-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'kanazawa-marathon-2026';
@@ -2971,6 +3048,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('kanazawa-marathon-2026', '温泉', '金沢駅周辺の温泉施設', 'Hot spring facilities near Kanazawa Station', '金沢駅周辺には日帰り温泉施設あり。レース後のリカバリーに。', 'Day-trip hot spring facilities available near Kanazawa Station. For post-race recovery.', '金沢駅周辺', NULL, 36.5781, 136.6486);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('kanazawa-marathon-2026', '["tshirt","local_product"]', '大会オリジナルTシャツ、完走メダル、地元特産品', 'Official race T-shirt, Finisher medal, Local specialty products', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('kanazawa-marathon-2026', '["medal"]', '大会オリジナルTシャツ、完走メダル、地元特産品', 'Official race T-shirt, Finisher medal, Local specialty products', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kanazawa-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-10', '2026-05-20', 14000, 0);
 
@@ -2985,6 +3064,7 @@ DELETE FROM access_points WHERE race_id = 'kasama-togeinosato-half-2025-2025';
 DELETE FROM nearby_spots WHERE race_id = 'kasama-togeinosato-half-2025-2025';
 DELETE FROM weather_history WHERE race_id = 'kasama-togeinosato-half-2025-2025';
 DELETE FROM participation_gifts WHERE race_id = 'kasama-togeinosato-half-2025-2025';
+DELETE FROM completion_gifts WHERE race_id = 'kasama-togeinosato-half-2025-2025';
 DELETE FROM race_entry_links WHERE race_id = 'kasama-togeinosato-half-2025-2025';
 DELETE FROM race_entry_periods WHERE race_id = 'kasama-togeinosato-half-2025-2025';
 DELETE FROM race_results WHERE race_id = 'kasama-togeinosato-half-2025-2025';
@@ -3088,6 +3168,7 @@ DELETE FROM access_points WHERE race_id = 'kasumigaura-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'kasumigaura-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'kasumigaura-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'kasumigaura-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'kasumigaura-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'kasumigaura-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'kasumigaura-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'kasumigaura-marathon-2026';
@@ -3161,6 +3242,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('kasumigaura-marathon-2026', '観光地', '霞ヶ浦', 'Lake Kasumigaura', '日本第2位の面積を持つ湖。コースで湖畔を走る。広大な水面は壮観。', 'Japan''s second largest lake. Run along the lakeshore. The vast water surface is spectacular.', 'コース上', NULL, 36.0333, 140.3333);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('kasumigaura-marathon-2026', '["tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('kasumigaura-marathon-2026', '["medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kasumigaura-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-12-01', '2026-01-25', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -3177,6 +3260,7 @@ DELETE FROM access_points WHERE race_id = 'katsuta-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'katsuta-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'katsuta-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'katsuta-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'katsuta-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'katsuta-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'katsuta-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'katsuta-marathon-2026';
@@ -3264,6 +3348,7 @@ DELETE FROM access_points WHERE race_id = 'kitakyushu-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'kitakyushu-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'kitakyushu-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'kitakyushu-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'kitakyushu-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'kitakyushu-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'kitakyushu-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'kitakyushu-marathon-2026';
@@ -3335,6 +3420,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('kitakyushu-marathon-2026', '観光地', '門司港レトロ', 'Mojiko Retro', '大正ロマンの雰囲気が残る港町。焼きカレーが名物。', 'A port town with Taisho-era atmosphere. Famous for baked curry.', '小倉から電車約15分', NULL, 33.95, 130.9611);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('kitakyushu-marathon-2026', '["tshirt","towel"]', '大会Tシャツ、完走メダル、フィニッシャータオル', 'Race T-shirt, Finisher medal, Finisher towel', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('kitakyushu-marathon-2026', '["medal"]', '大会Tシャツ、完走メダル、フィニッシャータオル', 'Race T-shirt, Finisher medal, Finisher towel', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kitakyushu-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-08-08', '2025-09-25', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -3353,6 +3440,7 @@ DELETE FROM access_points WHERE race_id = 'kix-senshu-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'kix-senshu-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'kix-senshu-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'kix-senshu-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'kix-senshu-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'kix-senshu-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'kix-senshu-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'kix-senshu-marathon-2026';
@@ -3438,6 +3526,7 @@ DELETE FROM access_points WHERE race_id = 'kobe-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'kobe-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'kobe-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'kobe-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'kobe-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'kobe-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'kobe-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'kobe-marathon-2026';
@@ -3529,6 +3618,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('kobe-marathon-2026', 'グルメ', '神戸牛', 'Kobe Beef', '世界的に有名なブランド和牛。レース後のご褒美に。三宮・元町エリアに名店多数。', 'World-famous premium wagyu beef. A reward after the race. Many restaurants in Sannomiya-Motomachi area.', '三宮・元町エリア', NULL, 34.6913, 135.1956);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('kobe-marathon-2026', '["tshirt","towel"]', '大会オリジナルTシャツ、完走メダル、フィニッシャータオル', 'Official race T-shirt, Finisher medal, Finisher towel', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('kobe-marathon-2026', '["medal"]', '大会オリジナルTシャツ、完走メダル、フィニッシャータオル', 'Official race T-shirt, Finisher medal, Finisher towel', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kobe-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-17', '2026-06-01', 18000, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -3549,6 +3640,7 @@ DELETE FROM access_points WHERE race_id = 'kochi-ryoma-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'kochi-ryoma-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'kochi-ryoma-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'kochi-ryoma-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'kochi-ryoma-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'kochi-ryoma-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'kochi-ryoma-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'kochi-ryoma-marathon-2026';
@@ -3620,6 +3712,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('kochi-ryoma-marathon-2026', 'グルメ', 'カツオのたたき', 'Katsuo no Tataki', '高知を代表するグルメ。藁焼きで仕上げた鰹のたたきは絶品。ひろめ市場で気軽に楽しめる。', 'Kochi''s signature dish. Straw-grilled bonito tataki is exquisite. Enjoy casually at Hirome Market.', '高知市内', NULL, 33.5589, 133.5311);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('kochi-ryoma-marathon-2026', '["tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('kochi-ryoma-marathon-2026', '["medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kochi-ryoma-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-08-01', '2025-10-31', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -3640,6 +3734,7 @@ DELETE FROM access_points WHERE race_id = 'kumamoto-castle-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'kumamoto-castle-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'kumamoto-castle-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'kumamoto-castle-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'kumamoto-castle-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'kumamoto-castle-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'kumamoto-castle-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'kumamoto-castle-marathon-2026';
@@ -3711,6 +3806,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('kumamoto-castle-marathon-2026', 'グルメ', '馬刺し・太平燕', 'Horse Sashimi & Taipien', '熊本を代表するグルメ。馬刺しと太平燕（春雨スープ）はぜひ試したい。', 'Kumamoto''s signature dishes. Horse sashimi and taipien (glass noodle soup) are must-tries.', '熊本市内', NULL, 32.8032, 130.7079);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('kumamoto-castle-marathon-2026', '["tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('kumamoto-castle-marathon-2026', '["medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kumamoto-castle-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-07-29', '2025-09-24', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -3727,6 +3824,7 @@ DELETE FROM access_points WHERE race_id = 'kyoto-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'kyoto-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'kyoto-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'kyoto-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'kyoto-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'kyoto-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'kyoto-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'kyoto-marathon-2026';
@@ -3800,6 +3898,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('kyoto-marathon-2026', '温泉', 'さがの温泉 天山の湯', 'Sagano Onsen Tenzan no Yu', '嵐山エリアの天然温泉。レース後のリカバリーに。', 'Natural hot spring in the Arashiyama area. For post-race recovery.', '嵐山エリア', NULL, 35.0167, 135.6833);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('kyoto-marathon-2026', '["tshirt"]', '大会オリジナルTシャツ、完走メダル', 'Official race T-shirt, Finisher medal', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('kyoto-marathon-2026', '["medal"]', '大会オリジナルTシャツ、完走メダル', 'Official race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kyoto-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-07-17', '2025-09-22', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -3824,6 +3924,7 @@ DELETE FROM access_points WHERE race_id = 'mie-matsusaka-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'mie-matsusaka-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'mie-matsusaka-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'mie-matsusaka-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'mie-matsusaka-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'mie-matsusaka-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'mie-matsusaka-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'mie-matsusaka-marathon-2026';
@@ -3893,6 +3994,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('mie-matsusaka-marathon-2026', 'グルメ', '松阪牛', 'Matsusaka Beef', '日本三大和牛の一つ。レース後のご褒美に。', 'One of Japan''s three premium wagyu. A reward after the race.', '松阪市内', NULL, 34.5778, 136.5312);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('mie-matsusaka-marathon-2026', '["tshirt","local_product"]', '大会Tシャツ、完走メダル、松阪の特産品', 'Race T-shirt, Finisher medal, Matsusaka local products', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('mie-matsusaka-marathon-2026', '["medal"]', '大会Tシャツ、完走メダル、松阪の特産品', 'Race T-shirt, Finisher medal, Matsusaka local products', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
   ('mie-matsusaka-marathon-2026', NULL, NULL, '松阪の城下町', 'Matsusaka castle town', NULL, NULL, 0);
 
@@ -3907,6 +4010,7 @@ DELETE FROM access_points WHERE race_id = 'mito-komon-manyu-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'mito-komon-manyu-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'mito-komon-manyu-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'mito-komon-manyu-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'mito-komon-manyu-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'mito-komon-manyu-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'mito-komon-manyu-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'mito-komon-manyu-marathon-2026';
@@ -3976,6 +4080,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('mito-komon-manyu-marathon-2026', '観光地', '偕楽園', 'Kairakuen Garden', '日本三名園の一つ。2〜3月は梅まつりで有名。コース上から望める。', 'One of Japan''s three most beautiful gardens. Famous for plum blossom festival in Feb-Mar.', 'コース付近', NULL, 36.3811, 140.4511);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('mito-komon-manyu-marathon-2026', '["tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('mito-komon-manyu-marathon-2026', '["medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_links (race_id, site_name, url, sort_order) VALUES
   ('mito-komon-manyu-marathon-2026', 'RUNNET', 'https://runnet.jp/entry/runtes/user/pc/competitionDetailAction.do?raceId=387694&div=1', 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
@@ -3992,6 +4098,7 @@ DELETE FROM access_points WHERE race_id = 'mtfuji-climb-run-2026';
 DELETE FROM nearby_spots WHERE race_id = 'mtfuji-climb-run-2026';
 DELETE FROM weather_history WHERE race_id = 'mtfuji-climb-run-2026';
 DELETE FROM participation_gifts WHERE race_id = 'mtfuji-climb-run-2026';
+DELETE FROM completion_gifts WHERE race_id = 'mtfuji-climb-run-2026';
 DELETE FROM race_entry_links WHERE race_id = 'mtfuji-climb-run-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'mtfuji-climb-run-2026';
 DELETE FROM race_results WHERE race_id = 'mtfuji-climb-run-2026';
@@ -4091,6 +4198,7 @@ DELETE FROM access_points WHERE race_id = 'nagai-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'nagai-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'nagai-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'nagai-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'nagai-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'nagai-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'nagai-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'nagai-marathon-2026';
@@ -4180,6 +4288,7 @@ DELETE FROM access_points WHERE race_id = 'nagoya-womens-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'nagoya-womens-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'nagoya-womens-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'nagoya-womens-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'nagoya-womens-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'nagoya-womens-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'nagoya-womens-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'nagoya-womens-marathon-2026';
@@ -4251,6 +4360,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('nagoya-womens-marathon-2026', 'グルメ', '名古屋めし', 'Nagoya Meshi', '味噌カツ、ひつまぶし、手羽先など名古屋名物が充実。レース後のご褒美に。', 'Miso katsu, hitsumabushi, chicken wings and more Nagoya specialties. A reward after the race.', '名古屋市内', NULL, 35.1709, 136.8815);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('nagoya-womens-marathon-2026', '["goods"]', 'ティファニー オリジナルペンダント（完走者全員）', 'Tiffany original pendant (all finishers)', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('nagoya-womens-marathon-2026', '["medal"]', 'ティファニー オリジナルペンダント（完走者全員）', 'Tiffany original pendant (all finishers)', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
   ('nagoya-womens-marathon-2026', NULL, NULL, '名古屋ドーム（バンテリンドーム ナゴヤ）', 'Nagoya Dome (Vantelin Dome Nagoya)', NULL, NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -4267,6 +4378,7 @@ DELETE FROM access_points WHERE race_id = 'naha-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'naha-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'naha-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'naha-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'naha-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'naha-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'naha-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'naha-marathon-2026';
@@ -4338,6 +4450,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('naha-marathon-2026', 'グルメ', '沖縄そば', 'Okinawa Soba', '沖縄を代表するご当地グルメ。あっさりとしたスープと太麺が特徴。レース後のエネルギー補給に。', 'Okinawa''s signature local dish. Characterized by light broth and thick noodles. Perfect for post-race energy.', '那覇市内各所', NULL, 26.3344, 127.7679);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('naha-marathon-2026', '["tshirt"]', '大会オリジナルTシャツ、完走メダル', 'Official race T-shirt, Finisher medal', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('naha-marathon-2026', '["medal"]', '大会オリジナルTシャツ、完走メダル', 'Official race T-shirt, Finisher medal', NULL, 0);
 
 -- ==================
 -- 奈良マラソン (nara-marathon-2026)
@@ -4350,6 +4464,7 @@ DELETE FROM access_points WHERE race_id = 'nara-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'nara-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'nara-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'nara-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'nara-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'nara-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'nara-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'nara-marathon-2026';
@@ -4421,6 +4536,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('nara-marathon-2026', '温泉', 'ゆららの湯 奈良店', 'Yurara no Yu Nara', '奈良市内の日帰り温泉施設。レース後のリカバリーに便利。', 'A day-trip hot spring facility in Nara city. Convenient for post-race recovery.', '奈良市内', NULL, 34.6851, 135.8048);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('nara-marathon-2026', '["tshirt","towel"]', '大会オリジナルTシャツ、完走メダル、フィニッシャータオル', 'Official race T-shirt, Finisher medal, Finisher towel', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('nara-marathon-2026', '["medal"]', '大会オリジナルTシャツ、完走メダル、フィニッシャータオル', 'Official race T-shirt, Finisher medal, Finisher towel', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
   ('nara-marathon-2026', NULL, NULL, '東大寺', 'Todai-ji', NULL, NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -4441,6 +4558,7 @@ DELETE FROM access_points WHERE race_id = 'niigata-city-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'niigata-city-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'niigata-city-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'niigata-city-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'niigata-city-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'niigata-city-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'niigata-city-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'niigata-city-marathon-2026';
@@ -4524,6 +4642,7 @@ DELETE FROM access_points WHERE race_id = 'nishio-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'nishio-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'nishio-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'nishio-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'nishio-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'nishio-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'nishio-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'nishio-marathon-2026';
@@ -4605,6 +4724,7 @@ DELETE FROM access_points WHERE race_id = 'okayama-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'okayama-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'okayama-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'okayama-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'okayama-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'okayama-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'okayama-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'okayama-marathon-2026';
@@ -4675,6 +4795,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('okayama-marathon-2026', '観光地', '後楽園', 'Korakuen Garden', '日本三名園の一つ。岡山城とセットで訪れたい。', 'One of Japan''s three most beautiful gardens. Visit together with Okayama Castle.', 'コース付近', NULL, 34.6694, 133.9356);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('okayama-marathon-2026', '["tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('okayama-marathon-2026', '["medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('okayama-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-16', '2026-05-18', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -4693,6 +4815,7 @@ DELETE FROM access_points WHERE race_id = 'okushinano100-2026';
 DELETE FROM nearby_spots WHERE race_id = 'okushinano100-2026';
 DELETE FROM weather_history WHERE race_id = 'okushinano100-2026';
 DELETE FROM participation_gifts WHERE race_id = 'okushinano100-2026';
+DELETE FROM completion_gifts WHERE race_id = 'okushinano100-2026';
 DELETE FROM race_entry_links WHERE race_id = 'okushinano100-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'okushinano100-2026';
 DELETE FROM race_results WHERE race_id = 'okushinano100-2026';
@@ -4795,6 +4918,7 @@ DELETE FROM access_points WHERE race_id = 'osaka-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'osaka-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'osaka-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'osaka-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'osaka-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'osaka-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'osaka-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'osaka-marathon-2026';
@@ -4868,6 +4992,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('osaka-marathon-2026', '温泉', 'スパワールド世界の大温泉', 'Spa World', '通天閣近くの大型温泉施設。レース後のリカバリーに。コースの近くにあり便利。', 'A large hot spring facility near Tsutenkaku. Convenient for post-race recovery, located near the course.', '通天閣付近', NULL, 34.6522, 135.5064);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('osaka-marathon-2026', '["tshirt","towel"]', '参加記念Tシャツ、完走メダル、フィニッシャータオル', 'Commemorative T-shirt, Finisher medal, Finisher towel', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('osaka-marathon-2026', '["medal"]', '参加記念Tシャツ、完走メダル、フィニッシャータオル', 'Commemorative T-shirt, Finisher medal, Finisher towel', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
   ('osaka-marathon-2026', NULL, NULL, '大阪城', 'Osaka Castle', NULL, NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -4888,6 +5014,7 @@ DELETE FROM access_points WHERE race_id = 'osaka-yodo-river-citizens-marathon-20
 DELETE FROM nearby_spots WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
@@ -4985,6 +5112,7 @@ DELETE FROM access_points WHERE race_id = 'osj-ontake100-2026';
 DELETE FROM nearby_spots WHERE race_id = 'osj-ontake100-2026';
 DELETE FROM weather_history WHERE race_id = 'osj-ontake100-2026';
 DELETE FROM participation_gifts WHERE race_id = 'osj-ontake100-2026';
+DELETE FROM completion_gifts WHERE race_id = 'osj-ontake100-2026';
 DELETE FROM race_entry_links WHERE race_id = 'osj-ontake100-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'osj-ontake100-2026';
 DELETE FROM race_results WHERE race_id = 'osj-ontake100-2026';
@@ -5070,6 +5198,7 @@ DELETE FROM access_points WHERE race_id = 'sado-toki-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'sado-toki-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'sado-toki-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'sado-toki-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'sado-toki-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'sado-toki-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'sado-toki-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'sado-toki-marathon-2026';
@@ -5141,6 +5270,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('sado-toki-marathon-2026', '観光地', 'トキの森公園', 'Toki no Mori Park', '国の特別天然記念物トキを間近で観察できる施設。大会のモチーフであるトキに会える。', 'A facility to observe the crested ibis, a national special natural monument, up close.', '佐渡島内', NULL, 38.0333, 138.3667);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('sado-toki-marathon-2026', '["tshirt","local_product"]', '大会Tシャツ、完走メダル、佐渡の特産品', 'Race T-shirt, Finisher medal, Sado Island local products', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('sado-toki-marathon-2026', '["medal"]', '大会Tシャツ、完走メダル、佐渡の特産品', 'Race T-shirt, Finisher medal, Sado Island local products', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('sado-toki-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-12-01', '2026-03-22', NULL, 0);
 
@@ -5155,6 +5286,7 @@ DELETE FROM access_points WHERE race_id = 'saga-sakura-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'saga-sakura-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'saga-sakura-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'saga-sakura-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'saga-sakura-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'saga-sakura-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'saga-sakura-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'saga-sakura-marathon-2026';
@@ -5224,6 +5356,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('saga-sakura-marathon-2026', '観光地', '吉野ヶ里遺跡', 'Yoshinogari Ruins', '弥生時代の大規模環濠集落遺跡。国の特別史跡。佐賀市から近い。', 'A large-scale Yayoi period moated settlement. National Special Historic Site. Close to Saga city.', '佐賀市から車約20分', NULL, 33.3167, 130.3833);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('saga-sakura-marathon-2026', '["tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('saga-sakura-marathon-2026', '["medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
   ('saga-sakura-marathon-2026', NULL, NULL, '桜並木', 'Cherry blossom trees', NULL, NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -5240,6 +5374,7 @@ DELETE FROM access_points WHERE race_id = 'saitama-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'saitama-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'saitama-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'saitama-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'saitama-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'saitama-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'saitama-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'saitama-marathon-2026';
@@ -5319,6 +5454,7 @@ DELETE FROM access_points WHERE race_id = 'sapporo-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'sapporo-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'sapporo-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'sapporo-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'sapporo-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'sapporo-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'sapporo-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'sapporo-marathon-2026';
@@ -5407,6 +5543,7 @@ DELETE FROM access_points WHERE race_id = 'shiga-kogen100-2026';
 DELETE FROM nearby_spots WHERE race_id = 'shiga-kogen100-2026';
 DELETE FROM weather_history WHERE race_id = 'shiga-kogen100-2026';
 DELETE FROM participation_gifts WHERE race_id = 'shiga-kogen100-2026';
+DELETE FROM completion_gifts WHERE race_id = 'shiga-kogen100-2026';
 DELETE FROM race_entry_links WHERE race_id = 'shiga-kogen100-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'shiga-kogen100-2026';
 DELETE FROM race_results WHERE race_id = 'shiga-kogen100-2026';
@@ -5583,6 +5720,7 @@ DELETE FROM access_points WHERE race_id = 'shimada-oigawa-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'shimada-oigawa-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'shimada-oigawa-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'shimada-oigawa-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'shimada-oigawa-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'shimada-oigawa-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'shimada-oigawa-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'shimada-oigawa-marathon-2026';
@@ -5672,6 +5810,7 @@ DELETE FROM access_points WHERE race_id = 'shinetsu5mountains-trail-100-2026';
 DELETE FROM nearby_spots WHERE race_id = 'shinetsu5mountains-trail-100-2026';
 DELETE FROM weather_history WHERE race_id = 'shinetsu5mountains-trail-100-2026';
 DELETE FROM participation_gifts WHERE race_id = 'shinetsu5mountains-trail-100-2026';
+DELETE FROM completion_gifts WHERE race_id = 'shinetsu5mountains-trail-100-2026';
 DELETE FROM race_entry_links WHERE race_id = 'shinetsu5mountains-trail-100-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'shinetsu5mountains-trail-100-2026';
 DELETE FROM race_results WHERE race_id = 'shinetsu5mountains-trail-100-2026';
@@ -5764,6 +5903,7 @@ DELETE FROM access_points WHERE race_id = 'shizuoka-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'shizuoka-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'shizuoka-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'shizuoka-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'shizuoka-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'shizuoka-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'shizuoka-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'shizuoka-marathon-2026';
@@ -5833,6 +5973,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('shizuoka-marathon-2026', '観光地', '三保松原', 'Miho no Matsubara', '世界遺産「富士山」の構成資産。松林越しの富士山の眺望が美しい。', 'Part of the World Heritage ''Mt. Fuji''. Beautiful views of Mt. Fuji through pine groves.', '静岡市内から車約30分', NULL, 35.0136, 138.5167);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('shizuoka-marathon-2026', '["tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('shizuoka-marathon-2026', '["medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 
 -- ==================
 -- 湘南国際マラソン (shonan-international-marathon-2026)
@@ -5845,6 +5987,7 @@ DELETE FROM access_points WHERE race_id = 'shonan-international-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'shonan-international-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'shonan-international-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'shonan-international-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'shonan-international-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'shonan-international-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'shonan-international-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'shonan-international-marathon-2026';
@@ -5916,6 +6059,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('shonan-international-marathon-2026', '観光地', '江の島', 'Enoshima', 'コースの折り返し地点付近。湘南のシンボル。しらす丼やサザエが名物。', 'Near the turnaround point. Symbol of Shonan. Famous for shirasu bowl and turban shell.', 'コース折り返し付近', NULL, 35.2994, 139.4806);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('shonan-international-marathon-2026', '["tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('shonan-international-marathon-2026', '["medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('shonan-international-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-04', '2026-09-09', 16000, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
@@ -5932,6 +6077,7 @@ DELETE FROM access_points WHERE race_id = 'soja-kibiji-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'soja-kibiji-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'soja-kibiji-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'soja-kibiji-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'soja-kibiji-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'soja-kibiji-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'soja-kibiji-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'soja-kibiji-marathon-2026';
@@ -6004,6 +6150,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('soja-kibiji-marathon-2026', '観光地', '備中国分寺五重塔', 'Bitchu Kokubunji Five-Story Pagoda', '吉備路のシンボル。コース上から望める。田園風景の中に立つ姿が美しい。', 'Symbol of Kibiji. Visible from the course. Beautiful standing among rice paddies.', 'コース上', NULL, 34.65, 133.7833);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('soja-kibiji-marathon-2026', '["tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('soja-kibiji-marathon-2026', '["medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('soja-kibiji-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-10-01', '2026-01-03', 9100, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -6024,6 +6172,7 @@ DELETE FROM access_points WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
@@ -6109,6 +6258,7 @@ DELETE FROM access_points WHERE race_id = 'tateyama-wakashio-2026';
 DELETE FROM nearby_spots WHERE race_id = 'tateyama-wakashio-2026';
 DELETE FROM weather_history WHERE race_id = 'tateyama-wakashio-2026';
 DELETE FROM participation_gifts WHERE race_id = 'tateyama-wakashio-2026';
+DELETE FROM completion_gifts WHERE race_id = 'tateyama-wakashio-2026';
 DELETE FROM race_entry_links WHERE race_id = 'tateyama-wakashio-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'tateyama-wakashio-2026';
 DELETE FROM race_results WHERE race_id = 'tateyama-wakashio-2026';
@@ -6180,6 +6330,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('tateyama-wakashio-2026', 'グルメ', '房総の海鮮', 'Boso Seafood', '新鮮な海鮮が楽しめる。特に寿司や刺身がおすすめ。', 'Fresh seafood. Sushi and sashimi are especially recommended.', '館山市内', NULL, 34.9997, 139.8697);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('tateyama-wakashio-2026', '["tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('tateyama-wakashio-2026', '["medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
   ('tateyama-wakashio-2026', NULL, NULL, '房総の海岸線', 'Boso coastline', NULL, NULL, 0);
 
@@ -6194,6 +6346,7 @@ DELETE FROM access_points WHERE race_id = 'tazawako-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'tazawako-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'tazawako-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'tazawako-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'tazawako-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'tazawako-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'tazawako-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'tazawako-marathon-2026';
@@ -6280,6 +6433,7 @@ DELETE FROM access_points WHERE race_id = 'tokushima-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'tokushima-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'tokushima-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'tokushima-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'tokushima-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'tokushima-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'tokushima-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'tokushima-marathon-2026';
@@ -6349,6 +6503,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('tokushima-marathon-2026', '観光地', '鳴門の渦潮', 'Naruto Whirlpools', '世界三大潮流の一つ。大鳴門橋の遊歩道から渦潮を観察できる。', 'One of the world''s three great tidal currents. Observe whirlpools from the Onaruto Bridge walkway.', '徳島市から車約1時間', NULL, 34.2333, 134.6333);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('tokushima-marathon-2026', '["tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('tokushima-marathon-2026', '["medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
   ('tokushima-marathon-2026', NULL, NULL, '吉野川', 'Yoshino River', NULL, NULL, 0);
 
@@ -6363,6 +6519,7 @@ DELETE FROM access_points WHERE race_id = 'tokyo-legacy-half-2026';
 DELETE FROM nearby_spots WHERE race_id = 'tokyo-legacy-half-2026';
 DELETE FROM weather_history WHERE race_id = 'tokyo-legacy-half-2026';
 DELETE FROM participation_gifts WHERE race_id = 'tokyo-legacy-half-2026';
+DELETE FROM completion_gifts WHERE race_id = 'tokyo-legacy-half-2026';
 DELETE FROM race_entry_links WHERE race_id = 'tokyo-legacy-half-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'tokyo-legacy-half-2026';
 DELETE FROM race_results WHERE race_id = 'tokyo-legacy-half-2026';
@@ -6501,6 +6658,8 @@ Competition Classes:
 Translated with DeepL.com (free version)', NULL, '[]', 0);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('tokyo-legacy-half-2026', '["goods"]', '', '', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('tokyo-legacy-half-2026', '["medal"]', '', '', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('tokyo-legacy-half-2026', NULL, 'ジャパンプレミアハーフ優先エントリー', 'General Entry', '2026-05-18', '2026-05-25', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
@@ -6517,6 +6676,7 @@ DELETE FROM access_points WHERE race_id = 'tokyo-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'tokyo-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'tokyo-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'tokyo-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'tokyo-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'tokyo-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'tokyo-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'tokyo-marathon-2026';
@@ -6594,6 +6754,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('tokyo-marathon-2026', 'グルメ', '東京駅周辺グルメ', 'Tokyo Station Area Dining', 'フィニッシュ地点の東京駅周辺には多数の飲食店。レース後の打ち上げに最適。', 'Numerous restaurants around Tokyo Station at the finish. Perfect for post-race celebrations.', 'フィニッシュ地点周辺', NULL, 35.6812, 139.7671);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('tokyo-marathon-2026', '["tshirt","towel"]', '参加記念Tシャツ（参加者全員）、完走メダル（完走者）、完走タオル（完走者）', 'Commemorative T-shirt (all participants), Finisher medal (finishers), Finisher towel (finishers)', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('tokyo-marathon-2026', '["medal"]', '参加記念Tシャツ（参加者全員）、完走メダル（完走者）、完走タオル（完走者）', 'Commemorative T-shirt (all participants), Finisher medal (finishers), Finisher towel (finishers)', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('tokyo-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-08-15', '2025-08-29', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -6620,6 +6782,7 @@ DELETE FROM access_points WHERE race_id = 'tokyo-marathon-2027';
 DELETE FROM nearby_spots WHERE race_id = 'tokyo-marathon-2027';
 DELETE FROM weather_history WHERE race_id = 'tokyo-marathon-2027';
 DELETE FROM participation_gifts WHERE race_id = 'tokyo-marathon-2027';
+DELETE FROM completion_gifts WHERE race_id = 'tokyo-marathon-2027';
 DELETE FROM race_entry_links WHERE race_id = 'tokyo-marathon-2027';
 DELETE FROM race_entry_periods WHERE race_id = 'tokyo-marathon-2027';
 DELETE FROM race_results WHERE race_id = 'tokyo-marathon-2027';
@@ -6697,6 +6860,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('tokyo-marathon-2027', 'グルメ', '東京駅周辺グルメ', 'Tokyo Station Area Dining', 'フィニッシュ地点の東京駅周辺には多数の飲食店。レース後の打ち上げに最適。', 'Numerous restaurants around Tokyo Station at the finish. Perfect for post-race celebrations.', 'フィニッシュ地点周辺', NULL, 35.6812, 139.7671);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('tokyo-marathon-2027', '["tshirt","towel"]', '参加記念Tシャツ（参加者全員）、完走メダル（完走者）、完走タオル（完走者）', 'Commemorative T-shirt (all participants), Finisher medal (finishers), Finisher towel (finishers)', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('tokyo-marathon-2027', '["medal"]', '参加記念Tシャツ（参加者全員）、完走メダル（完走者）、完走タオル（完走者）', 'Commemorative T-shirt (all participants), Finisher medal (finishers), Finisher towel (finishers)', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('tokyo-marathon-2027', NULL, '一般エントリー', 'General Entry', '2026-08-14', '2026-08-28', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -6723,6 +6888,7 @@ DELETE FROM access_points WHERE race_id = 'tomisato-suikaroad-2026';
 DELETE FROM nearby_spots WHERE race_id = 'tomisato-suikaroad-2026';
 DELETE FROM weather_history WHERE race_id = 'tomisato-suikaroad-2026';
 DELETE FROM participation_gifts WHERE race_id = 'tomisato-suikaroad-2026';
+DELETE FROM completion_gifts WHERE race_id = 'tomisato-suikaroad-2026';
 DELETE FROM race_entry_links WHERE race_id = 'tomisato-suikaroad-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'tomisato-suikaroad-2026';
 DELETE FROM race_results WHERE race_id = 'tomisato-suikaroad-2026';
@@ -6808,6 +6974,7 @@ DELETE FROM access_points WHERE race_id = 'tottori-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'tottori-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'tottori-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'tottori-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'tottori-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'tottori-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'tottori-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'tottori-marathon-2026';
@@ -6884,6 +7051,15 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
 ・鳥取のお土産
 ・スポンサードリンク
 ', 'Race T-shirt', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('tottori-marathon-2026', '["medal"]', '大会Tシャツ
+●完走賞
+・完走証
+・特別メダル
+・フィニッシャータオル
+・鳥取のお土産
+・スポンサードリンク
+', 'Race T-shirt', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('tottori-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-10-15', '2025-12-12', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -6902,6 +7078,7 @@ DELETE FROM access_points WHERE race_id = 'toyako-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'toyako-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'toyako-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'toyako-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'toyako-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'toyako-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'toyako-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'toyako-marathon-2026';
@@ -6973,6 +7150,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('toyako-marathon-2026', '観光地', '有珠山・昭和新山', 'Mt. Usu & Showa-Shinzan', '活火山とその噴火で誕生した昭和新山。ロープウェイで山頂へ。洞爺湖を一望。', 'An active volcano and Showa-Shinzan born from its eruption. Ropeway to the summit with panoramic lake views.', '洞爺湖温泉から車約10分', NULL, 42.5389, 140.8411);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('toyako-marathon-2026', '["tshirt"]', '大会Tシャツとトートバッグ及びフェイスタオル、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('toyako-marathon-2026', '["medal"]', '大会Tシャツとトートバッグ及びフェイスタオル、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('toyako-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-02-01', '2026-03-08', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -6991,6 +7170,7 @@ DELETE FROM access_points WHERE race_id = 'toyama-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'toyama-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'toyama-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'toyama-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'toyama-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'toyama-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'toyama-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'toyama-marathon-2026';
@@ -7062,6 +7242,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('toyama-marathon-2026', 'グルメ', '富山ブラックラーメン・白えび', 'Toyama Black Ramen & White Shrimp', '富山名物の濃い醤油ラーメンと、富山湾の宝石・白えび。', 'Toyama''s dark soy sauce ramen and white shrimp, jewels of Toyama Bay.', '富山市内', NULL, 36.6953, 137.2113);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('toyama-marathon-2026', '["tshirt","towel"]', '大会Tシャツ、完走メダル・フィニッシャータオル', 'Race T-shirt, Finisher medal', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('toyama-marathon-2026', '["medal"]', '大会Tシャツ、完走メダル・フィニッシャータオル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('toyama-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-11', '2026-06-30', 14000, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -7082,6 +7264,7 @@ DELETE FROM access_points WHERE race_id = 'tsukuba-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'tsukuba-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'tsukuba-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'tsukuba-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'tsukuba-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'tsukuba-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'tsukuba-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'tsukuba-marathon-2026';
@@ -7165,6 +7348,7 @@ DELETE FROM access_points WHERE race_id = 'wakkanai-peace-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'wakkanai-peace-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'wakkanai-peace-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'wakkanai-peace-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'wakkanai-peace-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'wakkanai-peace-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'wakkanai-peace-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'wakkanai-peace-marathon-2026';
@@ -7236,6 +7420,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('wakkanai-peace-marathon-2026', '温泉', '童夢', 'Domu Hot Spring', '稚内市内の温泉施設。レース後のリカバリーに。', 'Hot spring facility in Wakkanai. Great for post-race recovery.', '稚内市内', NULL, 45.4167, 141.6722);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('wakkanai-peace-marathon-2026', '["tshirt"]', '完走メダル、大会オリジナルTシャツ', 'Finisher medal, Official race T-shirt', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('wakkanai-peace-marathon-2026', '["medal"]', '完走メダル、大会オリジナルTシャツ', 'Finisher medal, Official race T-shirt', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('wakkanai-peace-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-01', '2026-06-30', 10000, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -7256,6 +7442,7 @@ DELETE FROM access_points WHERE race_id = 'yokohama-marathon-2026';
 DELETE FROM nearby_spots WHERE race_id = 'yokohama-marathon-2026';
 DELETE FROM weather_history WHERE race_id = 'yokohama-marathon-2026';
 DELETE FROM participation_gifts WHERE race_id = 'yokohama-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'yokohama-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'yokohama-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'yokohama-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'yokohama-marathon-2026';
@@ -7327,6 +7514,8 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('yokohama-marathon-2026', 'グルメ', '横浜中華街', 'Yokohama Chinatown', '日本最大の中華街。レース後の食べ歩きに最適。', 'Japan''s largest Chinatown. Perfect for post-race food tours.', 'みなとみらいから徒歩約15分', NULL, 35.4422, 139.6453);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('yokohama-marathon-2026', '["tshirt","towel"]', '大会Tシャツ、完走メダル、フィニッシャータオル', 'Race T-shirt, Finisher medal, Finisher towel', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('yokohama-marathon-2026', '["medal"]', '大会Tシャツ、完走メダル、フィニッシャータオル', 'Race T-shirt, Finisher medal, Finisher towel', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('yokohama-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-08', '2026-05-17', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES

--- a/migrations/seed-races-all.sql
+++ b/migrations/seed-races-all.sql
@@ -1,5 +1,5 @@
 -- 自動生成: generate-seed-races.js
--- 生成日時: 2026-06-06T13:54:56.669Z
+-- 生成日時: 2026-06-07T06:16:42.994Z
 -- 対象ファイル数: 80 件（既存 2 件はskip）
 
 -- ==================
@@ -79,7 +79,7 @@ INSERT OR REPLACE INTO races (
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('abashiri-marathon-2026', 'full', 42.195, 390, '08:45', 2600, 12000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('abashiri-marathon-2026', '["medal","goods"]', 'YAMAtune製オリジナルソックス、ランニンググローブ、おもてなしブース飲食券', '', NULL, 0);
+  ('abashiri-marathon-2026', '["goods"]', 'YAMAtune製オリジナルソックス、ランニンググローブ、おもてなしブース飲食券', '', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('abashiri-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-01', '2026-07-16', NULL, 0);
 
@@ -255,7 +255,7 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('aomori-sakura-marathon-2026', '観光地', '弘前城・弘前公園', 'Hirosaki Castle & Park', '日本屈指の桜の名所。4月下旬は桜まつりの時期と重なる可能性あり。', 'One of Japan''s top cherry blossom spots. Late April may coincide with the cherry blossom festival.', '青森市から車約1時間', NULL, 40.6072, 140.4639);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('aomori-sakura-marathon-2026', '["tshirt","medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+  ('aomori-sakura-marathon-2026', '["tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('aomori-sakura-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-11-01', '2026-01-30', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -603,7 +603,7 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('chiba-aqualine-marathon-2026', 'half', 21.0975, 205, '09:45', 5000, 13500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 1);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('chiba-aqualine-marathon-2026', '["medal","tshirt"]', '参加賞Tシャツ、完走メダル', '', NULL, 0);
+  ('chiba-aqualine-marathon-2026', '["tshirt"]', '参加賞Tシャツ、完走メダル', '', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('chiba-aqualine-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-03-22', '2026-04-12', 16500, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
@@ -696,7 +696,7 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('ehime-marathon-2026', '観光地', '松山城', 'Matsuyama Castle', '現存12天守の一つ。コース上から望める。ロープウェイで天守閣へ。', 'One of Japan''s 12 surviving original castle keeps. Visible from the course. Ropeway access to the keep.', 'コース付近', NULL, 33.8456, 132.7656);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('ehime-marathon-2026', '["tshirt","medal","towel"]', '大会オリジナルTシャツ、完走メダル、今治タオル（完走者）', 'Official race T-shirt, Finisher medal, Imabari towel (finishers)', NULL, 0);
+  ('ehime-marathon-2026', '["tshirt","towel"]', '大会オリジナルTシャツ、完走メダル、今治タオル（完走者）', 'Official race T-shirt, Finisher medal, Imabari towel (finishers)', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('ehime-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-08-01', '2025-08-19', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -872,7 +872,7 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('fujisan-marathon-2026', '温泉', '河口湖温泉', 'Lake Kawaguchi Onsen', '河口湖畔の温泉。富士山を望む露天風呂が魅力。レース後に最適。', 'Hot springs on the shore of Lake Kawaguchi. Open-air baths with Mt. Fuji views.', '会場付近', NULL, 35.51, 138.75);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('fujisan-marathon-2026', '["medal","tshirt","towel"]', '大会Tシャツ、完走メダル、フィニッシャータオル', 'Race T-shirt, Finisher medal, Finisher towel', NULL, 0);
+  ('fujisan-marathon-2026', '["tshirt","towel"]', '大会Tシャツ、完走メダル、フィニッシャータオル', 'Race T-shirt, Finisher medal, Finisher towel', NULL, 0);
 INSERT OR REPLACE INTO race_entry_links (race_id, site_name, url, sort_order) VALUES
   ('fujisan-marathon-2026', 'RUNNET', 'https://runnet.jp/parts/2026/392477/entry2.html', 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
@@ -959,7 +959,7 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('fukuchiyama-marathon-2026', '温泉', '天の湯', 'Ame no Yu Hot Spring', '福知山市内の温泉施設。レース後のリカバリーに利用できる。', 'Hot spring facility in Fukuchiyama. Available for post-race recovery.', '福知山市内', NULL, 35.295, 135.12);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('fukuchiyama-marathon-2026', '["medal","tshirt"]', '完走メダル、大会オリジナルTシャツ（レイト・直前申込を除く）', 'Finisher medal, Official race T-shirt (excluding late/last-minute entries)', NULL, 0);
+  ('fukuchiyama-marathon-2026', '["tshirt"]', '完走メダル、大会オリジナルTシャツ（レイト・直前申込を除く）', 'Finisher medal, Official race T-shirt (excluding late/last-minute entries)', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('fukuchiyama-marathon-2026', NULL, '早割', 'Early Bird', '2026-05-01', '2026-05-31', 10000, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
@@ -1052,7 +1052,7 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('fukui-sakura-marathon-2026', 'グルメ', '越前おろしそば', 'Echizen Oroshi Soba', '大根おろしとだしで食べる福井名物のそば。レース後のエネルギー補給に。', 'Fukui''s specialty soba with grated radish and broth. For post-race energy.', '福井市内', NULL, 36.0652, 136.2199);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('fukui-sakura-marathon-2026', '["medal","tshirt","towel"]', '大会Tシャツ、完走メダル、フィニッシャータオル', 'Race T-shirt, Finisher medal, Finisher towel', NULL, 0);
+  ('fukui-sakura-marathon-2026', '["tshirt","towel"]', '大会Tシャツ、完走メダル、フィニッシャータオル', 'Race T-shirt, Finisher medal, Finisher towel', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('fukui-sakura-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-09-25', '2025-11-10', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -1240,7 +1240,7 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('fukuoka-marathon-2026', '温泉', '二丈温泉きららの湯', 'Nijo Onsen Kirara no Yu', '糸島・二丈エリアの温泉施設。コース沿いでレース後のリカバリーに最適。', 'Hot spring facility in the Itoshima/Nijo area. Ideal for post-race recovery near the course.', '糸島市内', NULL, 33.54, 130.16);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('fukuoka-marathon-2026', '["medal","tshirt"]', '完走メダル、大会オリジナルTシャツ', 'Finisher medal, Official race T-shirt', NULL, 0);
+  ('fukuoka-marathon-2026', '["tshirt"]', '完走メダル、大会オリジナルTシャツ', 'Finisher medal, Official race T-shirt', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('fukuoka-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-20', '2026-05-20', 16000, 0);
 
@@ -1339,7 +1339,7 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
 
 Translated with DeepL.com (free version)', '', 'https://worldheritage.pref.gunma.jp/whc/', 36.2551968, 138.8850047);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('gunma-marathon-2026', '["medal","tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+  ('gunma-marathon-2026', '["tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('gunma-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-09', '2026-05-13', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -1604,7 +1604,7 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('himeji-castle-marathon-2026', '観光地', '姫路城', 'Himeji Castle', '世界遺産・国宝の白鷺城。日本で最も美しい城の一つ。コース上から望める。', 'A World Heritage and National Treasure. One of Japan''s most beautiful castles. Visible from the course.', 'コース上', NULL, 34.8394, 134.6939);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('himeji-castle-marathon-2026', '["tshirt","medal","towel"]', '大会Tシャツ、完走メダル、フィニッシャータオル', 'Race T-shirt, Finisher medal, Finisher towel', NULL, 0);
+  ('himeji-castle-marathon-2026', '["tshirt","towel"]', '大会Tシャツ、完走メダル、フィニッシャータオル', 'Race T-shirt, Finisher medal, Finisher towel', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('himeji-castle-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-08-04', '2025-10-31', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -1691,7 +1691,7 @@ With the scenery and the sea breeze pushing you forward, you can fully savor the
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('hitachi-seaside-marathon-2026', 'full', 42.195, 360, '10:00', 6000, 10000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('hitachi-seaside-marathon-2026', '["medal","towel"]', '出走特典
+  ('hitachi-seaside-marathon-2026', '["towel"]', '出走特典
 （タオル）
 
 完走賞
@@ -1777,8 +1777,6 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
   ('hofu-yomiuri-marathon-2026', 'full', 42.195, 240, '12:03', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('hofu-yomiuri-marathon-2026', '観光地', '防府天満宮', 'Hofu Tenmangu', '日本三大天神の一つ。学問の神様・菅原道真を祀る。コース付近。', 'One of Japan''s three great Tenmangu shrines. Enshrines Sugawara no Michizane, deity of learning.', 'コース付近', NULL, 34.0478, 131.5711);
-INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('hofu-yomiuri-marathon-2026', '["medal"]', '完走メダル', 'Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
   ('hofu-yomiuri-marathon-2026', NULL, NULL, '防府天満宮付近', 'Near Hofu Tenmangu Shrine', NULL, NULL, 0);
 
@@ -1865,7 +1863,7 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('hokkaido-marathon-2026', '温泉', '定山渓温泉', 'Jozankei Onsen', '札幌の奥座敷と呼ばれる温泉地。レース翌日の観光に。札幌中心部からバスで約60分。', 'Known as Sapporo''s inner parlor. For sightseeing the day after. About 60 min by bus from central Sapporo.', '札幌中心部からバス約60分', NULL, 42.9694, 141.1667);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('hokkaido-marathon-2026', '["tshirt","medal"]', '大会オリジナルTシャツ、完走メダル', 'Official race T-shirt, Finisher medal', NULL, 0);
+  ('hokkaido-marathon-2026', '["tshirt"]', '大会オリジナルTシャツ、完走メダル', 'Official race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('hokkaido-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-03-29', '2026-04-24', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -2215,7 +2213,7 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('itabashi-city-marathon-2026', '観光地', '荒川河川敷', 'Arakawa Riverbank', 'フラットな河川敷コース。記録を狙うランナーに人気の定番コース。', 'A flat riverbank course. A classic course popular with runners aiming for personal records.', 'コース上', NULL, 35.7917, 139.675);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('itabashi-city-marathon-2026', '["tshirt","medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+  ('itabashi-city-marathon-2026', '["tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('itabashi-city-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-08-01', '2025-11-24', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -2306,7 +2304,7 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('iwaki-sunshine-marathon-2026', '温泉', 'いわき湯本温泉', 'Iwaki Yumoto Onsen', 'いわき市の歴史ある温泉地。レース後のリカバリーに。', 'A historic hot spring in Iwaki. For post-race recovery.', 'いわき市内', NULL, 36.9744, 140.8456);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('iwaki-sunshine-marathon-2026', '["tshirt","medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+  ('iwaki-sunshine-marathon-2026', '["tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('iwaki-sunshine-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-09-12', '2025-10-15', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -2419,7 +2417,7 @@ Translated with DeepL.com (free version)',
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('iwate-morioka-city-marathon-2026', 'full', 42.195, 360, '09:00', 6000, 12000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('iwate-morioka-city-marathon-2026', '["medal","towel"]', '完走賞	フィニッシャータオル、南部鉄器製完走メダル', '', NULL, 0);
+  ('iwate-morioka-city-marathon-2026', '["towel"]', '完走賞	フィニッシャータオル、南部鉄器製完走メダル', '', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('iwate-morioka-city-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-01', '2026-07-20', 12000, 0);
 
@@ -2504,7 +2502,7 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('iwate-oshu-kirameki-marathon-2026', '観光地', '中尊寺金色堂', 'Chusonji Konjikido', '世界遺産・平泉。奥州藤原氏の栄華を伝える。奥州市から車約30分。', 'World Heritage Hiraizumi. Tells of the glory of the Oshu Fujiwara clan. About 30 min by car from Oshu.', '奥州市から車約30分', NULL, 39, 141.1);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('iwate-oshu-kirameki-marathon-2026', '["tshirt","medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+  ('iwate-oshu-kirameki-marathon-2026', '["tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('iwate-oshu-kirameki-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-11-28', '2026-02-28', NULL, 0);
 
@@ -2613,8 +2611,6 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
   ('izu-oshima-2026', 'half', 21.0975, 180, '08:20', 0, 7400, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 1);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('izu-oshima-2026', '10k', 10, 100, '09:00', 0, 5400, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 2);
-INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('izu-oshima-2026', '["medal"]', 'オリジナル完走メダル', '', NULL, 0);
 INSERT OR REPLACE INTO race_entry_links (race_id, site_name, url, sort_order) VALUES
   ('izu-oshima-2026', 'RUNNET', 'https://runnet.jp/entry/runtes/user/pc/competitionDetailAction.do?raceId=392378&div=1', 0);
 INSERT OR REPLACE INTO race_entry_links (race_id, site_name, url, sort_order) VALUES
@@ -2790,7 +2786,7 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('kagoshima-marathon-2026', '温泉', '指宿温泉', 'Ibusuki Onsen', '砂むし温泉で有名。鹿児島市から特急で約1時間。レース翌日の遠足に。', 'Famous for sand steam baths. About 1 hour by express from Kagoshima. Day trip the day after.', '鹿児島市から特急約1時間', NULL, 31.25, 130.65);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('kagoshima-marathon-2026', '["tshirt","medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+  ('kagoshima-marathon-2026', '["tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kagoshima-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-08-08', '2025-11-16', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -2881,7 +2877,7 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('kaikyo-marathon-2026', 'グルメ', 'ふくの里', 'Fuku no Sato', '下関名物のふぐ料理を堪能できるエリア。レース後のご褒美食事に最適。', 'Area to enjoy Shimonoseki''s famous fugu cuisine. Perfect post-race reward.', '下関市内', NULL, 33.955, 130.945);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('kaikyo-marathon-2026', '["medal","tshirt"]', '完走メダル、大会オリジナルTシャツ', 'Finisher medal, Official race T-shirt', NULL, 0);
+  ('kaikyo-marathon-2026', '["tshirt"]', '完走メダル、大会オリジナルTシャツ', 'Finisher medal, Official race T-shirt', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kaikyo-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-05-15', '2026-07-12', 12000, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -2974,7 +2970,7 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('kanazawa-marathon-2026', '温泉', '金沢駅周辺の温泉施設', 'Hot spring facilities near Kanazawa Station', '金沢駅周辺には日帰り温泉施設あり。レース後のリカバリーに。', 'Day-trip hot spring facilities available near Kanazawa Station. For post-race recovery.', '金沢駅周辺', NULL, 36.5781, 136.6486);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('kanazawa-marathon-2026', '["medal","tshirt","local_product"]', '大会オリジナルTシャツ、完走メダル、地元特産品', 'Official race T-shirt, Finisher medal, Local specialty products', NULL, 0);
+  ('kanazawa-marathon-2026', '["tshirt","local_product"]', '大会オリジナルTシャツ、完走メダル、地元特産品', 'Official race T-shirt, Finisher medal, Local specialty products', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kanazawa-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-10', '2026-05-20', 14000, 0);
 
@@ -3164,7 +3160,7 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('kasumigaura-marathon-2026', '観光地', '霞ヶ浦', 'Lake Kasumigaura', '日本第2位の面積を持つ湖。コースで湖畔を走る。広大な水面は壮観。', 'Japan''s second largest lake. Run along the lakeshore. The vast water surface is spectacular.', 'コース上', NULL, 36.0333, 140.3333);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('kasumigaura-marathon-2026', '["tshirt","medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+  ('kasumigaura-marathon-2026', '["tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kasumigaura-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-12-01', '2026-01-25', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -3338,7 +3334,7 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('kitakyushu-marathon-2026', '観光地', '門司港レトロ', 'Mojiko Retro', '大正ロマンの雰囲気が残る港町。焼きカレーが名物。', 'A port town with Taisho-era atmosphere. Famous for baked curry.', '小倉から電車約15分', NULL, 33.95, 130.9611);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('kitakyushu-marathon-2026', '["tshirt","medal","towel"]', '大会Tシャツ、完走メダル、フィニッシャータオル', 'Race T-shirt, Finisher medal, Finisher towel', NULL, 0);
+  ('kitakyushu-marathon-2026', '["tshirt","towel"]', '大会Tシャツ、完走メダル、フィニッシャータオル', 'Race T-shirt, Finisher medal, Finisher towel', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kitakyushu-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-08-08', '2025-09-25', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -3532,7 +3528,7 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('kobe-marathon-2026', 'グルメ', '神戸牛', 'Kobe Beef', '世界的に有名なブランド和牛。レース後のご褒美に。三宮・元町エリアに名店多数。', 'World-famous premium wagyu beef. A reward after the race. Many restaurants in Sannomiya-Motomachi area.', '三宮・元町エリア', NULL, 34.6913, 135.1956);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('kobe-marathon-2026', '["medal","tshirt","towel"]', '大会オリジナルTシャツ、完走メダル、フィニッシャータオル', 'Official race T-shirt, Finisher medal, Finisher towel', NULL, 0);
+  ('kobe-marathon-2026', '["tshirt","towel"]', '大会オリジナルTシャツ、完走メダル、フィニッシャータオル', 'Official race T-shirt, Finisher medal, Finisher towel', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kobe-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-17', '2026-06-01', 18000, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -3623,7 +3619,7 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('kochi-ryoma-marathon-2026', 'グルメ', 'カツオのたたき', 'Katsuo no Tataki', '高知を代表するグルメ。藁焼きで仕上げた鰹のたたきは絶品。ひろめ市場で気軽に楽しめる。', 'Kochi''s signature dish. Straw-grilled bonito tataki is exquisite. Enjoy casually at Hirome Market.', '高知市内', NULL, 33.5589, 133.5311);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('kochi-ryoma-marathon-2026', '["tshirt","medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+  ('kochi-ryoma-marathon-2026', '["tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kochi-ryoma-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-08-01', '2025-10-31', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -3714,7 +3710,7 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('kumamoto-castle-marathon-2026', 'グルメ', '馬刺し・太平燕', 'Horse Sashimi & Taipien', '熊本を代表するグルメ。馬刺しと太平燕（春雨スープ）はぜひ試したい。', 'Kumamoto''s signature dishes. Horse sashimi and taipien (glass noodle soup) are must-tries.', '熊本市内', NULL, 32.8032, 130.7079);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('kumamoto-castle-marathon-2026', '["tshirt","medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+  ('kumamoto-castle-marathon-2026', '["tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kumamoto-castle-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-07-29', '2025-09-24', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -3803,7 +3799,7 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('kyoto-marathon-2026', '温泉', 'さがの温泉 天山の湯', 'Sagano Onsen Tenzan no Yu', '嵐山エリアの天然温泉。レース後のリカバリーに。', 'Natural hot spring in the Arashiyama area. For post-race recovery.', '嵐山エリア', NULL, 35.0167, 135.6833);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('kyoto-marathon-2026', '["tshirt","medal"]', '大会オリジナルTシャツ、完走メダル', 'Official race T-shirt, Finisher medal', NULL, 0);
+  ('kyoto-marathon-2026', '["tshirt"]', '大会オリジナルTシャツ、完走メダル', 'Official race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kyoto-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-07-17', '2025-09-22', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -3896,7 +3892,7 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('mie-matsusaka-marathon-2026', 'グルメ', '松阪牛', 'Matsusaka Beef', '日本三大和牛の一つ。レース後のご褒美に。', 'One of Japan''s three premium wagyu. A reward after the race.', '松阪市内', NULL, 34.5778, 136.5312);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('mie-matsusaka-marathon-2026', '["tshirt","medal","local_product"]', '大会Tシャツ、完走メダル、松阪の特産品', 'Race T-shirt, Finisher medal, Matsusaka local products', NULL, 0);
+  ('mie-matsusaka-marathon-2026', '["tshirt","local_product"]', '大会Tシャツ、完走メダル、松阪の特産品', 'Race T-shirt, Finisher medal, Matsusaka local products', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
   ('mie-matsusaka-marathon-2026', NULL, NULL, '松阪の城下町', 'Matsusaka castle town', NULL, NULL, 0);
 
@@ -3979,7 +3975,7 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('mito-komon-manyu-marathon-2026', '観光地', '偕楽園', 'Kairakuen Garden', '日本三名園の一つ。2〜3月は梅まつりで有名。コース上から望める。', 'One of Japan''s three most beautiful gardens. Famous for plum blossom festival in Feb-Mar.', 'コース付近', NULL, 36.3811, 140.4511);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('mito-komon-manyu-marathon-2026', '["medal","tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+  ('mito-komon-manyu-marathon-2026', '["tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_links (race_id, site_name, url, sort_order) VALUES
   ('mito-komon-manyu-marathon-2026', 'RUNNET', 'https://runnet.jp/entry/runtes/user/pc/competitionDetailAction.do?raceId=387694&div=1', 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
@@ -4254,7 +4250,7 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('nagoya-womens-marathon-2026', 'グルメ', '名古屋めし', 'Nagoya Meshi', '味噌カツ、ひつまぶし、手羽先など名古屋名物が充実。レース後のご褒美に。', 'Miso katsu, hitsumabushi, chicken wings and more Nagoya specialties. A reward after the race.', '名古屋市内', NULL, 35.1709, 136.8815);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('nagoya-womens-marathon-2026', '["medal","goods"]', 'ティファニー オリジナルペンダント（完走者全員）', 'Tiffany original pendant (all finishers)', NULL, 0);
+  ('nagoya-womens-marathon-2026', '["goods"]', 'ティファニー オリジナルペンダント（完走者全員）', 'Tiffany original pendant (all finishers)', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
   ('nagoya-womens-marathon-2026', NULL, NULL, '名古屋ドーム（バンテリンドーム ナゴヤ）', 'Nagoya Dome (Vantelin Dome Nagoya)', NULL, NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -4341,7 +4337,7 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('naha-marathon-2026', 'グルメ', '沖縄そば', 'Okinawa Soba', '沖縄を代表するご当地グルメ。あっさりとしたスープと太麺が特徴。レース後のエネルギー補給に。', 'Okinawa''s signature local dish. Characterized by light broth and thick noodles. Perfect for post-race energy.', '那覇市内各所', NULL, 26.3344, 127.7679);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('naha-marathon-2026', '["medal","tshirt"]', '大会オリジナルTシャツ、完走メダル', 'Official race T-shirt, Finisher medal', NULL, 0);
+  ('naha-marathon-2026', '["tshirt"]', '大会オリジナルTシャツ、完走メダル', 'Official race T-shirt, Finisher medal', NULL, 0);
 
 -- ==================
 -- 奈良マラソン (nara-marathon-2026)
@@ -4424,7 +4420,7 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('nara-marathon-2026', '温泉', 'ゆららの湯 奈良店', 'Yurara no Yu Nara', '奈良市内の日帰り温泉施設。レース後のリカバリーに便利。', 'A day-trip hot spring facility in Nara city. Convenient for post-race recovery.', '奈良市内', NULL, 34.6851, 135.8048);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('nara-marathon-2026', '["tshirt","medal","towel"]', '大会オリジナルTシャツ、完走メダル、フィニッシャータオル', 'Official race T-shirt, Finisher medal, Finisher towel', NULL, 0);
+  ('nara-marathon-2026', '["tshirt","towel"]', '大会オリジナルTシャツ、完走メダル、フィニッシャータオル', 'Official race T-shirt, Finisher medal, Finisher towel', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
   ('nara-marathon-2026', NULL, NULL, '東大寺', 'Todai-ji', NULL, NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -4678,7 +4674,7 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('okayama-marathon-2026', '観光地', '後楽園', 'Korakuen Garden', '日本三名園の一つ。岡山城とセットで訪れたい。', 'One of Japan''s three most beautiful gardens. Visit together with Okayama Castle.', 'コース付近', NULL, 34.6694, 133.9356);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('okayama-marathon-2026', '["medal","tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+  ('okayama-marathon-2026', '["tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('okayama-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-16', '2026-05-18', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -4871,7 +4867,7 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('osaka-marathon-2026', '温泉', 'スパワールド世界の大温泉', 'Spa World', '通天閣近くの大型温泉施設。レース後のリカバリーに。コースの近くにあり便利。', 'A large hot spring facility near Tsutenkaku. Convenient for post-race recovery, located near the course.', '通天閣付近', NULL, 34.6522, 135.5064);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('osaka-marathon-2026', '["tshirt","medal","towel"]', '参加記念Tシャツ、完走メダル、フィニッシャータオル', 'Commemorative T-shirt, Finisher medal, Finisher towel', NULL, 0);
+  ('osaka-marathon-2026', '["tshirt","towel"]', '参加記念Tシャツ、完走メダル、フィニッシャータオル', 'Commemorative T-shirt, Finisher medal, Finisher towel', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
   ('osaka-marathon-2026', NULL, NULL, '大阪城', 'Osaka Castle', NULL, NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -5144,7 +5140,7 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('sado-toki-marathon-2026', '観光地', 'トキの森公園', 'Toki no Mori Park', '国の特別天然記念物トキを間近で観察できる施設。大会のモチーフであるトキに会える。', 'A facility to observe the crested ibis, a national special natural monument, up close.', '佐渡島内', NULL, 38.0333, 138.3667);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('sado-toki-marathon-2026', '["medal","tshirt","local_product"]', '大会Tシャツ、完走メダル、佐渡の特産品', 'Race T-shirt, Finisher medal, Sado Island local products', NULL, 0);
+  ('sado-toki-marathon-2026', '["tshirt","local_product"]', '大会Tシャツ、完走メダル、佐渡の特産品', 'Race T-shirt, Finisher medal, Sado Island local products', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('sado-toki-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-12-01', '2026-03-22', NULL, 0);
 
@@ -5227,7 +5223,7 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('saga-sakura-marathon-2026', '観光地', '吉野ヶ里遺跡', 'Yoshinogari Ruins', '弥生時代の大規模環濠集落遺跡。国の特別史跡。佐賀市から近い。', 'A large-scale Yayoi period moated settlement. National Special Historic Site. Close to Saga city.', '佐賀市から車約20分', NULL, 33.3167, 130.3833);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('saga-sakura-marathon-2026', '["tshirt","medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+  ('saga-sakura-marathon-2026', '["tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
   ('saga-sakura-marathon-2026', NULL, NULL, '桜並木', 'Cherry blossom trees', NULL, NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -5836,7 +5832,7 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('shizuoka-marathon-2026', '観光地', '三保松原', 'Miho no Matsubara', '世界遺産「富士山」の構成資産。松林越しの富士山の眺望が美しい。', 'Part of the World Heritage ''Mt. Fuji''. Beautiful views of Mt. Fuji through pine groves.', '静岡市内から車約30分', NULL, 35.0136, 138.5167);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('shizuoka-marathon-2026', '["medal","tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+  ('shizuoka-marathon-2026', '["tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 
 -- ==================
 -- 湘南国際マラソン (shonan-international-marathon-2026)
@@ -5919,7 +5915,7 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('shonan-international-marathon-2026', '観光地', '江の島', 'Enoshima', 'コースの折り返し地点付近。湘南のシンボル。しらす丼やサザエが名物。', 'Near the turnaround point. Symbol of Shonan. Famous for shirasu bowl and turban shell.', 'コース折り返し付近', NULL, 35.2994, 139.4806);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('shonan-international-marathon-2026', '["medal","tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+  ('shonan-international-marathon-2026', '["tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('shonan-international-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-04', '2026-09-09', 16000, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
@@ -6007,7 +6003,7 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('soja-kibiji-marathon-2026', '観光地', '備中国分寺五重塔', 'Bitchu Kokubunji Five-Story Pagoda', '吉備路のシンボル。コース上から望める。田園風景の中に立つ姿が美しい。', 'Symbol of Kibiji. Visible from the course. Beautiful standing among rice paddies.', 'コース上', NULL, 34.65, 133.7833);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('soja-kibiji-marathon-2026', '["medal","tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+  ('soja-kibiji-marathon-2026', '["tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('soja-kibiji-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-10-01', '2026-01-03', 9100, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -6183,7 +6179,7 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('tateyama-wakashio-2026', 'グルメ', '房総の海鮮', 'Boso Seafood', '新鮮な海鮮が楽しめる。特に寿司や刺身がおすすめ。', 'Fresh seafood. Sushi and sashimi are especially recommended.', '館山市内', NULL, 34.9997, 139.8697);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('tateyama-wakashio-2026', '["tshirt","medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+  ('tateyama-wakashio-2026', '["tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
   ('tateyama-wakashio-2026', NULL, NULL, '房総の海岸線', 'Boso coastline', NULL, NULL, 0);
 
@@ -6352,7 +6348,7 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('tokushima-marathon-2026', '観光地', '鳴門の渦潮', 'Naruto Whirlpools', '世界三大潮流の一つ。大鳴門橋の遊歩道から渦潮を観察できる。', 'One of the world''s three great tidal currents. Observe whirlpools from the Onaruto Bridge walkway.', '徳島市から車約1時間', NULL, 34.2333, 134.6333);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('tokushima-marathon-2026', '["tshirt","medal"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+  ('tokushima-marathon-2026', '["tshirt"]', '大会Tシャツ、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
   ('tokushima-marathon-2026', NULL, NULL, '吉野川', 'Yoshino River', NULL, NULL, 0);
 
@@ -6504,7 +6500,7 @@ Competition Classes:
 
 Translated with DeepL.com (free version)', NULL, '[]', 0);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('tokyo-legacy-half-2026', '["medal","goods"]', '', '', NULL, 0);
+  ('tokyo-legacy-half-2026', '["goods"]', '', '', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('tokyo-legacy-half-2026', NULL, 'ジャパンプレミアハーフ優先エントリー', 'General Entry', '2026-05-18', '2026-05-25', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
@@ -6597,7 +6593,7 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('tokyo-marathon-2026', 'グルメ', '東京駅周辺グルメ', 'Tokyo Station Area Dining', 'フィニッシュ地点の東京駅周辺には多数の飲食店。レース後の打ち上げに最適。', 'Numerous restaurants around Tokyo Station at the finish. Perfect for post-race celebrations.', 'フィニッシュ地点周辺', NULL, 35.6812, 139.7671);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('tokyo-marathon-2026', '["medal","tshirt","towel"]', '参加記念Tシャツ（参加者全員）、完走メダル（完走者）、完走タオル（完走者）', 'Commemorative T-shirt (all participants), Finisher medal (finishers), Finisher towel (finishers)', NULL, 0);
+  ('tokyo-marathon-2026', '["tshirt","towel"]', '参加記念Tシャツ（参加者全員）、完走メダル（完走者）、完走タオル（完走者）', 'Commemorative T-shirt (all participants), Finisher medal (finishers), Finisher towel (finishers)', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('tokyo-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-08-15', '2025-08-29', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -6700,7 +6696,7 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('tokyo-marathon-2027', 'グルメ', '東京駅周辺グルメ', 'Tokyo Station Area Dining', 'フィニッシュ地点の東京駅周辺には多数の飲食店。レース後の打ち上げに最適。', 'Numerous restaurants around Tokyo Station at the finish. Perfect for post-race celebrations.', 'フィニッシュ地点周辺', NULL, 35.6812, 139.7671);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('tokyo-marathon-2027', '["medal","tshirt","towel"]', '参加記念Tシャツ（参加者全員）、完走メダル（完走者）、完走タオル（完走者）', 'Commemorative T-shirt (all participants), Finisher medal (finishers), Finisher towel (finishers)', NULL, 0);
+  ('tokyo-marathon-2027', '["tshirt","towel"]', '参加記念Tシャツ（参加者全員）、完走メダル（完走者）、完走タオル（完走者）', 'Commemorative T-shirt (all participants), Finisher medal (finishers), Finisher towel (finishers)', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('tokyo-marathon-2027', NULL, '一般エントリー', 'General Entry', '2026-08-14', '2026-08-28', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -6880,7 +6876,7 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('tottori-marathon-2026', '観光地', '鳥取砂丘', 'Tottori Sand Dunes', '日本最大級の砂丘。起伏のある広大な砂の風景は圧巻。パラグライダーやラクダ乗りも。', 'Japan''s largest sand dunes. Vast sandy landscape. Paragliding and camel rides available.', '会場から車約15分', NULL, 35.5411, 134.2289);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('tottori-marathon-2026', '["medal","tshirt","towel","local_product"]', '大会Tシャツ
+  ('tottori-marathon-2026', '["tshirt","towel","local_product"]', '大会Tシャツ
 ●完走賞
 ・完走証
 ・特別メダル
@@ -6976,7 +6972,7 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('toyako-marathon-2026', '観光地', '有珠山・昭和新山', 'Mt. Usu & Showa-Shinzan', '活火山とその噴火で誕生した昭和新山。ロープウェイで山頂へ。洞爺湖を一望。', 'An active volcano and Showa-Shinzan born from its eruption. Ropeway to the summit with panoramic lake views.', '洞爺湖温泉から車約10分', NULL, 42.5389, 140.8411);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('toyako-marathon-2026', '["medal","tshirt"]', '大会Tシャツとトートバッグ及びフェイスタオル、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
+  ('toyako-marathon-2026', '["tshirt"]', '大会Tシャツとトートバッグ及びフェイスタオル、完走メダル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('toyako-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-02-01', '2026-03-08', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -7065,7 +7061,7 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('toyama-marathon-2026', 'グルメ', '富山ブラックラーメン・白えび', 'Toyama Black Ramen & White Shrimp', '富山名物の濃い醤油ラーメンと、富山湾の宝石・白えび。', 'Toyama''s dark soy sauce ramen and white shrimp, jewels of Toyama Bay.', '富山市内', NULL, 36.6953, 137.2113);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('toyama-marathon-2026', '["medal","tshirt","towel"]', '大会Tシャツ、完走メダル・フィニッシャータオル', 'Race T-shirt, Finisher medal', NULL, 0);
+  ('toyama-marathon-2026', '["tshirt","towel"]', '大会Tシャツ、完走メダル・フィニッシャータオル', 'Race T-shirt, Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('toyama-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-11', '2026-06-30', 14000, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -7239,7 +7235,7 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('wakkanai-peace-marathon-2026', '温泉', '童夢', 'Domu Hot Spring', '稚内市内の温泉施設。レース後のリカバリーに。', 'Hot spring facility in Wakkanai. Great for post-race recovery.', '稚内市内', NULL, 45.4167, 141.6722);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('wakkanai-peace-marathon-2026', '["medal","tshirt"]', '完走メダル、大会オリジナルTシャツ', 'Finisher medal, Official race T-shirt', NULL, 0);
+  ('wakkanai-peace-marathon-2026', '["tshirt"]', '完走メダル、大会オリジナルTシャツ', 'Finisher medal, Official race T-shirt', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('wakkanai-peace-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-01', '2026-06-30', 10000, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -7330,7 +7326,7 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('yokohama-marathon-2026', 'グルメ', '横浜中華街', 'Yokohama Chinatown', '日本最大の中華街。レース後の食べ歩きに最適。', 'Japan''s largest Chinatown. Perfect for post-race food tours.', 'みなとみらいから徒歩約15分', NULL, 35.4422, 139.6453);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('yokohama-marathon-2026', '["medal","tshirt","towel"]', '大会Tシャツ、完走メダル、フィニッシャータオル', 'Race T-shirt, Finisher medal, Finisher towel', NULL, 0);
+  ('yokohama-marathon-2026', '["tshirt","towel"]', '大会Tシャツ、完走メダル、フィニッシャータオル', 'Race T-shirt, Finisher medal, Finisher towel', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('yokohama-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-08', '2026-05-17', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES

--- a/scripts/generate-seed-races.js
+++ b/scripts/generate-seed-races.js
@@ -40,6 +40,7 @@ function generateRaceSQL(r) {
   lines.push(`DELETE FROM nearby_spots WHERE race_id = ${esc(r.id)};`);
   lines.push(`DELETE FROM weather_history WHERE race_id = ${esc(r.id)};`);
   lines.push(`DELETE FROM participation_gifts WHERE race_id = ${esc(r.id)};`);
+  lines.push(`DELETE FROM completion_gifts WHERE race_id = ${esc(r.id)};`);
   lines.push(`DELETE FROM race_entry_links WHERE race_id = ${esc(r.id)};`);
   lines.push(`DELETE FROM race_entry_periods WHERE race_id = ${esc(r.id)};`);
   lines.push(`DELETE FROM race_results WHERE race_id = ${esc(r.id)};`);
@@ -167,6 +168,14 @@ function generateRaceSQL(r) {
     r.participation_gifts.forEach((pg, idx) => {
       lines.push(`INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   (${esc(r.id)}, ${escJson(pg.gift_categories)}, ${esc(pg.description_ja || '')}, ${esc(pg.description_en || '')}, ${esc(pg.image)}, ${idx});`);
+    });
+  }
+
+  // completion_gifts
+  if (r.completion_gifts && r.completion_gifts.length > 0) {
+    r.completion_gifts.forEach((cg, idx) => {
+      lines.push(`INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  (${esc(r.id)}, ${escJson(cg.gift_categories)}, ${esc(cg.description_ja || '')}, ${esc(cg.description_en || '')}, ${esc(cg.image ?? null)}, ${idx});`);
     });
   }
 

--- a/scripts/migrate-medal-gifts.js
+++ b/scripts/migrate-medal-gifts.js
@@ -39,7 +39,7 @@ for (const file of files) {
         gift_categories: ['medal'],
         description_ja: gift.description_ja ?? '',
         description_en: gift.description_en ?? '',
-        image: null,
+        image: gift.image ?? null,
       };
       completionGifts.push(medalGift);
 

--- a/scripts/migrate-medal-gifts.js
+++ b/scripts/migrate-medal-gifts.js
@@ -1,0 +1,70 @@
+/**
+ * メダルデータ移行スクリプト
+ * participation_gifts に medal が含まれる場合、completion_gifts に移動する。
+ *
+ * 実行: node scripts/migrate-medal-gifts.js
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const RACES_DIR = path.join(__dirname, '../src/data/races');
+
+const files = fs.readdirSync(RACES_DIR)
+  .filter(f => f.endsWith('.json') && f !== 'index.json')
+  .sort();
+
+let migratedCount = 0;
+let skippedCount = 0;
+
+for (const file of files) {
+  const filePath = path.join(RACES_DIR, file);
+  const race = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+
+  const participationGifts = race.participation_gifts ?? [];
+  const completionGifts = race.completion_gifts ?? [];
+
+  let changed = false;
+  const newParticipationGifts = [];
+
+  for (const gift of participationGifts) {
+    const categories = gift.gift_categories ?? [];
+    if (categories.includes('medal')) {
+      // medal を除いた参加賞カテゴリ
+      const remainingCategories = categories.filter(c => c !== 'medal');
+
+      // medal のみのエントリー → completion_gifts に移動
+      const medalGift = {
+        gift_categories: ['medal'],
+        description_ja: gift.description_ja ?? '',
+        description_en: gift.description_en ?? '',
+        image: null,
+      };
+      completionGifts.push(medalGift);
+
+      // medal 以外のカテゴリが残る場合は参加賞として残す
+      if (remainingCategories.length > 0) {
+        newParticipationGifts.push({
+          ...gift,
+          gift_categories: remainingCategories,
+        });
+      }
+      changed = true;
+    } else {
+      newParticipationGifts.push(gift);
+    }
+  }
+
+  if (changed) {
+    race.participation_gifts = newParticipationGifts;
+    race.completion_gifts = completionGifts;
+    fs.writeFileSync(filePath, JSON.stringify(race, null, 2) + '\n', 'utf-8');
+    console.log(`[migrated] ${file}`);
+    migratedCount++;
+  } else {
+    skippedCount++;
+  }
+}
+
+console.log(`\n完了: ${migratedCount} 件移行, ${skippedCount} 件スキップ`);

--- a/src/app/[locale]/races/[id]/page.tsx
+++ b/src/app/[locale]/races/[id]/page.tsx
@@ -138,7 +138,7 @@ export default async function RaceDetailPage({
     { id: 'course', label: locale === 'ja' ? 'コース' : 'Course' },
     { id: 'entry', label: locale === 'ja' ? 'エントリー' : 'Registration' },
     ...(race.access_points.length > 0 ? [{ id: 'access', label: locale === 'ja' ? 'アクセス' : 'Access' }] : []),
-    ...(race.participation_gifts.length > 0 ? [{ id: 'gifts', label: locale === 'ja' ? '参加賞' : 'Gifts' }] : []),
+    ...((race.participation_gifts.length > 0 || race.completion_gifts.length > 0) ? [{ id: 'gifts', label: locale === 'ja' ? '参加賞' : 'Gifts' }] : []),
     ...(race.nearby_spots.length > 0 ? [{ id: 'nearby', label: locale === 'ja' ? '近隣' : 'Nearby' }] : []),
     ...(race.time_buckets.length > 0 ? [{ id: 'result', label: locale === 'ja' ? 'リザルト' : 'Result' }] : []),
     ...(race.result ? [{ id: 'last-edition', label: locale === 'ja' ? '前回大会' : 'Last Edition' }] : []),
@@ -563,37 +563,80 @@ export default async function RaceDetailPage({
           </section>
         )}
 
-        {/* Participation Gift */}
-        {race.participation_gifts.length > 0 && (
+        {/* Participation Gift / Completion Gift */}
+        {(race.participation_gifts.length > 0 || race.completion_gifts.length > 0) && (
           <section id="gifts" style={{ scrollMarginTop: '3.5rem' }}>
-            <SectionHeading num="05" title={locale === 'ja' ? '参加賞' : 'Participation / Finisher Gift'}
-              subtitle={locale === 'ja' ? 'Participation / Finisher Gift' : '参加賞'}
+            <SectionHeading num="05" title={locale === 'ja' ? '参加賞・完走賞' : 'Gifts'}
+              subtitle={locale === 'ja' ? 'Participation & Finisher Gift' : '参加賞・完走賞'}
             />
-            {race.participation_gifts.map((gift, i) => (
-              <Card key={i}>
-                <div className="flex flex-wrap gap-2 mb-3">
-                  {gift.gift_categories.map((catId) => {
-                    const cat = giftCategoryMap.get(catId);
-                    if (!cat) return null;
-                    return (
-                      <span
-                        key={catId}
-                        className="flex items-center gap-1.5 px-3 py-1.5 rounded-[4px] text-sm font-medium"
-                        style={{ background: 'var(--color-cream)', border: '1px solid var(--color-border)' }}
-                      >
-                        <span>{cat.icon}</span>
-                        <span>{locale === 'ja' ? cat.name_ja : cat.name_en}</span>
-                      </span>
-                    );
-                  })}
-                </div>
-                {(locale === 'ja' ? gift.description_ja : gift.description_en) && (
-                  <p className="text-sm leading-relaxed whitespace-pre-line" style={{ color: 'var(--color-ink2)' }}>
-                    {locale === 'ja' ? gift.description_ja : gift.description_en}
+            {race.participation_gifts.length > 0 && (
+              <>
+                {race.completion_gifts.length > 0 && (
+                  <p className="text-xs font-semibold uppercase tracking-widest mb-2" style={{ color: 'var(--color-mid)' }}>
+                    {locale === 'ja' ? '参加賞' : 'Participation Gift'}
                   </p>
                 )}
-              </Card>
-            ))}
+                {race.participation_gifts.map((gift, i) => (
+                  <Card key={i}>
+                    <div className="flex flex-wrap gap-2 mb-3">
+                      {gift.gift_categories.map((catId) => {
+                        const cat = giftCategoryMap.get(catId);
+                        if (!cat) return null;
+                        return (
+                          <span
+                            key={catId}
+                            className="flex items-center gap-1.5 px-3 py-1.5 rounded-[4px] text-sm font-medium"
+                            style={{ background: 'var(--color-cream)', border: '1px solid var(--color-border)' }}
+                          >
+                            <span>{cat.icon}</span>
+                            <span>{locale === 'ja' ? cat.name_ja : cat.name_en}</span>
+                          </span>
+                        );
+                      })}
+                    </div>
+                    {(locale === 'ja' ? gift.description_ja : gift.description_en) && (
+                      <p className="text-sm leading-relaxed whitespace-pre-line" style={{ color: 'var(--color-ink2)' }}>
+                        {locale === 'ja' ? gift.description_ja : gift.description_en}
+                      </p>
+                    )}
+                  </Card>
+                ))}
+              </>
+            )}
+            {race.completion_gifts.length > 0 && (
+              <>
+                {race.participation_gifts.length > 0 && (
+                  <p className="text-xs font-semibold uppercase tracking-widest mt-4 mb-2" style={{ color: 'var(--color-mid)' }}>
+                    {locale === 'ja' ? '完走賞' : 'Finisher Gift'}
+                  </p>
+                )}
+                {race.completion_gifts.map((gift, i) => (
+                  <Card key={i}>
+                    <div className="flex flex-wrap gap-2 mb-3">
+                      {gift.gift_categories.map((catId) => {
+                        const cat = giftCategoryMap.get(catId);
+                        if (!cat) return null;
+                        return (
+                          <span
+                            key={catId}
+                            className="flex items-center gap-1.5 px-3 py-1.5 rounded-[4px] text-sm font-medium"
+                            style={{ background: 'var(--color-cream)', border: '1px solid var(--color-border)' }}
+                          >
+                            <span>{cat.icon}</span>
+                            <span>{locale === 'ja' ? cat.name_ja : cat.name_en}</span>
+                          </span>
+                        );
+                      })}
+                    </div>
+                    {(locale === 'ja' ? gift.description_ja : gift.description_en) && (
+                      <p className="text-sm leading-relaxed whitespace-pre-line" style={{ color: 'var(--color-ink2)' }}>
+                        {locale === 'ja' ? gift.description_ja : gift.description_en}
+                      </p>
+                    )}
+                  </Card>
+                ))}
+              </>
+            )}
           </section>
         )}
 

--- a/src/data/races/abashiri-marathon-2026.json
+++ b/src/data/races/abashiri-marathon-2026.json
@@ -53,7 +53,6 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "medal",
         "goods"
       ],
       "description_ja": "YAMAtune製オリジナルソックス、ランニンググローブ、おもてなしブース飲食券",
@@ -105,5 +104,15 @@
     "data_accuracy_notes": [
       "2026-05-25: 自動クロールで更新"
     ]
-  }
+  },
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "YAMAtune製オリジナルソックス、ランニンググローブ、おもてなしブース飲食券",
+      "description_en": "",
+      "image": null
+    }
+  ]
 }

--- a/src/data/races/aomori-sakura-marathon-2026.json
+++ b/src/data/races/aomori-sakura-marathon-2026.json
@@ -82,8 +82,7 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "tshirt",
-        "medal"
+        "tshirt"
       ],
       "description_ja": "大会Tシャツ、完走メダル",
       "description_en": "Race T-shirt, Finisher medal",
@@ -162,6 +161,16 @@
     {
       "url": "https://aomori-sakuramarathon.com/qa/",
       "label": "FAQ"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "大会Tシャツ、完走メダル",
+      "description_en": "Race T-shirt, Finisher medal",
+      "image": null
     }
   ]
 }

--- a/src/data/races/challenge-fuji5lakes-2026.json
+++ b/src/data/races/challenge-fuji5lakes-2026.json
@@ -271,7 +271,6 @@
     {
       "gift_categories": [
         "tshirt",
-        "medal",
         "towel"
       ],
       "description_ja": "大会オリジナルTシャツ（THE NORTH FACE製・先着2,800名。先着数到達後はオリジナルタオルに変更）、完走メダル（完走者）、WEB完走証（完走者）",
@@ -373,6 +372,16 @@
     {
       "url": "https://www.r-wellness.com/fuji5/faq/",
       "label": "FAQ"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "大会オリジナルTシャツ（THE NORTH FACE製・先着2,800名。先着数到達後はオリジナルタオルに変更）、完走メダル（完走者）、WEB完走証（完走者）",
+      "description_en": "Official race T-shirt by THE NORTH FACE (first 2,800 entries; changes to original towel after limit reached), Finisher medal (finishers), Web finisher certificate (finishers)",
+      "image": null
     }
   ]
 }

--- a/src/data/races/chiba-aqualine-marathon-2026.json
+++ b/src/data/races/chiba-aqualine-marathon-2026.json
@@ -66,7 +66,6 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "medal",
         "tshirt"
       ],
       "description_ja": "参加賞Tシャツ、完走メダル",
@@ -149,6 +148,16 @@
     {
       "url": "https://chiba-aqualine-marathon.com/runner/guidelines.html",
       "label": "大会要項"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "参加賞Tシャツ、完走メダル",
+      "description_en": "",
+      "image": null
     }
   ]
 }

--- a/src/data/races/ehime-marathon-2026.json
+++ b/src/data/races/ehime-marathon-2026.json
@@ -87,7 +87,6 @@
     {
       "gift_categories": [
         "tshirt",
-        "medal",
         "towel"
       ],
       "description_ja": "大会オリジナルTシャツ、完走メダル、今治タオル（完走者）",
@@ -161,6 +160,16 @@
     {
       "url": "https://ehimemarathon.jp/access/",
       "label": "アクセス"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "大会オリジナルTシャツ、完走メダル、今治タオル（完走者）",
+      "description_en": "Official race T-shirt, Finisher medal, Imabari towel (finishers)",
+      "image": null
     }
   ]
 }

--- a/src/data/races/fujisan-marathon-2026.json
+++ b/src/data/races/fujisan-marathon-2026.json
@@ -78,7 +78,6 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "medal",
         "tshirt",
         "towel"
       ],
@@ -146,6 +145,16 @@
     {
       "url": "https://mtfujimarathon.com/access/",
       "label": "アクセス"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "大会Tシャツ、完走メダル、フィニッシャータオル",
+      "description_en": "Race T-shirt, Finisher medal, Finisher towel",
+      "image": null
     }
   ]
 }

--- a/src/data/races/fukuchiyama-marathon-2026.json
+++ b/src/data/races/fukuchiyama-marathon-2026.json
@@ -86,7 +86,6 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "medal",
         "tshirt"
       ],
       "description_ja": "完走メダル、大会オリジナルTシャツ（レイト・直前申込を除く）",
@@ -165,6 +164,16 @@
     {
       "url": "https://fukuchiyama-marathon.com/access/",
       "label": "アクセス"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "完走メダル、大会オリジナルTシャツ（レイト・直前申込を除く）",
+      "description_en": "Finisher medal, Official race T-shirt (excluding late/last-minute entries)",
+      "image": null
     }
   ]
 }

--- a/src/data/races/fukui-sakura-marathon-2026.json
+++ b/src/data/races/fukui-sakura-marathon-2026.json
@@ -93,7 +93,6 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "medal",
         "tshirt",
         "towel"
       ],
@@ -168,6 +167,16 @@
     {
       "url": "https://www.fukui-sakura-marathon.jp/stay/",
       "label": "アクセス"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "大会Tシャツ、完走メダル、フィニッシャータオル",
+      "description_en": "Race T-shirt, Finisher medal, Finisher towel",
+      "image": null
     }
   ]
 }

--- a/src/data/races/fukuoka-marathon-2026.json
+++ b/src/data/races/fukuoka-marathon-2026.json
@@ -133,7 +133,6 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "medal",
         "tshirt"
       ],
       "description_ja": "完走メダル、大会オリジナルTシャツ",
@@ -196,6 +195,16 @@
     {
       "url": "https://www.f-marathon.jp/traffic/",
       "label": "アクセス"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "完走メダル、大会オリジナルTシャツ",
+      "description_en": "Finisher medal, Official race T-shirt",
+      "image": null
     }
   ]
 }

--- a/src/data/races/gunma-marathon-2026.json
+++ b/src/data/races/gunma-marathon-2026.json
@@ -86,7 +86,6 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "medal",
         "tshirt"
       ],
       "description_ja": "大会Tシャツ、完走メダル",
@@ -174,6 +173,16 @@
     {
       "url": "https://www.g-marathon.com/info/",
       "label": "開催概要"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "大会Tシャツ、完走メダル",
+      "description_en": "Race T-shirt, Finisher medal",
+      "image": null
     }
   ]
 }

--- a/src/data/races/himeji-castle-marathon-2026.json
+++ b/src/data/races/himeji-castle-marathon-2026.json
@@ -68,7 +68,6 @@
     {
       "gift_categories": [
         "tshirt",
-        "medal",
         "towel"
       ],
       "description_ja": "大会Tシャツ、完走メダル、フィニッシャータオル",
@@ -135,6 +134,16 @@
     {
       "url": "https://www.himeji-marathon.jp/participation/index.html",
       "label": "エントリー"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "大会Tシャツ、完走メダル、フィニッシャータオル",
+      "description_en": "Race T-shirt, Finisher medal, Finisher towel",
+      "image": null
     }
   ]
 }

--- a/src/data/races/hitachi-seaside-marathon-2026.json
+++ b/src/data/races/hitachi-seaside-marathon-2026.json
@@ -62,7 +62,6 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "medal",
         "towel"
       ],
       "description_ja": "出走特典\n（タオル）\n\n完走賞\n（完走メダル）",
@@ -98,6 +97,16 @@
     {
       "url": "https://hitachi-marathon.jp/2025/wp-content/uploads/2025/08/roadclosure2025.pdf",
       "label": "アクセス"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "出走特典\n（タオル）\n\n完走賞\n（完走メダル）",
+      "description_en": "",
+      "image": null
     }
   ]
 }

--- a/src/data/races/hofu-yomiuri-marathon-2026.json
+++ b/src/data/races/hofu-yomiuri-marathon-2026.json
@@ -66,16 +66,7 @@
     }
   ],
   "weather_history": [],
-  "participation_gifts": [
-    {
-      "gift_categories": [
-        "medal"
-      ],
-      "description_ja": "完走メダル",
-      "description_en": "Finisher medal",
-      "image": null
-    }
-  ],
+  "participation_gifts": [],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
   "updated_at": "2026-05-30T06:35:00.134Z",
@@ -121,6 +112,16 @@
     {
       "url": "https://hofu-yomiuri.jp/course/",
       "label": "コース情報"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "完走メダル",
+      "description_en": "Finisher medal",
+      "image": null
     }
   ]
 }

--- a/src/data/races/hokkaido-marathon-2026.json
+++ b/src/data/races/hokkaido-marathon-2026.json
@@ -98,8 +98,7 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "tshirt",
-        "medal"
+        "tshirt"
       ],
       "description_ja": "大会オリジナルTシャツ、完走メダル",
       "description_en": "Official race T-shirt, Finisher medal",
@@ -178,6 +177,16 @@
     {
       "url": "https://hokkaido-marathon.com/info/12731/",
       "label": "開催概要"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "大会オリジナルTシャツ、完走メダル",
+      "description_en": "Official race T-shirt, Finisher medal",
+      "image": null
     }
   ]
 }

--- a/src/data/races/itabashi-city-marathon-2026.json
+++ b/src/data/races/itabashi-city-marathon-2026.json
@@ -81,8 +81,7 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "tshirt",
-        "medal"
+        "tshirt"
       ],
       "description_ja": "大会Tシャツ、完走メダル",
       "description_en": "Race T-shirt, Finisher medal",
@@ -145,6 +144,16 @@
     {
       "url": "https://i-c-m.jp/faq/",
       "label": "FAQ"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "大会Tシャツ、完走メダル",
+      "description_en": "Race T-shirt, Finisher medal",
+      "image": null
     }
   ]
 }

--- a/src/data/races/iwaki-sunshine-marathon-2026.json
+++ b/src/data/races/iwaki-sunshine-marathon-2026.json
@@ -95,8 +95,7 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "tshirt",
-        "medal"
+        "tshirt"
       ],
       "description_ja": "大会Tシャツ、完走メダル",
       "description_en": "Race T-shirt, Finisher medal",
@@ -163,6 +162,16 @@
     {
       "url": "https://iwaki-marathon.jp/access/",
       "label": "アクセス"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "大会Tシャツ、完走メダル",
+      "description_en": "Race T-shirt, Finisher medal",
+      "image": null
     }
   ]
 }

--- a/src/data/races/iwate-morioka-city-marathon-2026.json
+++ b/src/data/races/iwate-morioka-city-marathon-2026.json
@@ -62,7 +62,6 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "medal",
         "towel"
       ],
       "description_ja": "完走賞\tフィニッシャータオル、南部鉄器製完走メダル",
@@ -109,5 +108,15 @@
     "data_accuracy_notes": [
       "2026-05-30: 自動クロールで更新"
     ]
-  }
+  },
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "完走賞\tフィニッシャータオル、南部鉄器製完走メダル",
+      "description_en": "",
+      "image": null
+    }
+  ]
 }

--- a/src/data/races/iwate-oshu-kirameki-marathon-2026.json
+++ b/src/data/races/iwate-oshu-kirameki-marathon-2026.json
@@ -77,8 +77,7 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "tshirt",
-        "medal"
+        "tshirt"
       ],
       "description_ja": "大会Tシャツ、完走メダル",
       "description_en": "Race T-shirt, Finisher medal",
@@ -135,6 +134,16 @@
     {
       "url": "https://oshukirameki.jp/course/",
       "label": "コース情報"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "大会Tシャツ、完走メダル",
+      "description_en": "Race T-shirt, Finisher medal",
+      "image": null
     }
   ]
 }

--- a/src/data/races/izu-oshima-2026.json
+++ b/src/data/races/izu-oshima-2026.json
@@ -150,16 +150,7 @@
       "url": "https://do.l-tike.com/app/dss/race/detail?acd=nemqQ8yPKR7"
     }
   ],
-  "participation_gifts": [
-    {
-      "gift_categories": [
-        "medal"
-      ],
-      "description_ja": "オリジナル完走メダル",
-      "description_en": "",
-      "image": null
-    }
-  ],
+  "participation_gifts": [],
   "motif": "三原山",
   "motif_romaji": "Mt.MIHARA",
   "motif_color": null,
@@ -170,5 +161,15 @@
   "hero_caption_en": null,
   "gallery": [],
   "voices": [],
-  "time_buckets": []
+  "time_buckets": [],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "オリジナル完走メダル",
+      "description_en": "",
+      "image": null
+    }
+  ]
 }

--- a/src/data/races/kagoshima-marathon-2026.json
+++ b/src/data/races/kagoshima-marathon-2026.json
@@ -83,8 +83,7 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "tshirt",
-        "medal"
+        "tshirt"
       ],
       "description_ja": "大会Tシャツ、完走メダル",
       "description_en": "Race T-shirt, Finisher medal",
@@ -157,6 +156,16 @@
     {
       "url": "https://www.kagoshima-marathon.jp/faq/",
       "label": "FAQ"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "大会Tシャツ、完走メダル",
+      "description_en": "Race T-shirt, Finisher medal",
+      "image": null
     }
   ]
 }

--- a/src/data/races/kaikyo-marathon-2026.json
+++ b/src/data/races/kaikyo-marathon-2026.json
@@ -96,7 +96,6 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "medal",
         "tshirt"
       ],
       "description_ja": "完走メダル、大会オリジナルTシャツ",
@@ -177,6 +176,16 @@
     {
       "url": "https://kaikyomarathon.jp/qa/",
       "label": "FAQ"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "完走メダル、大会オリジナルTシャツ",
+      "description_en": "Finisher medal, Official race T-shirt",
+      "image": null
     }
   ]
 }

--- a/src/data/races/kanazawa-marathon-2026.json
+++ b/src/data/races/kanazawa-marathon-2026.json
@@ -100,7 +100,6 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "medal",
         "tshirt",
         "local_product"
       ],
@@ -165,5 +164,15 @@
     }
   ],
   "entry_closed": false,
-  "entry_links": []
+  "entry_links": [],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "大会オリジナルTシャツ、完走メダル、地元特産品",
+      "description_en": "Official race T-shirt, Finisher medal, Local specialty products",
+      "image": null
+    }
+  ]
 }

--- a/src/data/races/kasumigaura-marathon-2026.json
+++ b/src/data/races/kasumigaura-marathon-2026.json
@@ -91,8 +91,7 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "tshirt",
-        "medal"
+        "tshirt"
       ],
       "description_ja": "大会Tシャツ、完走メダル",
       "description_en": "Race T-shirt, Finisher medal",
@@ -159,6 +158,16 @@
     {
       "url": "https://www.kasumigaura-marathon.jp/faq/",
       "label": "FAQ"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "大会Tシャツ、完走メダル",
+      "description_en": "Race T-shirt, Finisher medal",
+      "image": null
     }
   ]
 }

--- a/src/data/races/kitakyushu-marathon-2026.json
+++ b/src/data/races/kitakyushu-marathon-2026.json
@@ -80,7 +80,6 @@
     {
       "gift_categories": [
         "tshirt",
-        "medal",
         "towel"
       ],
       "description_ja": "大会Tシャツ、完走メダル、フィニッシャータオル",
@@ -154,6 +153,16 @@
     {
       "url": "https://kitakyushu-marathon.jp/qa/",
       "label": "FAQ"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "大会Tシャツ、完走メダル、フィニッシャータオル",
+      "description_en": "Race T-shirt, Finisher medal, Finisher towel",
+      "image": null
     }
   ]
 }

--- a/src/data/races/kobe-marathon-2026.json
+++ b/src/data/races/kobe-marathon-2026.json
@@ -98,7 +98,6 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "medal",
         "tshirt",
         "towel"
       ],
@@ -180,6 +179,16 @@
     {
       "url": "https://www.kobe-marathon.net/2026/support/expo/expoinfo/",
       "label": "開催概要"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "大会オリジナルTシャツ、完走メダル、フィニッシャータオル",
+      "description_en": "Official race T-shirt, Finisher medal, Finisher towel",
+      "image": null
     }
   ]
 }

--- a/src/data/races/kochi-ryoma-marathon-2026.json
+++ b/src/data/races/kochi-ryoma-marathon-2026.json
@@ -86,8 +86,7 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "tshirt",
-        "medal"
+        "tshirt"
       ],
       "description_ja": "大会Tシャツ、完走メダル",
       "description_en": "Race T-shirt, Finisher medal",
@@ -166,6 +165,16 @@
     {
       "url": "https://ryoma-marathon.jp/faq/",
       "label": "FAQ"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "大会Tシャツ、完走メダル",
+      "description_en": "Race T-shirt, Finisher medal",
+      "image": null
     }
   ]
 }

--- a/src/data/races/kumamoto-castle-marathon-2026.json
+++ b/src/data/races/kumamoto-castle-marathon-2026.json
@@ -85,8 +85,7 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "tshirt",
-        "medal"
+        "tshirt"
       ],
       "description_ja": "大会Tシャツ、完走メダル",
       "description_en": "Race T-shirt, Finisher medal",
@@ -153,6 +152,16 @@
     {
       "url": "https://kumamotojyo-marathon.jp/traffic.php",
       "label": "アクセス"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "大会Tシャツ、完走メダル",
+      "description_en": "Race T-shirt, Finisher medal",
+      "image": null
     }
   ]
 }

--- a/src/data/races/kyoto-marathon-2026.json
+++ b/src/data/races/kyoto-marathon-2026.json
@@ -97,8 +97,7 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "tshirt",
-        "medal"
+        "tshirt"
       ],
       "description_ja": "大会オリジナルTシャツ、完走メダル",
       "description_en": "Official race T-shirt, Finisher medal",
@@ -189,6 +188,16 @@
     {
       "url": "https://kyoto-marathon.com/faq/",
       "label": "FAQ"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "大会オリジナルTシャツ、完走メダル",
+      "description_en": "Official race T-shirt, Finisher medal",
+      "image": null
     }
   ]
 }

--- a/src/data/races/mie-matsusaka-marathon-2026.json
+++ b/src/data/races/mie-matsusaka-marathon-2026.json
@@ -72,7 +72,6 @@
     {
       "gift_categories": [
         "tshirt",
-        "medal",
         "local_product"
       ],
       "description_ja": "大会Tシャツ、完走メダル、松阪の特産品",
@@ -133,6 +132,16 @@
     {
       "url": "https://mie-matsusaka-marathon.jp/runner/",
       "label": "エントリー"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "大会Tシャツ、完走メダル、松阪の特産品",
+      "description_en": "Race T-shirt, Finisher medal, Matsusaka local products",
+      "image": null
     }
   ]
 }

--- a/src/data/races/mito-komon-manyu-marathon-2026.json
+++ b/src/data/races/mito-komon-manyu-marathon-2026.json
@@ -76,7 +76,6 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "medal",
         "tshirt"
       ],
       "description_ja": "大会Tシャツ、完走メダル",
@@ -144,6 +143,16 @@
     {
       "url": "https://www.mitokomon-manyu-marathon.com/qa/index.html",
       "label": "FAQ"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "大会Tシャツ、完走メダル",
+      "description_en": "Race T-shirt, Finisher medal",
+      "image": null
     }
   ]
 }

--- a/src/data/races/nagano-marathon-2026.json
+++ b/src/data/races/nagano-marathon-2026.json
@@ -275,7 +275,6 @@
     {
       "gift_categories": [
         "tshirt",
-        "medal",
         "towel"
       ],
       "description_ja": "大会オリジナルTシャツ（参加者全員）、完走メダル（完走者）、フィニッシャータオル（完走者）",
@@ -377,6 +376,16 @@
     {
       "url": "https://www.naganomarathon.gr.jp/stay/",
       "label": "アクセス"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "大会オリジナルTシャツ（参加者全員）、完走メダル（完走者）、フィニッシャータオル（完走者）",
+      "description_en": "Official race T-shirt (all participants), Finisher medal (finishers), Finisher towel (finishers)",
+      "image": null
     }
   ]
 }

--- a/src/data/races/nagoya-womens-marathon-2026.json
+++ b/src/data/races/nagoya-womens-marathon-2026.json
@@ -86,7 +86,6 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "medal",
         "goods"
       ],
       "description_ja": "ティファニー オリジナルペンダント（完走者全員）",
@@ -152,6 +151,16 @@
     {
       "url": "https://womens-marathon.nagoya/course/",
       "label": "コース情報"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "ティファニー オリジナルペンダント（完走者全員）",
+      "description_en": "Tiffany original pendant (all finishers)",
+      "image": null
     }
   ]
 }

--- a/src/data/races/naha-marathon-2026.json
+++ b/src/data/races/naha-marathon-2026.json
@@ -88,7 +88,6 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "medal",
         "tshirt"
       ],
       "description_ja": "大会オリジナルTシャツ、完走メダル",
@@ -140,5 +139,15 @@
     }
   ],
   "entry_closed": false,
-  "entry_links": []
+  "entry_links": [],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "大会オリジナルTシャツ、完走メダル",
+      "description_en": "Official race T-shirt, Finisher medal",
+      "image": null
+    }
+  ]
 }

--- a/src/data/races/nara-marathon-2026.json
+++ b/src/data/races/nara-marathon-2026.json
@@ -86,7 +86,6 @@
     {
       "gift_categories": [
         "tshirt",
-        "medal",
         "towel"
       ],
       "description_ja": "大会オリジナルTシャツ、完走メダル、フィニッシャータオル",
@@ -165,6 +164,16 @@
     {
       "url": "https://www.nara-marathon.jp/entry.html",
       "label": "エントリー"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "大会オリジナルTシャツ、完走メダル、フィニッシャータオル",
+      "description_en": "Official race T-shirt, Finisher medal, Finisher towel",
+      "image": null
     }
   ]
 }

--- a/src/data/races/okayama-marathon-2026.json
+++ b/src/data/races/okayama-marathon-2026.json
@@ -72,7 +72,6 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "medal",
         "tshirt"
       ],
       "description_ja": "大会Tシャツ、完走メダル",
@@ -147,6 +146,16 @@
     {
       "url": "https://www.okayamamarathon.jp/faq/",
       "label": "FAQ"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "大会Tシャツ、完走メダル",
+      "description_en": "Race T-shirt, Finisher medal",
+      "image": null
     }
   ]
 }

--- a/src/data/races/osaka-marathon-2026.json
+++ b/src/data/races/osaka-marathon-2026.json
@@ -99,7 +99,6 @@
     {
       "gift_categories": [
         "tshirt",
-        "medal",
         "towel"
       ],
       "description_ja": "参加記念Tシャツ、完走メダル、フィニッシャータオル",
@@ -177,6 +176,16 @@
     {
       "url": "https://www.osaka-marathon.com/2026/expo/outline/",
       "label": "大会の特色"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "参加記念Tシャツ、完走メダル、フィニッシャータオル",
+      "description_en": "Commemorative T-shirt, Finisher medal, Finisher towel",
+      "image": null
     }
   ]
 }

--- a/src/data/races/sado-toki-marathon-2026.json
+++ b/src/data/races/sado-toki-marathon-2026.json
@@ -87,7 +87,6 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "medal",
         "tshirt",
         "local_product"
       ],
@@ -146,5 +145,15 @@
     }
   ],
   "entry_closed": false,
-  "entry_links": []
+  "entry_links": [],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "大会Tシャツ、完走メダル、佐渡の特産品",
+      "description_en": "Race T-shirt, Finisher medal, Sado Island local products",
+      "image": null
+    }
+  ]
 }

--- a/src/data/races/saga-sakura-marathon-2026.json
+++ b/src/data/races/saga-sakura-marathon-2026.json
@@ -71,8 +71,7 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "tshirt",
-        "medal"
+        "tshirt"
       ],
       "description_ja": "大会Tシャツ、完走メダル",
       "description_en": "Race T-shirt, Finisher medal",
@@ -137,6 +136,16 @@
     {
       "url": "https://sagasakura-marathon.jp/traffic/",
       "label": "アクセス"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "大会Tシャツ、完走メダル",
+      "description_en": "Race T-shirt, Finisher medal",
+      "image": null
     }
   ]
 }

--- a/src/data/races/shizuoka-marathon-2026.json
+++ b/src/data/races/shizuoka-marathon-2026.json
@@ -77,7 +77,6 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "medal",
         "tshirt"
       ],
       "description_ja": "大会Tシャツ、完走メダル",
@@ -131,5 +130,15 @@
     }
   ],
   "entry_closed": false,
-  "entry_links": []
+  "entry_links": [],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "大会Tシャツ、完走メダル",
+      "description_en": "Race T-shirt, Finisher medal",
+      "image": null
+    }
+  ]
 }

--- a/src/data/races/shonan-international-marathon-2026.json
+++ b/src/data/races/shonan-international-marathon-2026.json
@@ -90,7 +90,6 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "medal",
         "tshirt"
       ],
       "description_ja": "大会Tシャツ、完走メダル",
@@ -160,5 +159,15 @@
     }
   ],
   "entry_closed": false,
-  "entry_links": []
+  "entry_links": [],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "大会Tシャツ、完走メダル",
+      "description_en": "Race T-shirt, Finisher medal",
+      "image": null
+    }
+  ]
 }

--- a/src/data/races/soja-kibiji-marathon-2026.json
+++ b/src/data/races/soja-kibiji-marathon-2026.json
@@ -72,7 +72,6 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "medal",
         "tshirt"
       ],
       "description_ja": "大会Tシャツ、完走メダル",
@@ -153,6 +152,16 @@
     {
       "url": "https://soja-kibijimarathon.jp/wp/access/",
       "label": "アクセス"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "大会Tシャツ、完走メダル",
+      "description_en": "Race T-shirt, Finisher medal",
+      "image": null
     }
   ]
 }

--- a/src/data/races/tateyama-wakashio-2026.json
+++ b/src/data/races/tateyama-wakashio-2026.json
@@ -84,8 +84,7 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "tshirt",
-        "medal"
+        "tshirt"
       ],
       "description_ja": "大会Tシャツ、完走メダル",
       "description_en": "Race T-shirt, Finisher medal",
@@ -140,6 +139,16 @@
     {
       "url": "https://tateyama-wakasio.jp/faq/",
       "label": "FAQ"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "大会Tシャツ、完走メダル",
+      "description_en": "Race T-shirt, Finisher medal",
+      "image": null
     }
   ]
 }

--- a/src/data/races/tokushima-marathon-2026.json
+++ b/src/data/races/tokushima-marathon-2026.json
@@ -69,8 +69,7 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "tshirt",
-        "medal"
+        "tshirt"
       ],
       "description_ja": "大会Tシャツ、完走メダル",
       "description_en": "Race T-shirt, Finisher medal",
@@ -129,6 +128,16 @@
     {
       "url": "https://www.tokushima-marathon.jp/regulation/",
       "label": "アクセス"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "大会Tシャツ、完走メダル",
+      "description_en": "Race T-shirt, Finisher medal",
+      "image": null
     }
   ]
 }

--- a/src/data/races/tokyo-legacy-half-2026.json
+++ b/src/data/races/tokyo-legacy-half-2026.json
@@ -76,7 +76,6 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "medal",
         "goods"
       ],
       "description_ja": "",
@@ -107,6 +106,16 @@
     {
       "url": "https://legacyhalf.tokyo/news/detail/news_0248.html",
       "label": "エントリー"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "",
+      "description_en": "",
+      "image": null
     }
   ]
 }

--- a/src/data/races/tokyo-marathon-2026.json
+++ b/src/data/races/tokyo-marathon-2026.json
@@ -121,7 +121,6 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "medal",
         "tshirt",
         "towel"
       ],
@@ -219,6 +218,16 @@
     {
       "url": "https://www.marathon.tokyo/participants/",
       "label": "エントリー"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "参加記念Tシャツ（参加者全員）、完走メダル（完走者）、完走タオル（完走者）",
+      "description_en": "Commemorative T-shirt (all participants), Finisher medal (finishers), Finisher towel (finishers)",
+      "image": null
     }
   ]
 }

--- a/src/data/races/tokyo-marathon-2027.json
+++ b/src/data/races/tokyo-marathon-2027.json
@@ -121,7 +121,6 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "medal",
         "tshirt",
         "towel"
       ],
@@ -219,6 +218,16 @@
     {
       "url": "https://www.marathon.tokyo/participants/",
       "label": "エントリー"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "参加記念Tシャツ（参加者全員）、完走メダル（完走者）、完走タオル（完走者）",
+      "description_en": "Commemorative T-shirt (all participants), Finisher medal (finishers), Finisher towel (finishers)",
+      "image": null
     }
   ]
 }

--- a/src/data/races/tottori-marathon-2026.json
+++ b/src/data/races/tottori-marathon-2026.json
@@ -71,7 +71,6 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "medal",
         "tshirt",
         "towel",
         "local_product"
@@ -143,6 +142,16 @@
     {
       "url": "https://tottori-marathon.jp/faq/",
       "label": "FAQ"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "大会Tシャツ\n●完走賞\n・完走証\n・特別メダル\n・フィニッシャータオル\n・鳥取のお土産\n・スポンサードリンク\n",
+      "description_en": "Race T-shirt",
+      "image": null
     }
   ]
 }

--- a/src/data/races/toyako-marathon-2026.json
+++ b/src/data/races/toyako-marathon-2026.json
@@ -84,7 +84,6 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "medal",
         "tshirt"
       ],
       "description_ja": "大会Tシャツとトートバッグ及びフェイスタオル、完走メダル",
@@ -150,6 +149,16 @@
     {
       "url": "https://www.toyako-marathon.jp/course/",
       "label": "コース情報"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "大会Tシャツとトートバッグ及びフェイスタオル、完走メダル",
+      "description_en": "Race T-shirt, Finisher medal",
+      "image": null
     }
   ]
 }

--- a/src/data/races/toyama-marathon-2026.json
+++ b/src/data/races/toyama-marathon-2026.json
@@ -83,7 +83,6 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "medal",
         "tshirt",
         "towel"
       ],
@@ -165,6 +164,16 @@
     {
       "url": "https://www.toyamamarathon.com/faq/",
       "label": "FAQ"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "大会Tシャツ、完走メダル・フィニッシャータオル",
+      "description_en": "Race T-shirt, Finisher medal",
+      "image": null
     }
   ]
 }

--- a/src/data/races/wakkanai-peace-marathon-2026.json
+++ b/src/data/races/wakkanai-peace-marathon-2026.json
@@ -85,7 +85,6 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "medal",
         "tshirt"
       ],
       "description_ja": "完走メダル、大会オリジナルTシャツ",
@@ -157,6 +156,16 @@
     {
       "url": "https://wakkanai-marathon.jp/course/",
       "label": "コース情報"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "完走メダル、大会オリジナルTシャツ",
+      "description_en": "Finisher medal, Official race T-shirt",
+      "image": null
     }
   ]
 }

--- a/src/data/races/yokohama-marathon-2026.json
+++ b/src/data/races/yokohama-marathon-2026.json
@@ -84,7 +84,6 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "medal",
         "tshirt",
         "towel"
       ],
@@ -164,6 +163,16 @@
     {
       "url": "https://yokohamamarathon.jp/volunteerqa/",
       "label": "FAQ"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal"
+      ],
+      "description_ja": "大会Tシャツ、完走メダル、フィニッシャータオル",
+      "description_en": "Race T-shirt, Finisher medal, Finisher towel",
+      "image": null
     }
   ]
 }

--- a/src/lib/__tests__/fixtures.ts
+++ b/src/lib/__tests__/fixtures.ts
@@ -1,8 +1,9 @@
-import type { Race, RaceCategory, EntryPeriod, EntryLink, RaceGallery, RaceVoice, RaceTimeBucket, RaceCourseHighlight, ParticipationGift } from '../types';
+import type { Race, RaceCategory, EntryPeriod, EntryLink, RaceGallery, RaceVoice, RaceTimeBucket, RaceCourseHighlight, ParticipationGift, CompletionGift } from '../types';
 
 /** テスト用の最小限 Race オブジェクトを生成するファクトリ */
 export function makeRace(overrides: Partial<Race> = {}): Race {
   return {
+    completion_gifts: [],
     id: 'test-race-2026',
     name_ja: 'テスト大会2026',
     name_en: 'Test Race 2026',
@@ -169,6 +170,16 @@ export function makeParticipationGift(overrides: Partial<ParticipationGift> = {}
     gift_categories: ['medal'],
     description_ja: 'テスト参加賞',
     description_en: 'Test participation gift',
+    image: null,
+    ...overrides,
+  };
+}
+
+export function makeCompletionGift(overrides: Partial<CompletionGift> = {}): CompletionGift {
+  return {
+    gift_categories: ['medal'],
+    description_ja: 'テスト完走賞',
+    description_en: 'Test completion gift',
     image: null,
     ...overrides,
   };

--- a/src/lib/__tests__/utils.filter.test.ts
+++ b/src/lib/__tests__/utils.filter.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { vi } from 'vitest';
 import { filterRaces, sortRacesByDate, sortRaces, emptyFilter } from '../utils';
-import { makeRace, makeCategory, makeEntryPeriod, makeParticipationGift } from './fixtures';
+import { makeRace, makeCategory, makeEntryPeriod, makeParticipationGift, makeCompletionGift } from './fixtures';
 import type { Race } from '../types';
 
 const TODAY = '2026-04-02';
@@ -242,6 +242,30 @@ describe('filterRaces - giftCategories フィルタ', () => {
     ];
     const result = filterRaces(races, { ...emptyFilter(), giftCategories: ['medal'] });
     expect(result).toHaveLength(1);
+  });
+});
+
+describe('filterRaces - completion_gifts を含む giftCategories フィルタ', () => {
+  it('completion_gifts にのみ medal がある大会が medal フィルタにヒットする', () => {
+    const races = [
+      makeRace({ id: 'completion-medal', participation_gifts: [], completion_gifts: [makeCompletionGift({ gift_categories: ['medal'] })] }),
+      makeRace({ id: 'no-gift', participation_gifts: [], completion_gifts: [] }),
+    ];
+    const result = filterRaces(races, { ...emptyFilter(), giftCategories: ['medal'] });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('completion-medal');
+  });
+
+  it('participation_gifts と completion_gifts 両方を合算してフィルタする', () => {
+    const races = [
+      makeRace({ id: 'both', participation_gifts: [makeParticipationGift({ gift_categories: ['tshirt'] })], completion_gifts: [makeCompletionGift({ gift_categories: ['medal'] })] }),
+      makeRace({ id: 'only-completion', participation_gifts: [], completion_gifts: [makeCompletionGift({ gift_categories: ['medal'] })] }),
+      makeRace({ id: 'no-medal', participation_gifts: [makeParticipationGift({ gift_categories: ['tshirt'] })], completion_gifts: [] }),
+    ];
+    const result = filterRaces(races, { ...emptyFilter(), giftCategories: ['medal'] });
+    expect(result).toHaveLength(2);
+    expect(result.map(r => r.id)).toContain('both');
+    expect(result.map(r => r.id)).toContain('only-completion');
   });
 });
 

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -4,7 +4,7 @@ import * as schema from "./db/schema";
 import type {
   Race, Prefecture, GiftCategory, RaceCategory, Wave, CourseInfo,
   AidStation, Checkpoint, AccessPoint, NearbySpot, WeatherHistory,
-  ParticipationGift, GiftCategoryId, CourseSurface, ReceptionType, NearbySpotType,
+  ParticipationGift, CompletionGift, GiftCategoryId, CourseSurface, ReceptionType, NearbySpotType,
   RaceSeries, RaceResult, EntryPeriod, EntryLink,
   RaceGallery, RaceVoice, RaceTimeBucket, RaceCourseHighlight,
 } from "./types";
@@ -29,6 +29,7 @@ type AccessPointRow = typeof schema.access_points.$inferSelect;
 type NearbySpotRow = typeof schema.nearby_spots.$inferSelect;
 type WeatherRow = typeof schema.weather_history.$inferSelect;
 type GiftRow = typeof schema.participation_gifts.$inferSelect;
+type CompletionGiftRow = typeof schema.completion_gifts.$inferSelect;
 
 function rowToCategory(row: CategoryRow, highlights: CourseHighlightRow[] = []): RaceCategory {
   return {
@@ -106,7 +107,7 @@ function rowToWeather(row: WeatherRow): WeatherHistory {
   };
 }
 
-function rowToGift(row: GiftRow): ParticipationGift {
+function rowToGift(row: GiftRow | CompletionGiftRow): ParticipationGift | CompletionGift {
   return {
     gift_categories: parseJson<GiftCategoryId[]>(row.gift_categories, []),
     description_ja: row.description_ja,
@@ -229,6 +230,7 @@ function assembleRace(
   voiceRows: VoiceRow[] = [],
   timeBucketRows: TimeBucketRow[] = [],
   courseHighlightRows: CourseHighlightRow[] = [],
+  completionGiftRows: CompletionGiftRow[] = [],
 ): Race {
   const course_info: CourseInfo = {
     max_elevation_m: row.course_max_elevation_m,
@@ -285,7 +287,8 @@ function assembleRace(
     access_points: accessPointRows.map(rowToAccessPoint),
     nearby_spots: nearbySpotRows.map(rowToNearbySpot),
     weather_history: weatherRows.map(rowToWeather),
-    participation_gifts: giftRows.map(rowToGift),
+    participation_gifts: giftRows.map(rowToGift) as ParticipationGift[],
+    completion_gifts: completionGiftRows.map(rowToGift) as CompletionGift[],
     entry_periods: entryPeriodRows.map(rowToEntryPeriod),
     entry_links: entryLinkRows.map(rowToEntryLink),
     result: resultRows.length > 0 ? rowToResult(resultRows[0]) : null,
@@ -312,11 +315,12 @@ function assembleRace(
 export async function getRaces(): Promise<Race[]> {
   const db = getDatabase();
 
-  const [raceRows, categoryRows, giftRows, entryPeriodRows] = await db.batch([
+  const [raceRows, categoryRows, giftRows, entryPeriodRows, completionGiftRows] = await db.batch([
     db.select().from(schema.races).orderBy(asc(schema.races.date)),
     db.select().from(schema.race_categories).orderBy(asc(schema.race_categories.sort_order)),
     db.select().from(schema.participation_gifts).orderBy(asc(schema.participation_gifts.sort_order)),
     db.select().from(schema.race_entry_periods).orderBy(asc(schema.race_entry_periods.sort_order)),
+    db.select().from(schema.completion_gifts).orderBy(asc(schema.completion_gifts.sort_order)),
   ]);
 
   return raceRows.map((row) =>
@@ -327,6 +331,8 @@ export async function getRaces(): Promise<Race[]> {
       giftRows.filter((g) => g.race_id === row.id),
       [],
       entryPeriodRows.filter((p) => p.race_id === row.id),
+      [], [], [], [], [],
+      completionGiftRows.filter((g) => g.race_id === row.id),
     ),
   );
 }
@@ -334,7 +340,7 @@ export async function getRaces(): Promise<Race[]> {
 export async function getRaceById(id: string): Promise<Race | null> {
   const db = getDatabase();
 
-  const [raceRows, categoryRows, aidRows, checkRows, accessRows, spotRows, weatherRows, giftRows, resultRows, entryPeriodRows, entryLinkRows, galleryRows, voiceRows, timeBucketRows, courseHighlightRows] =
+  const [raceRows, categoryRows, aidRows, checkRows, accessRows, spotRows, weatherRows, giftRows, resultRows, entryPeriodRows, entryLinkRows, galleryRows, voiceRows, timeBucketRows, courseHighlightRows, completionGiftRows] =
     await db.batch([
       db.select().from(schema.races).where(eq(schema.races.id, id)),
       db.select().from(schema.race_categories).where(eq(schema.race_categories.race_id, id)).orderBy(asc(schema.race_categories.sort_order)),
@@ -351,12 +357,13 @@ export async function getRaceById(id: string): Promise<Race | null> {
       db.select().from(schema.race_voices).where(eq(schema.race_voices.race_id, id)).orderBy(asc(schema.race_voices.sort_order)),
       db.select().from(schema.race_time_buckets).where(eq(schema.race_time_buckets.race_id, id)).orderBy(asc(schema.race_time_buckets.sort_order)),
       db.select().from(schema.race_course_highlights).where(eq(schema.race_course_highlights.race_id, id)).orderBy(asc(schema.race_course_highlights.sort_order)),
+      db.select().from(schema.completion_gifts).where(eq(schema.completion_gifts.race_id, id)).orderBy(asc(schema.completion_gifts.sort_order)),
     ]);
 
   const row = raceRows[0];
   if (!row) return null;
 
-  return assembleRace(row, categoryRows, aidRows, checkRows, accessRows, spotRows, weatherRows, giftRows, resultRows, entryPeriodRows, entryLinkRows, galleryRows, voiceRows, timeBucketRows, courseHighlightRows);
+  return assembleRace(row, categoryRows, aidRows, checkRows, accessRows, spotRows, weatherRows, giftRows, resultRows, entryPeriodRows, entryLinkRows, galleryRows, voiceRows, timeBucketRows, courseHighlightRows, completionGiftRows);
 }
 
 export async function getRacesByPrefecture(prefecture: string): Promise<Race[]> {
@@ -368,11 +375,12 @@ export async function getUpcomingRaces(limit = 6): Promise<Race[]> {
   const db = getDatabase();
   const today = new Date().toISOString().split("T")[0];
 
-  const [raceRows, categoryRows, giftRows, entryPeriodRows] = await db.batch([
+  const [raceRows, categoryRows, giftRows, entryPeriodRows, completionGiftRows] = await db.batch([
     db.select().from(schema.races).where(gte(schema.races.date, today)).orderBy(asc(schema.races.date)),
     db.select().from(schema.race_categories).orderBy(asc(schema.race_categories.sort_order)),
     db.select().from(schema.participation_gifts),
     db.select().from(schema.race_entry_periods).orderBy(asc(schema.race_entry_periods.sort_order)),
+    db.select().from(schema.completion_gifts),
   ]);
 
   const limited = raceRows.slice(0, limit);
@@ -385,6 +393,8 @@ export async function getUpcomingRaces(limit = 6): Promise<Race[]> {
       giftRows.filter((g) => g.race_id === row.id),
       [],
       entryPeriodRows.filter((p) => p.race_id === row.id),
+      [], [], [], [], [],
+      completionGiftRows.filter((g) => g.race_id === row.id),
     ),
   );
 }
@@ -393,7 +403,7 @@ export async function getOpenEntryRaces(limit = 8): Promise<Race[]> {
   const db = getDatabase();
   const today = new Date().toISOString().split("T")[0];
 
-  const [raceRows, categoryRows, giftRows, entryPeriodRows] = await db.batch([
+  const [raceRows, categoryRows, giftRows, entryPeriodRows, completionGiftRows] = await db.batch([
     db.select().from(schema.races).where(
       sql`EXISTS (
         SELECT 1 FROM race_entry_periods rep
@@ -405,10 +415,11 @@ export async function getOpenEntryRaces(limit = 8): Promise<Race[]> {
     db.select().from(schema.race_categories).orderBy(asc(schema.race_categories.sort_order)),
     db.select().from(schema.participation_gifts),
     db.select().from(schema.race_entry_periods).orderBy(asc(schema.race_entry_periods.sort_order)),
+    db.select().from(schema.completion_gifts),
   ]);
 
   return raceRows.slice(0, limit).map((row) =>
-    assembleRace(row, categoryRows.filter((c) => c.race_id === row.id), [], [], [], [], [], giftRows.filter((g) => g.race_id === row.id), [], entryPeriodRows.filter((p) => p.race_id === row.id)),
+    assembleRace(row, categoryRows.filter((c) => c.race_id === row.id), [], [], [], [], [], giftRows.filter((g) => g.race_id === row.id), [], entryPeriodRows.filter((p) => p.race_id === row.id), [], [], [], [], [], completionGiftRows.filter((g) => g.race_id === row.id)),
   );
 }
 
@@ -417,7 +428,7 @@ export async function getSoonOpeningEntryRaces(limit = 6): Promise<Race[]> {
   const today = new Date().toISOString().split("T")[0];
   const in30days = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString().split("T")[0];
 
-  const [raceRows, categoryRows, giftRows, entryPeriodRows] = await db.batch([
+  const [raceRows, categoryRows, giftRows, entryPeriodRows, completionGiftRows] = await db.batch([
     db.select().from(schema.races).where(
       sql`EXISTS (
         SELECT 1 FROM race_entry_periods rep
@@ -429,10 +440,11 @@ export async function getSoonOpeningEntryRaces(limit = 6): Promise<Race[]> {
     db.select().from(schema.race_categories).orderBy(asc(schema.race_categories.sort_order)),
     db.select().from(schema.participation_gifts),
     db.select().from(schema.race_entry_periods).orderBy(asc(schema.race_entry_periods.sort_order)),
+    db.select().from(schema.completion_gifts),
   ]);
 
   return raceRows.slice(0, limit).map((row) =>
-    assembleRace(row, categoryRows.filter((c) => c.race_id === row.id), [], [], [], [], [], giftRows.filter((g) => g.race_id === row.id), [], entryPeriodRows.filter((p) => p.race_id === row.id)),
+    assembleRace(row, categoryRows.filter((c) => c.race_id === row.id), [], [], [], [], [], giftRows.filter((g) => g.race_id === row.id), [], entryPeriodRows.filter((p) => p.race_id === row.id), [], [], [], [], [], completionGiftRows.filter((g) => g.race_id === row.id)),
   );
 }
 
@@ -512,13 +524,14 @@ export async function getSeriesById(seriesId: string): Promise<RaceSeries | null
 export async function getSeriesRaces(seriesId: string, excludeRaceId: string): Promise<Race[]> {
   const db = getDatabase();
 
-  const [raceRows, categoryRows, giftRows, resultRows] = await db.batch([
+  const [raceRows, categoryRows, giftRows, resultRows, completionGiftRows] = await db.batch([
     db.select().from(schema.races)
       .where(eq(schema.races.series_id, seriesId))
       .orderBy(asc(schema.races.date)),
     db.select().from(schema.race_categories).orderBy(asc(schema.race_categories.sort_order)),
     db.select().from(schema.participation_gifts),
     db.select().from(schema.race_results),
+    db.select().from(schema.completion_gifts),
   ]);
 
   return raceRows
@@ -530,6 +543,8 @@ export async function getSeriesRaces(seriesId: string, excludeRaceId: string): P
         [], [], [], [], [],
         giftRows.filter((g) => g.race_id === row.id),
         resultRows.filter((r) => r.race_id === row.id),
+        [], [], [], [], [], [],
+        completionGiftRows.filter((g) => g.race_id === row.id),
       ),
     );
 }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -200,6 +200,22 @@ export const participation_gifts = sqliteTable("participation_gifts", {
 ]);
 
 // ==================
+// completion_gifts
+// ==================
+
+export const completion_gifts = sqliteTable("completion_gifts", {
+  id:              integer("id").primaryKey({ autoIncrement: true }),
+  race_id:         text("race_id").notNull().references(() => races.id, { onDelete: "cascade" }),
+  gift_categories: text("gift_categories").notNull().default("[]"), // JSON: GiftCategoryId[]
+  description_ja:  text("description_ja").notNull().default(""),
+  description_en:  text("description_en").notNull().default(""),
+  image:           text("image"),
+  sort_order:      integer("sort_order").notNull().default(0),
+}, (t) => [
+  index("completion_gifts_race_id_idx").on(t.race_id),
+]);
+
+// ==================
 // race_series (シリーズマスタ)
 // ==================
 
@@ -454,6 +470,7 @@ export const racesRelations = relations(races, ({ many, one }) => ({
   nearby_spots:        many(nearby_spots),
   weather_history:     many(weather_history),
   participation_gifts: many(participation_gifts),
+  completion_gifts:    many(completion_gifts),
   entry_periods:       many(race_entry_periods),
   entry_links:         many(race_entry_links),
   result:              one(race_results, { fields: [races.id], references: [race_results.race_id] }),
@@ -517,6 +534,10 @@ export const weatherHistoryRelations = relations(weather_history, ({ one }) => (
 
 export const participationGiftsRelations = relations(participation_gifts, ({ one }) => ({
   race: one(races, { fields: [participation_gifts.race_id], references: [races.id] }),
+}));
+
+export const completionGiftsRelations = relations(completion_gifts, ({ one }) => ({
+  race: one(races, { fields: [completion_gifts.race_id], references: [races.id] }),
 }));
 
 export const userRacesRelations = relations(user_races, ({ one }) => ({

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -46,6 +46,7 @@ export interface Race {
   nearby_spots: NearbySpot[];
   weather_history: WeatherHistory[];
   participation_gifts: ParticipationGift[];
+  completion_gifts: CompletionGift[];
   entry_periods: EntryPeriod[];
   entry_links: EntryLink[];
   result: RaceResult | null;      // 開催実績（未開催の場合は null）
@@ -233,6 +234,9 @@ export interface ParticipationGift {
   description_en: string;
   image: string | null;
 }
+
+/** 完走賞（ParticipationGift と同構造） */
+export type CompletionGift = ParticipationGift;
 
 export interface GiftCategory {
   id: GiftCategoryId;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -207,8 +207,9 @@ export function filterRaces(races: Race[], filter: RaceFilter): Race[] {
     }
 
     if (filter.giftCategories.length > 0) {
+      const allGifts = [...race.participation_gifts, ...(race.completion_gifts ?? [])];
       const hasGift = filter.giftCategories.some((catId) =>
-        race.participation_gifts.some((g) => g.gift_categories.includes(catId)),
+        allGifts.some((g) => g.gift_categories.includes(catId)),
       );
       if (!hasGift) return false;
     }

--- a/tools/admin/app.js
+++ b/tools/admin/app.js
@@ -196,11 +196,11 @@ function populateForm(r) {
   // 参加賞
   renderGifts(r.participation_gifts ?? []);
 
+  // 完走賞
+  renderCompletionGifts(r.completion_gifts ?? []);
+
   // 周辺スポット
   renderNearbySpots(r.nearby_spots ?? []);
-
-  // コース
-  setVal('f-course_gpx_file', r.course_gpx_file ?? '');
 
   // ビジュアル (Phase 2)
   setVal('f-motif', r.motif ?? '');
@@ -400,10 +400,6 @@ function addEntryPeriodRow(period = {}) {
         <input type="date" class="ep-end" value="${period.end_date ?? ''}" />
       </div>
       <div class="field">
-        <label>参加費（円）</label>
-        <input type="number" class="ep-fee" min="0" value="${period.entry_fee ?? ''}" />
-      </div>
-      <div class="field">
         <label>ラベル（日本語）</label>
         <input type="text" class="ep-label-ja" value="${period.label_ja ?? ''}" placeholder="例: 一般エントリー" />
       </div>
@@ -431,7 +427,6 @@ function collectEntryPeriods() {
   return [...document.querySelectorAll('.entry-period-row')].map(row => ({
     start_date: row.querySelector('.ep-start').value || null,
     end_date: row.querySelector('.ep-end').value || null,
-    entry_fee: parseInt(row.querySelector('.ep-fee').value) || null,
     label_ja: row.querySelector('.ep-label-ja').value || '',
     label_en: row.querySelector('.ep-label-en').value || '',
   })).filter(p => p.start_date && p.end_date);
@@ -683,6 +678,108 @@ function collectGifts() {
 
 document.getElementById('btn-add-gift').addEventListener('click', () => {
   addGiftRow();
+  markDirty();
+});
+
+// ── 完走賞 ─────────────────────────────────────────────────────────
+function renderCompletionGifts(gifts) {
+  const container = document.getElementById('completion-gifts-container');
+  container.innerHTML = '';
+  gifts.forEach(gift => addCompletionGiftRow(gift));
+}
+
+function addCompletionGiftRow(gift = {}) {
+  const container = document.getElementById('completion-gifts-container');
+  const selectedCats = new Set(gift.gift_categories ?? []);
+  const row = document.createElement('div');
+  row.className = 'gift-row completion-gift-row';
+
+  row.innerHTML = `
+    <div class="gift-row-header">
+      <span class="gift-row-label">完走賞 ${container.children.length + 1}</span>
+      <button class="btn btn-danger btn-remove-completion-gift">削除</button>
+    </div>
+    <div class="gift-categories-grid">
+      ${GIFT_CATEGORIES.map(c => `
+        <label class="gift-cat-item${selectedCats.has(c.id) ? ' selected' : ''}">
+          <input type="checkbox" value="${c.id}" ${selectedCats.has(c.id) ? 'checked' : ''} />
+          ${c.icon} ${c.label}
+        </label>
+      `).join('')}
+    </div>
+    <div class="gift-fields">
+      <div class="field full">
+        <label>説明（日本語）</label>
+        <textarea class="gift-desc-ja" rows="2">${gift.description_ja ?? ''}</textarea>
+      </div>
+      <div class="field full">
+        <label>説明（English）</label>
+        <div class="input-row align-top">
+          <textarea class="gift-desc-en" rows="2">${gift.description_en ?? ''}</textarea>
+          <button class="btn btn-translate completion-gift-translate">🔄 翻訳</button>
+        </div>
+      </div>
+    </div>
+  `;
+
+  row.querySelectorAll('.gift-cat-item').forEach(el => {
+    el.addEventListener('click', () => {
+      const cb = el.querySelector('input');
+      cb.checked = !cb.checked;
+      el.classList.toggle('selected', cb.checked);
+      markDirty();
+    });
+  });
+
+  row.querySelector('.completion-gift-translate').addEventListener('click', async (e) => {
+    const btn = e.currentTarget;
+    const srcEl = row.querySelector('.gift-desc-ja');
+    const dstEl = row.querySelector('.gift-desc-en');
+    const text = srcEl.value.trim();
+    if (!text) return alert('翻訳する日本語テキストを入力してください');
+    btn.disabled = true;
+    btn.textContent = '翻訳中…';
+    try {
+      const res = await fetch('/api/translate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text, field: 'description' }),
+      });
+      const data = await res.json();
+      if (data.error) throw new Error(data.error);
+      dstEl.value = data.translated;
+      markDirty();
+    } catch (err) {
+      alert(`翻訳エラー: ${err.message}`);
+    } finally {
+      btn.disabled = false;
+      btn.textContent = '🔄 翻訳';
+    }
+  });
+
+  row.querySelector('.btn-remove-completion-gift').addEventListener('click', () => {
+    row.remove();
+    document.querySelectorAll('.completion-gift-row .gift-row-label').forEach((el, i) => {
+      el.textContent = `完走賞 ${i + 1}`;
+    });
+    markDirty();
+  });
+
+  row.querySelectorAll('textarea').forEach(el => el.addEventListener('input', markDirty));
+  container.appendChild(row);
+}
+
+function collectCompletionGifts() {
+  return [...document.querySelectorAll('.completion-gift-row')].map(row => ({
+    gift_categories: [...row.querySelectorAll('.gift-cat-item input:checked')].map(cb => cb.value),
+    description_ja: row.querySelector('.gift-desc-ja').value,
+    description_en: row.querySelector('.gift-desc-en').value,
+    image: null,
+  }));
+}
+
+document.getElementById('btn-add-completion-gift').addEventListener('click', () => {
+  addCompletionGiftRow();
   markDirty();
 });
 
@@ -973,8 +1070,8 @@ function buildRaceData() {
     reception_note_en: getVal('f-reception_note_en'),
     categories,
     tags,
-    course_gpx_file: getVal('f-course_gpx_file') || null,
     participation_gifts: collectGifts(),
+    completion_gifts: collectCompletionGifts(),
     nearby_spots: collectNearbySpots(),
     // Phase 2: ビジュアル拡張フィールド
     motif: getVal('f-motif') || null,
@@ -1152,8 +1249,8 @@ function markDirty() {
 }
 
 function bindEvents() {
-  // フォーム変更検知
-  document.querySelectorAll('input:not([readonly]), select, textarea').forEach(el => {
+  // フォーム変更検知（エディター内の静的要素のみ対象。動的要素は各 addXxxRow で個別にバインド）
+  document.querySelectorAll('.form-body input:not([readonly]), .form-body select, .form-body textarea').forEach(el => {
     el.addEventListener('input', markDirty);
   });
 

--- a/tools/admin/app.js
+++ b/tools/admin/app.js
@@ -385,6 +385,8 @@ function addEntryPeriodRow(period = {}) {
   const container = document.getElementById('entry-periods-container');
   const row = document.createElement('div');
   row.className = 'entry-period-row';
+  // entry_fee はUI廃止後も既存データを保持するため data属性に退避
+  if (period.entry_fee != null) row.dataset.entryFee = period.entry_fee;
   row.innerHTML = `
     <div class="entry-period-header">
       <span class="entry-period-label">期間 ${container.children.length + 1}</span>
@@ -427,6 +429,7 @@ function collectEntryPeriods() {
   return [...document.querySelectorAll('.entry-period-row')].map(row => ({
     start_date: row.querySelector('.ep-start').value || null,
     end_date: row.querySelector('.ep-end').value || null,
+    entry_fee: row.dataset.entryFee != null ? parseInt(row.dataset.entryFee) : null,
     label_ja: row.querySelector('.ep-label-ja').value || '',
     label_en: row.querySelector('.ep-label-en').value || '',
   })).filter(p => p.start_date && p.end_date);
@@ -1070,6 +1073,8 @@ function buildRaceData() {
     reception_note_en: getVal('f-reception_note_en'),
     categories,
     tags,
+    // course_gpx_file はUI廃止後も既存データを保持（カテゴリ別GPXに未移行のレース用）
+    course_gpx_file: currentRace?.course_gpx_file ?? null,
     participation_gifts: collectGifts(),
     completion_gifts: collectCompletionGifts(),
     nearby_spots: collectNearbySpots(),

--- a/tools/admin/index.html
+++ b/tools/admin/index.html
@@ -217,6 +217,13 @@
             <button class="btn btn-secondary" id="btn-add-gift">＋ 参加賞を追加</button>
           </section>
 
+          <!-- 完走賞 -->
+          <section class="form-section">
+            <h2 class="section-title">完走賞</h2>
+            <div id="completion-gifts-container"></div>
+            <button class="btn btn-secondary" id="btn-add-completion-gift">＋ 完走賞を追加</button>
+          </section>
+
           <!-- 周辺スポット -->
           <section class="form-section">
             <h2 class="section-title">周辺スポット</h2>
@@ -281,16 +288,6 @@
                 <label>ヒーロー画像キャプション（英語）</label>
                 <input type="text" id="f-hero_caption_en" placeholder="例: Runners beneath cherry blossoms in Nagano" />
               </div>
-            </div>
-          </section>
-
-          <!-- コース -->
-          <section class="form-section">
-            <h2 class="section-title">コース</h2>
-            <div class="field full">
-              <label>GPXファイル名</label>
-              <input type="text" id="f-course_gpx_file" placeholder="例: nagano-marathon-2026.gpx" />
-              <p class="field-hint">GPXファイルは <code>public/gpx/</code> に配置し、保存後に <code>npm run course:generate</code> を実行するとコースマップが表示されます。ファイル名はレースID（例: <code>nagano-marathon-2026.gpx</code>）に合わせてください。</p>
             </div>
           </section>
 


### PR DESCRIPTION
## Summary

- **「未保存」バグ修正**: `bindEvents()` のセレクターを `.form-body` 内に限定。サイドバー検索やデータチェックフィルター操作で誤って `isDirty = true` になっていた原因を解消
- **完走賞セクション追加**: 参加賞と並列で完走賞を管理できるよう `index.html` + `app.js` に追加
- **メダルデータ移行**: `participation_gifts` にあったメダル（medal）を 51件すべて `completion_gifts` に移行
- **コースセクション削除**: 「コース」セクション（トップレベル GPX ファイル名フィールド）を丸ごと削除。カテゴリ別 GPX に統一済みのため不要
- **エントリー参加費フィールド削除**: エントリー期間の「参加費（円）」フィールドを削除。カテゴリ別参加費に統一

## Test plan

- [ ] 管理ツールを起動し、大会を選択後に何も編集せず別の大会をクリックしても「未保存」ポップアップが出ないことを確認
- [ ] サイドバーの検索フォームに入力後、大会を切り替えても「未保存」ポップアップが出ないことを確認
- [ ] 参加賞セクションと完走賞セクションが並んで表示されること
- [ ] 移行済みレースの完走賞にメダルが表示され、参加賞にはメダルが表示されないことを確認（例: 東京マラソン2026）
- [ ] エントリー期間の参加費フィールドが表示されないことを確認
- [ ] コースセクションが表示されないことを確認
- [ ] `pnpm run test:admin` が全パスすること

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 管理ツールに「完走賞」セクションを追加し、完走者向けギフトの入力・管理を実装

* **不具合修正**
  * 管理画面のイベントバインド範囲を限定して誤検知を防止

* **機能削除**
  * 管理ツールから「コース（GPX）」入力を削除
  * エントリー期間の「参加費」入力欄を削除

* **データ移行**
  * 完走メダル情報を参加賞から完走賞へ移行するデータ移行とシード再生成を実施

* **ドキュメント**
  * 更新履歴に今回変更を追記
<!-- end of auto-generated comment: release notes by coderabbit.ai -->