### PR TITLE
fix: end_date nullable 対応 - 型修正と null ガード追加

### DIFF
--- a/src/components/calendar/CalendarView.tsx
+++ b/src/components/calendar/CalendarView.tsx
@@ -23,7 +23,7 @@ function getRaceStatus(race: Race, today: string): 'open' | 'soon' | 'closed' | 
   if (race.entry_closed) return 'closed';
 
   const activePeriod = race.entry_periods.find(
-    (p) => today >= p.start_date && today <= p.end_date,
+    (p) => today >= p.start_date && (p.end_date === null || today <= p.end_date),
   ) ?? (race.entry_start_date && race.entry_end_date &&
     today >= race.entry_start_date && today <= race.entry_end_date
       ? { start_date: race.entry_start_date, end_date: race.entry_end_date }

--- a/src/components/calendar/MonthGrid.tsx
+++ b/src/components/calendar/MonthGrid.tsx
@@ -62,6 +62,7 @@ export default function MonthGrid({ races, year, month, locale, today, onHover }
           : []);
 
     effectivePeriods.forEach((period) => {
+      if (!period.end_date) return;
       const periodStart = new Date(period.start_date + 'T00:00:00');
       const periodEnd = new Date(period.end_date + 'T00:00:00');
       if (periodStart > monthEnd || periodEnd < monthStart) return;
@@ -102,6 +103,7 @@ export default function MonthGrid({ races, year, month, locale, today, onHover }
           : []);
 
     effectivePeriods.forEach((period) => {
+      if (!period.end_date) return;
       const periodStart = new Date(period.start_date + 'T00:00:00');
       const periodEnd = new Date(period.end_date + 'T00:00:00');
       if (periodStart > monthEnd || periodEnd < monthStart) return;

--- a/src/components/home/HomeSections.tsx
+++ b/src/components/home/HomeSections.tsx
@@ -62,9 +62,7 @@ function OpenSection({ races, locale }: { races: Race[]; locale: Locale }) {
           {races.slice(0, 3).map((race) => {
             const periods = race.entry_periods ?? [];
             const activePeriod = periods.find((p) => p.start_date <= today && (p.end_date === null || p.end_date >= today));
-            const deadline = activePeriod?.end_date
-              ?? race.entry_end_date
-              ?? null;
+            const deadline = activePeriod ? activePeriod.end_date : (race.entry_end_date ?? null);
 
             return (
               <Link key={race.id} href={`/races/${race.id}`} className="no-underline" style={{ color: 'inherit' }}>

--- a/src/components/home/HomeSections.tsx
+++ b/src/components/home/HomeSections.tsx
@@ -61,7 +61,7 @@ function OpenSection({ races, locale }: { races: Race[]; locale: Locale }) {
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
           {races.slice(0, 3).map((race) => {
             const periods = race.entry_periods ?? [];
-            const activePeriod = periods.find((p) => p.start_date <= today && p.end_date >= today);
+            const activePeriod = periods.find((p) => p.start_date <= today && (p.end_date === null || p.end_date >= today));
             const deadline = activePeriod?.end_date
               ?? race.entry_end_date
               ?? null;

--- a/src/components/races/RaceCard.tsx
+++ b/src/components/races/RaceCard.tsx
@@ -74,14 +74,14 @@ export default function RaceCard({ race, locale, from }: RaceCardProps) {
   const isPast = race.date < today;
 
   const periods = race.entry_periods ?? [];
-  const activePeriod = periods.find((p) => p.start_date <= today && p.end_date >= today)
+  const activePeriod = periods.find((p) => p.start_date <= today && (p.end_date === null || p.end_date >= today))
     ?? (race.entry_start_date && race.entry_end_date && today >= race.entry_start_date && today <= race.entry_end_date
         ? { start_date: race.entry_start_date, end_date: race.entry_end_date } : null);
   const futurePeriod = periods.find((p) => p.start_date > today)
     ?? (race.entry_start_date && today < race.entry_start_date
         ? { start_date: race.entry_start_date, end_date: race.entry_end_date ?? '' } : null);
   const latestEndDate = periods.length > 0
-    ? periods.reduce((max, p) => p.end_date > max ? p.end_date : max, '')
+    ? periods.reduce((max, p) => (p.end_date !== null && p.end_date > max) ? p.end_date : max, '')
     : race.entry_end_date ?? null;
 
   const isEntryOpen = !!activePeriod && !race.entry_closed;
@@ -89,6 +89,7 @@ export default function RaceCard({ race, locale, from }: RaceCardProps) {
     isEntryOpen &&
     activePeriod !== null &&
     'end_date' in activePeriod &&
+    activePeriod.end_date !== null &&
     new Date(activePeriod.end_date).getTime() - new Date(today).getTime() <= 14 * 24 * 60 * 60 * 1000;
   const isEntrySoon = !isEntryOpen && !isPast && !!futurePeriod;
   const isEntryClosed =
@@ -100,7 +101,7 @@ export default function RaceCard({ race, locale, from }: RaceCardProps) {
     const fmt = (d: string) => formatDate(d, locale);
     if (periods.length > 0) {
       const first = periods[0];
-      const base = `${fmt(first.start_date)} 〜 ${fmt(first.end_date)}`;
+      const base = `${fmt(first.start_date)} 〜 ${first.end_date ? fmt(first.end_date) : '—'}`;
       return periods.length > 1
         ? `${base} ${locale === 'ja' ? `他${periods.length - 1}件` : `+${periods.length - 1} more`}`
         : base;

--- a/src/components/races/RaceCardExp.tsx
+++ b/src/components/races/RaceCardExp.tsx
@@ -16,7 +16,7 @@ export default function RaceCardExp({ race, locale, from }: RaceCardExpProps) {
   const isPast = race.date < today;
   const periods = race.entry_periods ?? [];
   const isEntryOpen = periods.length > 0
-    ? periods.some((p) => p.start_date <= today && p.end_date >= today)
+    ? periods.some((p) => p.start_date <= today && (p.end_date === null || p.end_date >= today))
     : (race.entry_start_date !== null &&
        race.entry_end_date !== null &&
        today >= race.entry_start_date &&

--- a/src/components/races/detail/EntrySection.tsx
+++ b/src/components/races/detail/EntrySection.tsx
@@ -48,7 +48,7 @@ export default function EntrySection({ race, locale, today }: EntrySectionProps)
                 <p className="font-medium">
                   {formatDate(race.entry_periods[0].start_date, locale)}
                   {' — '}
-                  {formatDate(race.entry_periods[0].end_date, locale)}
+                  {race.entry_periods[0].end_date ? formatDate(race.entry_periods[0].end_date, locale) : '—'}
                 </p>
               </div>
               {race.entry_periods[0].entry_fee && (
@@ -83,7 +83,7 @@ export default function EntrySection({ race, locale, today }: EntrySectionProps)
                         {locale === 'ja' ? ep.label_ja : ep.label_en}
                       </td>
                       <td className="py-2.5">
-                        {formatDate(ep.start_date, locale)} — {formatDate(ep.end_date, locale)}
+                        {formatDate(ep.start_date, locale)} — {ep.end_date ? formatDate(ep.end_date, locale) : '—'}
                       </td>
                       <td className="py-2.5 text-right">
                         {ep.entry_fee

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -79,7 +79,7 @@ export interface EntryPeriod {
   label_ja: string;
   label_en: string;
   start_date: string; // YYYY-MM-DD
-  end_date: string;   // YYYY-MM-DD
+  end_date: string | null; // YYYY-MM-DD（終了日未定の場合は null）
   entry_fee: number | null;
   sort_order: number;
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -114,7 +114,7 @@ export function getRaceStatus(race: Race): RaceStatus {
   if (race.date < today) return 'past';
   if (race.entry_closed) return 'entry_closed';
   const periods = race.entry_periods ?? [];
-  if (periods.some((p) => p.start_date <= today && p.end_date >= today)) return 'open_entry';
+  if (periods.some((p) => p.start_date <= today && (p.end_date === null || p.end_date >= today))) return 'open_entry';
   if (periods.some((p) => p.start_date > today)) return 'entry_not_open';
   // Phase 2 で削除予定: 旧フィールドへのフォールバック
   const { entry_start_date: es, entry_end_date: ee } = race;
@@ -248,11 +248,13 @@ export function sortRacesByDate(races: Race[], ascending = true): Race[] {
 
 /** 受付中の期間のうち最も早い終了日を取得（締切が近い順用） */
 function getEarliestActiveEnd(race: Race, today: string): string | null {
-  const periods = (race as { entry_periods?: { start_date: string; end_date: string }[] }).entry_periods ?? [];
+  const periods = (race as { entry_periods?: { start_date: string; end_date: string | null }[] }).entry_periods ?? [];
   if (periods.length > 0) {
-    const active = periods.filter((p) => p.start_date <= today && p.end_date >= today);
+    const active = periods.filter((p) => p.start_date <= today && (p.end_date === null || p.end_date >= today));
     if (active.length === 0) return null;
-    return active.reduce((min, p) => (p.end_date < min ? p.end_date : min), active[0].end_date);
+    const withEnd = active.filter((p): p is { start_date: string; end_date: string } => p.end_date !== null);
+    if (withEnd.length === 0) return null;
+    return withEnd.reduce((min, p) => (p.end_date < min ? p.end_date : min), withEnd[0].end_date);
   }
   // 旧フィールドへのフォールバック
   const es = race.entry_start_date;


### PR DESCRIPTION
## Summary

PR #76 でスキーマの `end_date NOT NULL` 制約を削除したが、TypeScript 型・コンポーネントの null ガードが未対応のためデプロイビルドが失敗していた。

エラー:
```
./src/lib/data.ts:140:5
Type error: Type 'string | null' is not assignable to type 'string'.
```

## 変更内容

- `src/lib/types.ts`: `EntryPeriod.end_date` を `string | null` に変更
- `src/lib/utils.ts`: `getRaceStatus`・`getEarliestActiveEnd` で `end_date === null` を open-ended として扱う
- `src/components/calendar/CalendarView.tsx`: null ガード追加
- `src/components/calendar/MonthGrid.tsx`: `end_date` が null の期間をカレンダー表示対象外に
- `src/components/home/HomeSections.tsx`: null ガード追加
- `src/components/races/RaceCard.tsx`: 複数箇所に null 対応
- `src/components/races/RaceCardExp.tsx`: null ガード追加
- `src/components/races/detail/EntrySection.tsx`: `formatDate` に null ガード追加（`'—'` を表示）

## テスト

- `pnpm run build` ✅
- `pnpm run test` ✅（332件全通過）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * エントリー期間に終了日が設定されていない場合でも、正しく「受付中」として表示・判定されるように改善しました。
  * カレンダービュー、レースカード、受付期間表示など、複数箇所での終了日の表記をダッシュ記号（—）で統一し、わかりやすくしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->