### PR TITLE
crawl: レースデータ更新・crawlコード改善 2026-06-27

### DIFF
--- a/migrations/seed-races-all.sql
+++ b/migrations/seed-races-all.sql
@@ -1,6 +1,6 @@
 -- 自動生成: generate-seed-races.js
--- 生成日時: 2026-06-27T13:59:27.815Z
--- 対象ファイル数: 85 件（既存 2 件はskip）
+-- 生成日時: 2026-06-27T14:11:17.003Z
+-- 対象ファイル数: 86 件（既存 2 件はskip）
 
 -- ==================
 -- オホーツク網走マラソン (abashiri-marathon-2026)
@@ -751,6 +751,98 @@ INSERT OR REPLACE INTO races (
   0,
   1,
   10000,
+  '2025-08-01',
+  '2025-08-19',
+  0,
+  'pre_day',
+  '',
+  '',
+  '["城下町","景色が良い","温泉"]',
+  NULL,
+  0,
+  0,
+  0,
+  'road',
+  '["JAAF"]',
+  '松山城、道後温泉',
+  'Matsuyama Castle, Dogo Onsen',
+  NULL,
+  NULL,
+  'みかん',
+  '#f97316',
+  'Mikan',
+  '蜜柑の香り漂う、瀬戸内の道を走る',
+  'Run through the Seto Inland citrus country',
+  NULL,
+  NULL,
+  NULL,
+  '2026-03-15T00:00:00Z',
+  '2026-05-25T01:17:59.684Z'
+);
+INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
+  ('ehime-marathon-2026', 'full', 42.195, 360, '10:00', 10000, 12900, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
+INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
+  ('ehime-marathon-2026', '温泉', '道後温泉', 'Dogo Onsen', '日本最古の温泉の一つ。フィニッシュ地点から近く、レース後のリカバリーに最適。夏目漱石の「坊ちゃん」の舞台としても有名。', 'One of Japan''s oldest hot springs. Close to the finish and perfect for post-race recovery. Famous as the setting of Natsume Soseki''s ''Botchan''.', 'フィニッシュ付近', NULL, 33.8492, 132.7867);
+INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
+  ('ehime-marathon-2026', '観光地', '松山城', 'Matsuyama Castle', '現存12天守の一つ。コース上から望める。ロープウェイで天守閣へ。', 'One of Japan''s 12 surviving original castle keeps. Visible from the course. Ropeway access to the keep.', 'コース付近', NULL, 33.8456, 132.7656);
+INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('ehime-marathon-2026', '["tshirt","towel"]', '大会オリジナルTシャツ、完走メダル、今治タオル（完走者）', 'Official race T-shirt, Finisher medal, Imabari towel (finishers)', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('ehime-marathon-2026', '["medal"]', '大会オリジナルTシャツ、完走メダル、今治タオル（完走者）', 'Official race T-shirt, Finisher medal, Imabari towel (finishers)', NULL, 0);
+INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
+  ('ehime-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-08-01', '2025-08-19', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('ehime-marathon-2026', NULL, NULL, '松山城', 'Matsuyama Castle', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('ehime-marathon-2026', NULL, NULL, '道後温泉', 'Dogo Onsen', NULL, NULL, 1);
+
+-- ==================
+-- 愛媛マラソン (ehime-marathon-2027)
+-- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'ehime-marathon-2027';
+DELETE FROM race_categories WHERE race_id = 'ehime-marathon-2027';
+DELETE FROM aid_stations WHERE race_id = 'ehime-marathon-2027';
+DELETE FROM checkpoints WHERE race_id = 'ehime-marathon-2027';
+DELETE FROM access_points WHERE race_id = 'ehime-marathon-2027';
+DELETE FROM nearby_spots WHERE race_id = 'ehime-marathon-2027';
+DELETE FROM weather_history WHERE race_id = 'ehime-marathon-2027';
+DELETE FROM participation_gifts WHERE race_id = 'ehime-marathon-2027';
+DELETE FROM completion_gifts WHERE race_id = 'ehime-marathon-2027';
+DELETE FROM race_entry_links WHERE race_id = 'ehime-marathon-2027';
+DELETE FROM race_entry_periods WHERE race_id = 'ehime-marathon-2027';
+DELETE FROM race_results WHERE race_id = 'ehime-marathon-2027';
+DELETE FROM race_gallery WHERE race_id = 'ehime-marathon-2027';
+DELETE FROM race_voices WHERE race_id = 'ehime-marathon-2027';
+DELETE FROM race_time_buckets WHERE race_id = 'ehime-marathon-2027';
+INSERT OR REPLACE INTO races (
+  id, name_ja, name_en, date, prefecture, city_ja, city_en,
+  description_ja, description_en, official_url,
+  entry_fee, entry_fee_by_category, entry_capacity,
+  entry_start_date, entry_end_date, entry_closed,
+  reception_type, reception_note_ja, reception_note_en,
+  tags, course_gpx_file,
+  course_max_elevation_m, course_min_elevation_m, course_elevation_diff_m,
+  course_surface, course_certification,
+  course_highlights_ja, course_highlights_en,
+  course_notes_ja, course_notes_en,
+  motif, motif_color, motif_romaji,
+  tagline_ja, tagline_en,
+  hero_image_url, hero_caption_ja, hero_caption_en,
+  created_at, updated_at
+) VALUES (
+  'ehime-marathon-2027',
+  '愛媛マラソン',
+  'Ehime Marathon',
+  '2027-02-07',
+  '38',
+  '松山市',
+  'Matsuyama City',
+  '愛媛県松山市で開催されるフルマラソン。松山城や道後温泉など、歴史ある街並みを走る。レース後は道後温泉でリカバリー。',
+  'A full marathon in Matsuyama, Ehime. Run through historic streets past Matsuyama Castle and Dogo Onsen. Recover at Dogo Onsen after the race.',
+  'https://ehimemarathon.jp',
+  0,
+  1,
+  10000,
   '2026-07-13',
   '2026-07-31',
   0,
@@ -776,29 +868,29 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   NULL,
-  '2026-03-15T00:00:00Z',
+  '2026-06-27T00:00:00Z',
   '2026-06-27T13:27:58.737Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
-  ('ehime-marathon-2026', 'full', 42.195, 360, '10:00', 10000, 12900, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
+  ('ehime-marathon-2027', 'full', 42.195, 360, '10:00', 10000, 12900, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
-  ('ehime-marathon-2026', '温泉', '道後温泉', 'Dogo Onsen', '日本最古の温泉の一つ。フィニッシュ地点から近く、レース後のリカバリーに最適。夏目漱石の「坊ちゃん」の舞台としても有名。', 'One of Japan''s oldest hot springs. Close to the finish and perfect for post-race recovery. Famous as the setting of Natsume Soseki''s ''Botchan''.', 'フィニッシュ付近', NULL, 33.8492, 132.7867);
+  ('ehime-marathon-2027', '温泉', '道後温泉', 'Dogo Onsen', '日本最古の温泉の一つ。フィニッシュ地点から近く、レース後のリカバリーに最適。夏目漱石の「坊ちゃん」の舞台としても有名。', 'One of Japan''s oldest hot springs. Close to the finish and perfect for post-race recovery. Famous as the setting of Natsume Soseki''s ''Botchan''.', 'フィニッシュ付近', NULL, 33.8492, 132.7867);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
-  ('ehime-marathon-2026', '観光地', '松山城', 'Matsuyama Castle', '現存12天守の一つ。コース上から望める。ロープウェイで天守閣へ。', 'One of Japan''s 12 surviving original castle keeps. Visible from the course. Ropeway access to the keep.', 'コース付近', NULL, 33.8456, 132.7656);
+  ('ehime-marathon-2027', '観光地', '松山城', 'Matsuyama Castle', '現存12天守の一つ。コース上から望める。ロープウェイで天守閣へ。', 'One of Japan''s 12 surviving original castle keeps. Visible from the course. Ropeway access to the keep.', 'コース付近', NULL, 33.8456, 132.7656);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('ehime-marathon-2026', '["tshirt","towel"]', '大会オリジナルTシャツ、完走メダル、今治タオル（完走者）', 'Official race T-shirt, Finisher medal, Imabari towel (finishers)', NULL, 0);
+  ('ehime-marathon-2027', '["tshirt"]', '大会オリジナルTシャツ', 'Official race T-shirt', NULL, 0);
 INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('ehime-marathon-2026', '["medal"]', '大会オリジナルTシャツ、完走メダル、今治タオル（完走者）', 'Official race T-shirt, Finisher medal, Imabari towel (finishers)', NULL, 0);
+  ('ehime-marathon-2027', '["medal","towel"]', '完走メダル、今治タオル（完走者）', 'Finisher medal, Imabari towel (finishers)', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
-  ('ehime-marathon-2026', NULL, 'アスリートエントリー', 'Athlete Entry', '2026-07-13', '2026-07-31', NULL, 0);
+  ('ehime-marathon-2027', NULL, 'アスリートエントリー', 'Athlete Entry', '2026-07-13', '2026-07-31', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
-  ('ehime-marathon-2026', NULL, 'ネットタイムアスリートエントリー', 'Net Time Athlete Entry', '2026-07-13', '2026-07-31', NULL, 1);
+  ('ehime-marathon-2027', NULL, 'ネットタイムアスリートエントリー', 'Net Time Athlete Entry', '2026-07-13', '2026-07-31', NULL, 1);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
-  ('ehime-marathon-2026', NULL, 'ランナーボランティア参加者エントリー', 'Runner Volunteer Entry', '2026-07-13', '2026-07-31', NULL, 2);
+  ('ehime-marathon-2027', NULL, 'ランナーボランティア参加者エントリー', 'Runner Volunteer Entry', '2026-07-13', '2026-07-31', NULL, 2);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('ehime-marathon-2026', NULL, NULL, '松山城', 'Matsuyama Castle', NULL, NULL, 0);
+  ('ehime-marathon-2027', NULL, NULL, '松山城', 'Matsuyama Castle', NULL, NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('ehime-marathon-2026', NULL, NULL, '道後温泉', 'Dogo Onsen', NULL, NULL, 1);
+  ('ehime-marathon-2027', NULL, NULL, '道後温泉', 'Dogo Onsen', NULL, NULL, 1);
 
 -- ==================
 -- 富士登山競走 (fuji-mountain-race-2026)

--- a/migrations/seed-races-all.sql
+++ b/migrations/seed-races-all.sql
@@ -1,6 +1,6 @@
 -- 自動生成: generate-seed-races.js
--- 生成日時: 2026-06-25T14:01:04.274Z
--- 対象ファイル数: 84 件（既存 2 件はskip）
+-- 生成日時: 2026-06-27T13:59:27.815Z
+-- 対象ファイル数: 85 件（既存 2 件はskip）
 
 -- ==================
 -- オホーツク網走マラソン (abashiri-marathon-2026)
@@ -751,8 +751,8 @@ INSERT OR REPLACE INTO races (
   0,
   1,
   10000,
-  '2025-08-01',
-  '2025-08-19',
+  '2026-07-13',
+  '2026-07-31',
   0,
   'pre_day',
   '',
@@ -777,7 +777,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-05-25T01:17:59.684Z'
+  '2026-06-27T13:27:58.737Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('ehime-marathon-2026', 'full', 42.195, 360, '10:00', 10000, 12900, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -790,7 +790,11 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
 INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('ehime-marathon-2026', '["medal"]', '大会オリジナルTシャツ、完走メダル、今治タオル（完走者）', 'Official race T-shirt, Finisher medal, Imabari towel (finishers)', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
-  ('ehime-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-08-01', '2025-08-19', NULL, 0);
+  ('ehime-marathon-2026', NULL, 'アスリートエントリー', 'Athlete Entry', '2026-07-13', '2026-07-31', NULL, 0);
+INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
+  ('ehime-marathon-2026', NULL, 'ネットタイムアスリートエントリー', 'Net Time Athlete Entry', '2026-07-13', '2026-07-31', NULL, 1);
+INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
+  ('ehime-marathon-2026', NULL, 'ランナーボランティア参加者エントリー', 'Runner Volunteer Entry', '2026-07-13', '2026-07-31', NULL, 2);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
   ('ehime-marathon-2026', NULL, NULL, '松山城', 'Matsuyama Castle', NULL, NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -1981,9 +1985,9 @@ INSERT OR REPLACE INTO races (
   0,
   0,
   'road',
-  '["JAAF"]',
-  '大通公園、北海道大学、豊平川',
-  'Odori Park, Hokkaido University, Toyohira River',
+  '["JAAF","WA","AIMS"]',
+  '大通公園、北海道大学、北海道庁赤れんが庁舎、豊平川',
+  'Odori Park, Hokkaido University, Hokkaido Government Red Brick Office, Toyohira River',
   '夏開催のため暑さ対策が必須。制限時間6時間。',
   'Summer heat countermeasures essential. 6-hour time limit.',
   'ライラック',
@@ -1995,7 +1999,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-05-30T06:35:06.519Z'
+  '2026-06-27T13:29:05.102Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('hokkaido-marathon-2026', 'full', 42.195, 360, '08:30', 20000, 16500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -2934,9 +2938,9 @@ INSERT OR REPLACE INTO races (
   0,
   0,
   'road',
-  '[]',
-  '瀬戸内海',
-  'Seto Inland Sea',
+  '["JAAF"]',
+  '瀬戸内海、島々、栗林公園、里山、讃岐平野',
+  'Seto Inland Sea, islands, Ritsurin Garden, satoyama, Sanuki Plain',
   NULL,
   NULL,
   '瀬戸内海',
@@ -2948,7 +2952,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-05-30T06:36:17.548Z'
+  '2026-06-27T13:29:44.929Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kagawa-marathon-2026', 'full', 42.195, 360, '10:00', 10000, 14000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -2956,6 +2960,10 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
   ('kagawa-marathon-2026', 'グルメ', '讃岐うどん', 'Sanuki Udon', '香川を代表するご当地グルメ。コシの強い麺とシンプルなだしが特徴。市内に多数の名店。', 'Kagawa''s signature dish. Characterized by chewy noodles and simple broth. Many famous shops in the city.', '高松市内各所', NULL, 34.3403, 134.0472);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('kagawa-marathon-2026', '観光地', '栗林公園', 'Ritsurin Garden', '国の特別名勝。日本を代表する回遊式大名庭園。', 'A Special Place of Scenic Beauty. One of Japan''s finest strolling gardens.', '高松市内', NULL, 34.3289, 134.0467);
+INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('kagawa-marathon-2026', '["tshirt"]', 'オリジナルTシャツと記念品', 'Original T-shirt and commemorative item', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('kagawa-marathon-2026', '["medal","towel"]', '完走メダルとフィニッシャータオル', 'Finisher medal and finisher towel', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kagawa-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-10-06', '2025-11-24', NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -3792,7 +3800,7 @@ For relay runs, both runners must register together. Registration by one person,
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-06-22T15:03:49.422Z'
+  '2026-06-27T13:30:41.348Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kobe-marathon-2026', 'full', 42.195, 420, '09:00', 20000, 18000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -5464,7 +5472,7 @@ Based on themes such as “people,” “environment,” and “the Yodogawa Riv
   NULL,
   NULL,
   '2026-04-11T14:42:59.225Z',
-  '2026-06-08T14:38:38.451Z'
+  '2026-06-27T13:32:25.650Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('osaka-yodo-river-citizens-marathon-2026', 'full', 42.195, 480, '09:00', 4000, 9800, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -5830,6 +5838,90 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
   ('saitama-marathon-2026', 'full', 42.195, 360, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('saitama-marathon-2026', '観光地', '氷川神社', 'Hikawa Shrine', '武蔵国一宮。2km以上の参道は日本一の長さ。大宮の象徴。', 'The first shrine of Musashi Province. Its 2km+ approach is the longest in Japan.', '大宮エリア', NULL, 35.9069, 139.6286);
+
+-- ==================
+-- さいたまマラソン (saitama-marathon-2027)
+-- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'saitama-marathon-2027';
+DELETE FROM race_categories WHERE race_id = 'saitama-marathon-2027';
+DELETE FROM aid_stations WHERE race_id = 'saitama-marathon-2027';
+DELETE FROM checkpoints WHERE race_id = 'saitama-marathon-2027';
+DELETE FROM access_points WHERE race_id = 'saitama-marathon-2027';
+DELETE FROM nearby_spots WHERE race_id = 'saitama-marathon-2027';
+DELETE FROM weather_history WHERE race_id = 'saitama-marathon-2027';
+DELETE FROM participation_gifts WHERE race_id = 'saitama-marathon-2027';
+DELETE FROM completion_gifts WHERE race_id = 'saitama-marathon-2027';
+DELETE FROM race_entry_links WHERE race_id = 'saitama-marathon-2027';
+DELETE FROM race_entry_periods WHERE race_id = 'saitama-marathon-2027';
+DELETE FROM race_results WHERE race_id = 'saitama-marathon-2027';
+DELETE FROM race_gallery WHERE race_id = 'saitama-marathon-2027';
+DELETE FROM race_voices WHERE race_id = 'saitama-marathon-2027';
+DELETE FROM race_time_buckets WHERE race_id = 'saitama-marathon-2027';
+INSERT OR REPLACE INTO races (
+  id, name_ja, name_en, date, prefecture, city_ja, city_en,
+  description_ja, description_en, official_url,
+  entry_fee, entry_fee_by_category, entry_capacity,
+  entry_start_date, entry_end_date, entry_closed,
+  reception_type, reception_note_ja, reception_note_en,
+  tags, course_gpx_file,
+  course_max_elevation_m, course_min_elevation_m, course_elevation_diff_m,
+  course_surface, course_certification,
+  course_highlights_ja, course_highlights_en,
+  course_notes_ja, course_notes_en,
+  motif, motif_color, motif_romaji,
+  tagline_ja, tagline_en,
+  hero_image_url, hero_caption_ja, hero_caption_en,
+  created_at, updated_at
+) VALUES (
+  'saitama-marathon-2027',
+  'さいたまマラソン',
+  'Saitama Marathon',
+  '2027-02-14',
+  '11',
+  'さいたま市',
+  'Saitama City',
+  'さいたま市で開催されるフルマラソン。荒川沿いのフラットなコース。',
+  'A full marathon in Saitama City along the flat Arakawa River course.',
+  'https://saitama-marathon.jp',
+  15000,
+  1,
+  14000,
+  '2026-07-01',
+  NULL,
+  0,
+  'pre_day',
+  '',
+  '',
+  '[]',
+  NULL,
+  0,
+  0,
+  0,
+  'road',
+  '["JAAF"]',
+  '',
+  '',
+  NULL,
+  NULL,
+  '荒川',
+  '#0369a1',
+  'Arakawa',
+  '荒川の雄大な流れとともに走る、さいたまの42km',
+  'Run along the vast Arakawa River through Saitama',
+  NULL,
+  NULL,
+  NULL,
+  '2026-06-27T00:00:00Z',
+  '2026-06-27T13:33:20.980Z'
+);
+INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
+  ('saitama-marathon-2027', 'full', 42.195, 360, '', 14000, 15000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
+INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
+  ('saitama-marathon-2027', '観光地', '氷川神社', 'Hikawa Shrine', '武蔵国一宮。2km以上の参道は日本一の長さ。大宮の象徴。', 'The first shrine of Musashi Province. Its 2km+ approach is the longest in Japan.', '大宮エリア', NULL, 35.9069, 139.6286);
+INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
+  ('saitama-marathon-2027', NULL, '優先エントリー（さいたま市民・越谷市民／2026大会参加者）', 'Priority Entry', '2026-07-01', '2026-07-13', 15000, 0);
+INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
+  ('saitama-marathon-2027', NULL, '一般エントリー', 'General Entry', '2026-07-15', NULL, 15000, 1);
 
 -- ==================
 -- 札幌マラソン (sapporo-marathon-2026)
@@ -7212,7 +7304,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   1,
   38500,
-  '2026-07-31',
+  '2026-06-24',
   '2026-08-28',
   0,
   'pre_day',
@@ -7257,9 +7349,13 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
 INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('tokyo-marathon-2027', '["medal","towel"]', '完走メダル、完走タオル（完走者）', 'Finisher medal, Finisher towel (finishers)', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
-  ('tokyo-marathon-2027', NULL, 'ONE TOKYOプレミアムメンバーエントリー', 'ONE TOKYO Premium Member Entry', '2026-07-31', '2026-08-13', NULL, 0);
+  ('tokyo-marathon-2027', NULL, 'チャリティランナー寄付申込', 'Charity Runner Donation Entry', '2026-06-24', '2026-07-09', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
-  ('tokyo-marathon-2027', NULL, '一般エントリー', 'General Entry', '2026-08-14', '2026-08-28', NULL, 1);
+  ('tokyo-marathon-2027', NULL, 'ONE TOKYOプレミアムメンバーエントリー', 'ONE TOKYO Premium Member Entry', '2026-07-31', '2026-08-13', NULL, 1);
+INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
+  ('tokyo-marathon-2027', NULL, '準エリートエントリー', 'Sub-Elite Entry', '2026-07-31', '2026-08-13', NULL, 2);
+INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
+  ('tokyo-marathon-2027', NULL, '一般エントリー', 'General Entry', '2026-08-14', '2026-08-28', NULL, 3);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
   ('tokyo-marathon-2027', NULL, NULL, '東京都庁', 'Tokyo Metropolitan Government', NULL, NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES

--- a/migrations/seed-races-all.sql
+++ b/migrations/seed-races-all.sql
@@ -1,5 +1,5 @@
 -- 自動生成: generate-seed-races.js
--- 生成日時: 2026-06-27T14:11:17.003Z
+-- 生成日時: 2026-06-27T14:38:06.836Z
 -- 対象ファイル数: 86 件（既存 2 件はskip）
 
 -- ==================
@@ -7279,75 +7279,45 @@ INSERT OR REPLACE INTO races (
 ) VALUES (
   'tokyo-marathon-2026',
   '東京マラソン',
-  'Tokyo Marathon',
-  '2026-03-01',
-  '13',
-  '新宿区〜千代田区',
-  'Shinjuku to Chiyoda',
-  '日本最大規模の市民マラソン。東京都庁をスタートし、皇居、浅草、銀座など東京の名所を巡り東京駅前でフィニッシュ。ワールドマラソンメジャーズの一つ。',
-  'Japan''s largest citizens'' marathon. Starting from Tokyo Metropolitan Government, passing the Imperial Palace, Asakusa, Ginza, finishing at Tokyo Station. One of the World Marathon Majors.',
-  'https://www.marathon.tokyo',
   NULL,
-  1,
-  38500,
-  '2025-08-15',
-  '2025-08-29',
+  '2027-03-01',
+  NULL,
+  NULL,
+  NULL,
+  '',
+  '',
+  '',
+  16200,
   0,
-  'pre_day',
-  'EXPO会場（東京ビッグサイト）にて前日受付。2/26-28。大会当日の受付なし。',
-  'Pre-race registration at EXPO venue (Tokyo Big Sight). Feb 26-28. No registration on race day.',
-  '["フラット","ワールドメジャーズ","初心者おすすめ","大規模","日本陸連公認","観光"]',
+  38000,
+  '2025-08-01',
+  '2025-10-31',
+  0,
+  'race_day',
+  '',
+  '',
+  '{}',
   NULL,
-  40,
-  3,
-  37,
+  0,
+  0,
+  0,
   'road',
-  '["JAAF","AIMS","WMM"]',
-  '東京都庁、皇居、浅草雷門、銀座、東京タワー、東京駅丸の内',
-  'Tokyo Metropolitan Government, Imperial Palace, Asakusa Kaminarimon, Ginza, Tokyo Tower, Tokyo Station Marunouchi',
-  NULL,
-  NULL,
-  '東京の街',
-  '#1e293b',
-  'Tokyo-no-Machi',
-  '世界6大メジャーの一つ、東京の街を駆け抜ける',
-  'Race through Tokyo — one of the six World Marathon Majors',
+  '{}',
+  '',
+  '',
   NULL,
   NULL,
   NULL,
-  '2026-03-15T00:00:00Z',
-  '2026-03-15T00:00:00Z'
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  '2026-06-27T14:28:07.694Z'
 );
-INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
-  ('tokyo-marathon-2026', 'full', 42.195, 420, '09:10', 38500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
-INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, sort_order) VALUES
-  ('tokyo-marathon-2026', '新宿駅', 'Shinjuku Station', 'shinjuku', '新宿駅西口から徒歩約10分でスタート会場（東京都庁前）', '10 min walk from Shinjuku Station West Exit to the start (Tokyo Metropolitan Government)', 35.6896, 139.6999, 0);
-INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, sort_order) VALUES
-  ('tokyo-marathon-2026', '都庁前駅', 'Tochomae Station', 'tochomae', '都営大江戸線都庁前駅直結', 'Direct access from Toei Oedo Line Tochomae Station', 35.6915, 139.6917, 1);
-INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
-  ('tokyo-marathon-2026', '観光地', '浅草寺・雷門', 'Sensoji Temple & Kaminarimon', 'コース上を通過する東京を代表する観光名所。外国人ランナーにも人気のスポット。', 'An iconic Tokyo landmark on the course. Popular with international runners.', 'コース上（約15km地点）', NULL, 35.7148, 139.7967);
-INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
-  ('tokyo-marathon-2026', '観光地', '皇居', 'Imperial Palace', 'コースの中盤で皇居周辺を通過。普段はランナーの聖地として知られるランニングコース。', 'The course passes near the Imperial Palace in the middle section. Known as a holy ground for runners.', 'コース上（約37km地点）', NULL, 35.6852, 139.7528);
-INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
-  ('tokyo-marathon-2026', 'グルメ', '東京駅周辺グルメ', 'Tokyo Station Area Dining', 'フィニッシュ地点の東京駅周辺には多数の飲食店。レース後の打ち上げに最適。', 'Numerous restaurants around Tokyo Station at the finish. Perfect for post-race celebrations.', 'フィニッシュ地点周辺', NULL, 35.6812, 139.7671);
-INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('tokyo-marathon-2026', '["tshirt","towel"]', '参加記念Tシャツ（参加者全員）、完走メダル（完走者）、完走タオル（完走者）', 'Commemorative T-shirt (all participants), Finisher medal (finishers), Finisher towel (finishers)', NULL, 0);
-INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('tokyo-marathon-2026', '["medal"]', '参加記念Tシャツ（参加者全員）、完走メダル（完走者）、完走タオル（完走者）', 'Commemorative T-shirt (all participants), Finisher medal (finishers), Finisher towel (finishers)', NULL, 0);
-INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
-  ('tokyo-marathon-2026', NULL, '一般エントリー', 'General Entry', '2025-08-15', '2025-08-29', NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('tokyo-marathon-2026', NULL, NULL, '東京都庁', 'Tokyo Metropolitan Government', NULL, NULL, 0);
-INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('tokyo-marathon-2026', NULL, NULL, '皇居', 'Imperial Palace', NULL, NULL, 1);
-INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('tokyo-marathon-2026', NULL, NULL, '浅草雷門', 'Asakusa Kaminarimon', NULL, NULL, 2);
-INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('tokyo-marathon-2026', NULL, NULL, '銀座', 'Ginza', NULL, NULL, 3);
-INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('tokyo-marathon-2026', NULL, NULL, '東京タワー', 'Tokyo Tower', NULL, NULL, 4);
-INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
-  ('tokyo-marathon-2026', NULL, NULL, '東京駅丸の内', 'Tokyo Station Marunouchi', NULL, NULL, 5);
 
 -- ==================
 -- 東京マラソン (tokyo-marathon-2027)
@@ -7422,7 +7392,7 @@ INSERT OR REPLACE INTO races (
   NULL,
   NULL,
   '2026-06-24T00:00:00Z',
-  '2026-06-22T15:07:47.390Z'
+  '2026-06-27T00:00:00Z'
 );
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('tokyo-marathon-2027', 'full', 42.195, 420, '09:10', 38500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);

--- a/src/data/races/ehime-marathon-2026.json
+++ b/src/data/races/ehime-marathon-2026.json
@@ -15,8 +15,8 @@
   "entry_fee": 0,
   "entry_fee_by_category": true,
   "entry_capacity": 10000,
-  "entry_start_date": "2025-08-01",
-  "entry_end_date": "2025-08-19",
+  "entry_start_date": "2026-07-13",
+  "entry_end_date": "2026-07-31",
   "reception_type": "pre_day",
   "reception_note_ja": "",
   "reception_note_en": "",
@@ -96,23 +96,44 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-05-25T01:17:59.684Z",
+  "updated_at": "2026-06-27T13:27:58.737Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
       "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
-      "2026-05-25: 自動クロールで更新"
+      "2026-05-25: 自動クロールで更新",
+      "2026-06-27: 自動クロールで更新"
     ],
-    "last_verified": "2026-05-25",
+    "last_verified": "2026-06-27",
     "detail_level": "medium"
   },
   "entry_periods": [
     {
-      "label_ja": "一般エントリー",
-      "label_en": "General Entry",
-      "start_date": "2025-08-01",
-      "end_date": "2025-08-19",
-      "entry_fee": null
+      "label_ja": "アスリートエントリー",
+      "label_en": "Athlete Entry",
+      "start_date": "2026-07-13",
+      "end_date": "2026-07-31",
+      "entry_fee": null,
+      "category_id": null,
+      "sort_order": 0
+    },
+    {
+      "label_ja": "ネットタイムアスリートエントリー",
+      "label_en": "Net Time Athlete Entry",
+      "start_date": "2026-07-13",
+      "end_date": "2026-07-31",
+      "entry_fee": null,
+      "category_id": null,
+      "sort_order": 1
+    },
+    {
+      "label_ja": "ランナーボランティア参加者エントリー",
+      "label_en": "Runner Volunteer Entry",
+      "start_date": "2026-07-13",
+      "end_date": "2026-07-31",
+      "entry_fee": null,
+      "category_id": null,
+      "sort_order": 2
     }
   ],
   "motif": "みかん",

--- a/src/data/races/ehime-marathon-2027.json
+++ b/src/data/races/ehime-marathon-2027.json
@@ -1,11 +1,11 @@
 {
-  "id": "ehime-marathon-2026",
+  "id": "ehime-marathon-2027",
   "name_ja": "愛媛マラソン",
   "name_en": "Ehime Marathon",
-  "full_name_ja": "第63回 愛媛マラソン",
+  "full_name_ja": "第64回 愛媛マラソン",
   "full_name_en": "Ehime Marathon",
-  "edition": null,
-  "date": "2026-02-01",
+  "edition": 64,
+  "date": "2027-02-07",
   "prefecture": "38",
   "city_ja": "松山市",
   "city_en": "Matsuyama City",
@@ -15,8 +15,8 @@
   "entry_fee": 0,
   "entry_fee_by_category": true,
   "entry_capacity": 10000,
-  "entry_start_date": "2025-08-01",
-  "entry_end_date": "2025-08-19",
+  "entry_start_date": "2026-07-13",
+  "entry_end_date": "2026-07-31",
   "reception_type": "pre_day",
   "reception_note_ja": "",
   "reception_note_en": "",
@@ -86,33 +86,53 @@
   "participation_gifts": [
     {
       "gift_categories": [
-        "tshirt",
-        "towel"
+        "tshirt"
       ],
-      "description_ja": "大会オリジナルTシャツ、完走メダル、今治タオル（完走者）",
-      "description_en": "Official race T-shirt, Finisher medal, Imabari towel (finishers)",
+      "description_ja": "大会オリジナルTシャツ",
+      "description_en": "Official race T-shirt",
       "image": null
     }
   ],
   "result": null,
-  "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-05-25T01:17:59.684Z",
+  "created_at": "2026-06-27T00:00:00Z",
+  "updated_at": "2026-06-27T13:27:58.737Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
       "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
-      "2026-05-25: 自動クロールで更新"
+      "2026-06-27: 自動クロールで取得した2027年大会情報を元に新規作成",
+      "開催日は例年パターン（2月第1日曜）からの推定。正式発表後に要更新"
     ],
-    "last_verified": "2026-05-25",
+    "last_verified": "2026-06-27",
     "detail_level": "medium"
   },
   "entry_periods": [
     {
-      "label_ja": "一般エントリー",
-      "label_en": "General Entry",
-      "start_date": "2025-08-01",
-      "end_date": "2025-08-19",
-      "entry_fee": null
+      "label_ja": "アスリートエントリー",
+      "label_en": "Athlete Entry",
+      "start_date": "2026-07-13",
+      "end_date": "2026-07-31",
+      "entry_fee": null,
+      "category_id": null,
+      "sort_order": 0
+    },
+    {
+      "label_ja": "ネットタイムアスリートエントリー",
+      "label_en": "Net Time Athlete Entry",
+      "start_date": "2026-07-13",
+      "end_date": "2026-07-31",
+      "entry_fee": null,
+      "category_id": null,
+      "sort_order": 1
+    },
+    {
+      "label_ja": "ランナーボランティア参加者エントリー",
+      "label_en": "Runner Volunteer Entry",
+      "start_date": "2026-07-13",
+      "end_date": "2026-07-31",
+      "entry_fee": null,
+      "category_id": null,
+      "sort_order": 2
     }
   ],
   "motif": "みかん",
@@ -165,10 +185,11 @@
   "completion_gifts": [
     {
       "gift_categories": [
-        "medal"
+        "medal",
+        "towel"
       ],
-      "description_ja": "大会オリジナルTシャツ、完走メダル、今治タオル（完走者）",
-      "description_en": "Official race T-shirt, Finisher medal, Imabari towel (finishers)",
+      "description_ja": "完走メダル、今治タオル（完走者）",
+      "description_en": "Finisher medal, Imabari towel (finishers)",
       "image": null
     }
   ]

--- a/src/data/races/hokkaido-marathon-2026.json
+++ b/src/data/races/hokkaido-marathon-2026.json
@@ -33,10 +33,12 @@
     "elevation_diff_m": null,
     "surface": "road",
     "certification": [
-      "JAAF"
+      "JAAF",
+      "WA",
+      "AIMS"
     ],
-    "highlights_ja": "大通公園、北海道大学、豊平川",
-    "highlights_en": "Odori Park, Hokkaido University, Toyohira River",
+    "highlights_ja": "大通公園、北海道大学、北海道庁赤れんが庁舎、豊平川",
+    "highlights_en": "Odori Park, Hokkaido University, Hokkaido Government Red Brick Office, Toyohira River",
     "notes_ja": "夏開催のため暑さ対策が必須。制限時間6時間。",
     "notes_en": "Summer heat countermeasures essential. 6-hour time limit."
   },
@@ -107,14 +109,15 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-05-30T06:35:06.519Z",
+  "updated_at": "2026-06-27T13:29:05.102Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
       "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
-      "2026-05-30: 自動クロールで更新"
+      "2026-05-30: 自動クロールで更新",
+      "2026-06-27: 自動クロールで更新"
     ],
-    "last_verified": "2026-05-30",
+    "last_verified": "2026-06-27",
     "detail_level": "medium"
   },
   "entry_periods": [

--- a/src/data/races/kagawa-marathon-2026.json
+++ b/src/data/races/kagawa-marathon-2026.json
@@ -31,9 +31,11 @@
     "min_elevation_m": null,
     "elevation_diff_m": null,
     "surface": "road",
-    "certification": [],
-    "highlights_ja": "瀬戸内海",
-    "highlights_en": "Seto Inland Sea",
+    "certification": [
+      "JAAF"
+    ],
+    "highlights_ja": "瀬戸内海、島々、栗林公園、里山、讃岐平野",
+    "highlights_en": "Seto Inland Sea, islands, Ritsurin Garden, satoyama, Sanuki Plain",
     "notes_ja": null,
     "notes_en": null
   },
@@ -81,17 +83,27 @@
     }
   ],
   "weather_history": [],
-  "participation_gifts": [],
+  "participation_gifts": [
+    {
+      "gift_categories": [
+        "tshirt"
+      ],
+      "description_ja": "オリジナルTシャツと記念品",
+      "description_en": "Original T-shirt and commemorative item",
+      "image": null
+    }
+  ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-05-30T06:36:17.548Z",
+  "updated_at": "2026-06-27T13:29:44.929Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
       "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
-      "2026-05-30: 自動クロールで更新"
+      "2026-05-30: 自動クロールで更新",
+      "2026-06-27: 自動クロールで更新"
     ],
-    "last_verified": "2026-05-30",
+    "last_verified": "2026-06-27",
     "detail_level": "medium"
   },
   "entry_periods": [
@@ -142,6 +154,17 @@
     {
       "url": "https://kagawa-marathon.com/information/concept/",
       "label": "大会の特色"
+    }
+  ],
+  "completion_gifts": [
+    {
+      "gift_categories": [
+        "medal",
+        "towel"
+      ],
+      "description_ja": "完走メダルとフィニッシャータオル",
+      "description_en": "Finisher medal and finisher towel",
+      "image": null
     }
   ]
 }

--- a/src/data/races/kobe-marathon-2026.json
+++ b/src/data/races/kobe-marathon-2026.json
@@ -110,25 +110,28 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-06-22T15:03:49.422Z",
+  "updated_at": "2026-06-27T13:30:41.348Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
       "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
       "秋冬大会の日程は例年パターンからの推定を含む。正式発表後に要更新",
       "2026-05-30: 自動クロールで更新",
-      "2026-06-22: 自動クロールで更新"
+      "2026-06-22: 自動クロールで更新",
+      "2026-06-27: 自動クロールで更新"
     ],
-    "last_verified": "2026-06-22",
+    "last_verified": "2026-06-27",
     "detail_level": "medium"
   },
   "entry_periods": [
     {
+      "label_ja": "一般エントリー",
+      "label_en": "General Entry",
       "start_date": "2026-04-17",
       "end_date": "2026-06-01",
       "entry_fee": 18000,
-      "label_ja": "",
-      "label_en": ""
+      "category_id": null,
+      "sort_order": 0
     }
   ],
   "motif": "異人館",

--- a/src/data/races/osaka-yodo-river-citizens-marathon-2026.json
+++ b/src/data/races/osaka-yodo-river-citizens-marathon-2026.json
@@ -65,14 +65,14 @@
   "nearby_spots": [],
   "result": null,
   "created_at": "2026-04-11T14:42:59.225Z",
-  "updated_at": "2026-06-08T14:38:38.451Z",
+  "updated_at": "2026-06-27T13:32:25.650Z",
   "entry_periods": [
     {
+      "label_ja": "一般エントリー",
+      "label_en": "General Entry",
       "start_date": "2026-04-17",
       "end_date": "2026-09-27",
-      "entry_fee": null,
-      "label_ja": "",
-      "label_en": ""
+      "entry_fee": null
     }
   ],
   "participation_gifts": [
@@ -121,9 +121,10 @@
     }
   ],
   "_metadata": {
-    "last_verified": "2026-06-08",
+    "last_verified": "2026-06-27",
     "data_accuracy_notes": [
-      "2026-06-08: 自動クロールで更新"
+      "2026-06-08: 自動クロールで更新",
+      "2026-06-27: 自動クロールで更新"
     ]
   }
 }

--- a/src/data/races/saitama-marathon-2027.json
+++ b/src/data/races/saitama-marathon-2027.json
@@ -1,0 +1,135 @@
+{
+  "id": "saitama-marathon-2027",
+  "name_ja": "さいたまマラソン",
+  "name_en": "Saitama Marathon",
+  "full_name_ja": "さいたまマラソン2027",
+  "full_name_en": "Saitama Marathon 2027",
+  "edition": null,
+  "date": "2027-02-14",
+  "prefecture": "11",
+  "city_ja": "さいたま市",
+  "city_en": "Saitama City",
+  "description_ja": "さいたま市で開催されるフルマラソン。荒川沿いのフラットなコース。",
+  "description_en": "A full marathon in Saitama City along the flat Arakawa River course.",
+  "official_url": "https://saitama-marathon.jp",
+  "entry_fee": 15000,
+  "entry_fee_by_category": true,
+  "entry_capacity": 14000,
+  "entry_start_date": "2026-07-01",
+  "entry_end_date": null,
+  "reception_type": "pre_day",
+  "reception_note_ja": "",
+  "reception_note_en": "",
+  "tags": [],
+  "course_gpx_file": null,
+  "course_info": {
+    "max_elevation_m": null,
+    "min_elevation_m": null,
+    "elevation_diff_m": null,
+    "surface": "road",
+    "certification": [
+      "JAAF"
+    ],
+    "highlights_ja": null,
+    "highlights_en": null,
+    "notes_ja": null,
+    "notes_en": null
+  },
+  "categories": [
+    {
+      "distance_type": "full",
+      "distance_km": 42.195,
+      "time_limit_minutes": 360,
+      "start_time": "",
+      "capacity": 14000,
+      "entry_fee": 15000,
+      "entry_fee_u25": null,
+      "name_ja": null,
+      "name_en": null,
+      "description_ja": null,
+      "description_en": null,
+      "waves": null
+    }
+  ],
+  "aid_stations": [],
+  "checkpoints": [],
+  "access_points": [],
+  "nearby_spots": [
+    {
+      "type": "観光地",
+      "name_ja": "氷川神社",
+      "name_en": "Hikawa Shrine",
+      "description_ja": "武蔵国一宮。2km以上の参道は日本一の長さ。大宮の象徴。",
+      "description_en": "The first shrine of Musashi Province. Its 2km+ approach is the longest in Japan.",
+      "distance_from_venue": "大宮エリア",
+      "url": null,
+      "latitude": 35.9069,
+      "longitude": 139.6286
+    }
+  ],
+  "weather_history": [],
+  "participation_gifts": [],
+  "result": null,
+  "created_at": "2026-06-27T00:00:00Z",
+  "updated_at": "2026-06-27T13:33:20.980Z",
+  "_metadata": {
+    "data_source": "公式サイト等の公開情報から転記",
+    "data_accuracy_notes": [
+      "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
+      "2026-06-27: 自動クロールで取得した2027年大会情報を元に新規作成"
+    ],
+    "last_verified": "2026-06-27",
+    "detail_level": "medium"
+  },
+  "entry_periods": [
+    {
+      "label_ja": "優先エントリー（さいたま市民・越谷市民／2026大会参加者）",
+      "label_en": "Priority Entry",
+      "start_date": "2026-07-01",
+      "end_date": "2026-07-13",
+      "entry_fee": 15000,
+      "category_id": null,
+      "sort_order": 0
+    },
+    {
+      "label_ja": "一般エントリー",
+      "label_en": "General Entry",
+      "start_date": "2026-07-15",
+      "end_date": null,
+      "entry_fee": 15000,
+      "category_id": null,
+      "sort_order": 1
+    }
+  ],
+  "motif": "荒川",
+  "motif_color": "#0369a1",
+  "motif_romaji": "Arakawa",
+  "tagline_ja": "荒川の雄大な流れとともに走る、さいたまの42km",
+  "tagline_en": "Run along the vast Arakawa River through Saitama",
+  "hero_image_url": null,
+  "hero_caption_ja": null,
+  "hero_caption_en": null,
+  "gallery": [],
+  "voices": [],
+  "time_buckets": [],
+  "course_highlights": [],
+  "info_urls": [
+    {
+      "url": "https://saitama-marathon.jp/about/",
+      "label": "大会要項"
+    },
+    {
+      "url": "https://saitama-marathon.jp/about/guest/",
+      "label": "大会の特色"
+    },
+    {
+      "url": "https://saitama-marathon.jp/about/map/",
+      "label": "コース情報"
+    },
+    {
+      "url": "https://saitama-marathon.jp/entry/",
+      "label": "エントリー"
+    }
+  ],
+  "completion_gifts": []
+}

--- a/src/data/races/tokyo-marathon-2027.json
+++ b/src/data/races/tokyo-marathon-2027.json
@@ -15,7 +15,7 @@
   "entry_fee": null,
   "entry_fee_by_category": true,
   "entry_capacity": 38500,
-  "entry_start_date": "2026-07-31",
+  "entry_start_date": "2026-06-24",
   "entry_end_date": "2026-08-28",
   "reception_type": "pre_day",
   "reception_note_ja": "EXPO会場（東京ビッグサイト）にて前日受付。大会当日の受付なし。",
@@ -122,12 +122,22 @@
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
       "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
-      "2026-06-22: 自動クロールで取得した2027年大会情報を元に新規作成"
+      "2026-06-22: 自動クロールで取得した2027年大会情報を元に新規作成",
+      "2026-06-27: 自動クロールでエントリー区分を更新"
     ],
-    "last_verified": "2026-06-22",
+    "last_verified": "2026-06-27",
     "detail_level": "medium"
   },
   "entry_periods": [
+    {
+      "label_ja": "チャリティランナー寄付申込",
+      "label_en": "Charity Runner Donation Entry",
+      "start_date": "2026-06-24",
+      "end_date": "2026-07-09",
+      "entry_fee": null,
+      "category_id": null,
+      "sort_order": 0
+    },
     {
       "label_ja": "ONE TOKYOプレミアムメンバーエントリー",
       "label_en": "ONE TOKYO Premium Member Entry",
@@ -135,7 +145,16 @@
       "end_date": "2026-08-13",
       "entry_fee": null,
       "category_id": null,
-      "sort_order": 0
+      "sort_order": 1
+    },
+    {
+      "label_ja": "準エリートエントリー",
+      "label_en": "Sub-Elite Entry",
+      "start_date": "2026-07-31",
+      "end_date": "2026-08-13",
+      "entry_fee": null,
+      "category_id": null,
+      "sort_order": 2
     },
     {
       "label_ja": "一般エントリー",
@@ -144,7 +163,7 @@
       "end_date": "2026-08-28",
       "entry_fee": null,
       "category_id": null,
-      "sort_order": 1
+      "sort_order": 3
     }
   ],
   "motif": "東京の街",

--- a/src/data/races/tokyo-marathon-2027.json
+++ b/src/data/races/tokyo-marathon-2027.json
@@ -117,7 +117,7 @@
   ],
   "result": null,
   "created_at": "2026-06-24T00:00:00Z",
-  "updated_at": "2026-06-22T15:07:47.390Z",
+  "updated_at": "2026-06-27T00:00:00Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [

--- a/tools/crawl/checksums.json
+++ b/tools/crawl/checksums.json
@@ -1,22 +1,22 @@
 {
   "https://www.abashiri-marathon.jp/outline/": {
     "hash": "91fff2f513a6e920e41faf6bbdc1ea92c4f4af653b9c9493d4e761aab15d8406",
-    "last_checked": "2026-06-22T14:57:09.168Z",
+    "last_checked": "2026-06-27T13:25:50.119Z",
     "race_id": "abashiri-marathon-2026"
   },
   "https://www.abashiri-marathon.jp/entry/": {
     "hash": "518f61990bfb00fe5fc1484e38f4110cbf1d5ff8f592485b672561a3afb91626",
-    "last_checked": "2026-06-22T14:57:09.246Z",
+    "last_checked": "2026-06-27T13:25:50.232Z",
     "race_id": "abashiri-marathon-2026"
   },
   "https://www.abashiri-marathon.jp/course/": {
     "hash": "524bf485c0c884ea094a068dfbd0f17da14038d6ced4f63fbdb4b8138a70692f",
-    "last_checked": "2026-06-22T14:57:09.322Z",
+    "last_checked": "2026-06-27T13:25:50.327Z",
     "race_id": "abashiri-marathon-2026"
   },
   "https://www.abashiri-marathon.jp/contact/": {
     "hash": "4d85fecfd42c89832ba9116770d13e6f2c613ae42a7c6a0365b195e6aa50420c",
-    "last_checked": "2026-06-22T14:57:09.461Z",
+    "last_checked": "2026-06-27T13:25:50.424Z",
     "race_id": "abashiri-marathon-2026"
   },
   "https://www.abashiri-marathon.jp/feed/": {
@@ -26,82 +26,82 @@
   },
   "https://aomori-sakuramarathon.com/category/infomation/": {
     "hash": "eb29c381bf5f8d09ffce5efc1f5918d5c887645c09c01263876aa1a415ee0bc6",
-    "last_checked": "2026-06-22T14:57:10.919Z",
+    "last_checked": "2026-06-27T13:25:51.033Z",
     "race_id": "aomori-sakura-marathon-2026"
   },
   "https://aomori-sakuramarathon.com/guide/": {
     "hash": "093ed21ce726044fc2160fe1048ea20ec4267a8616694d0afd659b8afc268293",
-    "last_checked": "2026-06-22T14:57:11.349Z",
+    "last_checked": "2026-06-27T13:25:51.450Z",
     "race_id": "aomori-sakura-marathon-2026"
   },
   "https://aomori-sakuramarathon.com/entry/": {
     "hash": "929ce7eb0a216882ab359c6db23a056c0aeb3f681fcc2c7870f8a3642f919103",
-    "last_checked": "2026-06-22T14:57:11.763Z",
+    "last_checked": "2026-06-27T13:25:51.825Z",
     "race_id": "aomori-sakura-marathon-2026"
   },
   "https://aomori-sakuramarathon.com/course/": {
     "hash": "639ad9395ee64db3c98e74fcf39e63bc77d66d8b1342e329f6874b0faa5d8ea4",
-    "last_checked": "2026-06-22T14:57:12.171Z",
+    "last_checked": "2026-06-27T13:25:52.213Z",
     "race_id": "aomori-sakura-marathon-2026"
   },
   "https://aomori-sakuramarathon.com/qa/": {
     "hash": "db8dc87ba474fc8a19674133ab384c8e9f5cbb1623c94113659b53e2e0d08b04",
-    "last_checked": "2026-06-22T14:57:12.560Z",
+    "last_checked": "2026-06-27T13:25:52.589Z",
     "race_id": "aomori-sakura-marathon-2026"
   },
   "https://www.asahikawa-half-marathon.jp/outline/": {
     "hash": "47bf70698f75e9773f0d62dd66104d2a62d6c0a46dbbd5e5432a31e5cb2f067c",
-    "last_checked": "2026-06-22T14:57:12.981Z",
+    "last_checked": "2026-06-27T13:25:53.039Z",
     "race_id": "asahikawa-half-marathon-2026"
   },
   "https://www.asahikawa-half-marathon.jp/course/": {
     "hash": "ac5b1580e8a0f3746e06825503c72d4483e3644da174851c7744325029488c0c",
-    "last_checked": "2026-06-22T14:57:13.112Z",
+    "last_checked": "2026-06-27T13:25:53.183Z",
     "race_id": "asahikawa-half-marathon-2026"
   },
   "https://www.asahikawa-half-marathon.jp/entry/": {
     "hash": "0bb52c00d86a87e10a0156c3afa929892e2ce9f518b4bc6a1a0bf04e1ad4dae0",
-    "last_checked": "2026-06-22T14:57:13.237Z",
+    "last_checked": "2026-06-27T13:25:53.304Z",
     "race_id": "asahikawa-half-marathon-2026"
   },
   "https://www.betsudai.com/outline/": {
     "hash": "ba5d06d6001a87b52a3f6b3acb26014122145b0be3df21e6b3df2a812b746b3e",
-    "last_checked": "2026-06-22T14:57:13.388Z",
+    "last_checked": "2026-06-27T13:25:53.518Z",
     "race_id": "beppu-oita-marathon-2026"
   },
   "https://www.betsudai.com/outline/flow/": {
     "hash": "1afe6f26ac5ba16f3fa4511026e2f719b7b728678809ec3aaeaac655755f2fac",
-    "last_checked": "2026-06-22T14:57:13.451Z",
+    "last_checked": "2026-06-27T13:25:53.599Z",
     "race_id": "beppu-oita-marathon-2026"
   },
   "https://www.betsudai.com/outline/course/": {
     "hash": "12eb3ac0b00f41b4f4ded05771e9ea319459feb86f44c0c506bac38e2f6eed6d",
-    "last_checked": "2026-06-22T14:57:13.525Z",
+    "last_checked": "2026-06-27T13:25:53.674Z",
     "race_id": "beppu-oita-marathon-2026"
   },
   "https://www.betsudai.com/question/": {
     "hash": "83398aaeaa0331deab4c6d4db6335e4176b73779ec67c8735939e27dd6778cc1",
-    "last_checked": "2026-06-22T14:57:13.599Z",
+    "last_checked": "2026-06-27T13:25:53.741Z",
     "race_id": "beppu-oita-marathon-2026"
   },
   "https://biwako-marathon.com/outline-marathon/": {
     "hash": "80eaeb12202c49ab21ab909492fc9f8864a95b90cb0955afb6f3958849387450",
-    "last_checked": "2026-06-22T14:57:13.845Z",
+    "last_checked": "2026-06-27T13:25:54.027Z",
     "race_id": "biwako-marathon-2026"
   },
   "https://biwako-marathon.com/entry/": {
     "hash": "ff417bbf223f6c982d5d9c967e2a5c41608ebc066d68e096cc1a2c8dca39c615",
-    "last_checked": "2026-06-22T14:57:13.968Z",
+    "last_checked": "2026-06-27T13:25:54.098Z",
     "race_id": "biwako-marathon-2026"
   },
   "https://biwako-marathon.com/course/": {
     "hash": "3bdce9f981b374e91105a05aa8b990f89b158c9214c20031803284d12d1f7046",
-    "last_checked": "2026-06-22T14:57:14.020Z",
+    "last_checked": "2026-06-27T13:25:54.154Z",
     "race_id": "biwako-marathon-2026"
   },
   "https://biwako-marathon.com/traffic_regulation/": {
     "hash": "fd5bd185b8321031b8596a703c333ecca913a5288113c8b292a951d7a8831d7e",
-    "last_checked": "2026-06-22T14:57:14.070Z",
+    "last_checked": "2026-06-27T13:25:54.211Z",
     "race_id": "biwako-marathon-2026"
   },
   "https://biwako-marathon.com/feed/": {
@@ -111,127 +111,127 @@
   },
   "https://www.r-wellness.com/fuji5/participant-info/": {
     "hash": "266eb373d5f7dee2aa4866a58e0b49cab963a90fd068d98f05097b59f1d8c13a",
-    "last_checked": "2026-06-22T14:57:14.468Z",
+    "last_checked": "2026-06-27T13:25:54.612Z",
     "race_id": "challenge-fuji5lakes-2026"
   },
   "https://www.r-wellness.com/fuji5/course/": {
     "hash": "fdbb2054b500145a2e7f1894e6298d5bd901dd4095ea0a2d2f4349b94818465e",
-    "last_checked": "2026-06-22T14:57:14.792Z",
+    "last_checked": "2026-06-27T13:25:54.947Z",
     "race_id": "challenge-fuji5lakes-2026"
   },
   "https://www.r-wellness.com/fuji5/access/": {
     "hash": "bdb641d9f83202ae9a56b3534d94684c59238edee36f647a7ad843941a5e122f",
-    "last_checked": "2026-06-22T14:57:15.110Z",
+    "last_checked": "2026-06-27T13:25:55.271Z",
     "race_id": "challenge-fuji5lakes-2026"
   },
   "https://www.r-wellness.com/fuji5/entry/": {
     "hash": "d026e418928b077798ff62a960290b19fbd9d7af5960c9fa3968b4d6e24524e4",
-    "last_checked": "2026-06-22T14:57:15.426Z",
+    "last_checked": "2026-06-27T13:25:55.585Z",
     "race_id": "challenge-fuji5lakes-2026"
   },
   "https://www.r-wellness.com/fuji5/faq/": {
     "hash": "3c2f0764c3a9a0e03adde57da20e67aafa5445a5fc15097d671e9ea5da6ecbaa",
-    "last_checked": "2026-06-22T14:57:15.742Z",
+    "last_checked": "2026-06-27T13:25:55.896Z",
     "race_id": "challenge-fuji5lakes-2026"
   },
   "https://chiba-aqualine-marathon.com/tournament/": {
     "hash": "df7a126bd7d94629c03046057c7e5ab21a83a2828972983cfaca6f96d4a5eb59",
-    "last_checked": "2026-06-22T14:57:15.810Z",
+    "last_checked": "2026-06-27T13:25:55.961Z",
     "race_id": "chiba-aqualine-marathon-2026"
   },
   "https://ehimemarathon.jp/outline/": {
     "hash": "bec359a1d463c5a2c2fa5d739202c9d55a5f7dd30d1a7c9af8091c1fdaa48121",
-    "last_checked": "2026-06-22T14:57:15.922Z",
+    "last_checked": "2026-06-27T13:25:56.100Z",
     "race_id": "ehime-marathon-2026"
   },
   "https://ehimemarathon.jp/entry/": {
-    "hash": "c89ed7fca399b652df6cc3d89abf3e53f4200613136b1ca039f7d74e876f2183",
-    "last_checked": "2026-06-22T14:57:15.934Z",
+    "hash": "7849963410b1506d02a06e747e7a0549647553eba95ddb2050ac866257fcf88f",
+    "last_checked": "2026-06-27T13:25:56.115Z",
     "race_id": "ehime-marathon-2026"
   },
   "https://ehimemarathon.jp/about-volunteer/": {
     "hash": "34918b29945d9f85289ec5bba2eabfd4c7edc1fa9468f8cf9d8c395bdfbb523c",
-    "last_checked": "2026-06-22T14:57:16.814Z",
+    "last_checked": "2026-06-27T13:25:56.997Z",
     "race_id": "ehime-marathon-2026"
   },
   "https://ehimemarathon.jp/course/": {
     "hash": "8c8a1a044dfdfcec861cd5c6fded13d1815375f143577a6180ab9f1765e93d28",
-    "last_checked": "2026-06-22T14:57:17.631Z",
+    "last_checked": "2026-06-27T13:25:57.787Z",
     "race_id": "ehime-marathon-2026"
   },
   "https://ehimemarathon.jp/access/": {
     "hash": "4135417da6d685adb536fc376558c8d28181a3659a1a67191e7d05a33b001bc1",
-    "last_checked": "2026-06-22T14:57:18.397Z",
+    "last_checked": "2026-06-27T13:25:58.675Z",
     "race_id": "ehime-marathon-2026"
   },
   "https://fujimountainrace.city.fujiyoshida.yamanashi.jp/outline/": {
     "hash": "11b53a19485dc6b3a6f369aa82950c125dbfcb78c3161a84e1b1295af5bc65eb",
-    "last_checked": "2026-06-22T14:57:18.533Z",
+    "last_checked": "2026-06-27T13:25:58.813Z",
     "race_id": "fuji-mountain-race-2026"
   },
   "https://fujimountainrace.city.fujiyoshida.yamanashi.jp/entry/": {
     "hash": "663102edbfa4b982ffff2cd10e17a1c96373b8ffadb9b98378a7639d0b81e348",
-    "last_checked": "2026-06-22T14:57:18.582Z",
+    "last_checked": "2026-06-27T13:25:58.865Z",
     "race_id": "fuji-mountain-race-2026"
   },
   "https://fujimountainrace.city.fujiyoshida.yamanashi.jp/course/": {
     "hash": "6eee351362ff3e9e79355b794fb2828af2f525ca2ca74d2c0210f01385292d69",
-    "last_checked": "2026-06-22T14:57:18.631Z",
+    "last_checked": "2026-06-27T13:25:58.914Z",
     "race_id": "fuji-mountain-race-2026"
   },
   "https://fujimountainrace.city.fujiyoshida.yamanashi.jp/access/": {
     "hash": "f1ad26062f183f3c2d0b62cd7b3071e545a1d776415f86cd73db8b9b40bd86e4",
-    "last_checked": "2026-06-22T14:57:18.678Z",
+    "last_checked": "2026-06-27T13:25:58.930Z",
     "race_id": "fuji-mountain-race-2026"
   },
   "https://fujimountainrace.city.fujiyoshida.yamanashi.jp/2026/wp-content/uploads/2026/04/info-sponsors.pdf": {
     "hash": "9c68961564530716e0c619e88a9e9026cf86635e36c3c79f4969a5672f39d048",
-    "last_checked": "2026-06-22T14:57:18.858Z",
+    "last_checked": "2026-06-27T13:25:59.148Z",
     "race_id": "fuji-mountain-race-2026"
   },
   "https://mtfujimarathon.com/info/": {
     "hash": "380d0e66124b1168733e80b62cdfba4a4a1ecdd0c3567c4bd5d35a621a7d1304",
-    "last_checked": "2026-06-22T14:57:19.092Z",
+    "last_checked": "2026-06-27T13:25:59.350Z",
     "race_id": "fujisan-marathon-2026"
   },
   "https://mtfujimarathon.com/entry-front/": {
     "hash": "6963b577e0591f62d1c41081e72cabcbbd6744b6170edfadcd9160016331492b",
-    "last_checked": "2026-06-22T14:57:19.149Z",
+    "last_checked": "2026-06-27T13:25:59.408Z",
     "race_id": "fujisan-marathon-2026"
   },
   "https://mtfujimarathon.com/outline/": {
     "hash": "9798446b2dfd1740a550b16aa37fa0e52d8e7cf86d22b86d6f86a56c5ffd0825",
-    "last_checked": "2026-06-22T14:57:19.215Z",
+    "last_checked": "2026-06-27T13:25:59.470Z",
     "race_id": "fujisan-marathon-2026"
   },
   "https://mtfujimarathon.com/course/": {
     "hash": "24e42984514c3e8a3482555b5746b2e315590c3b93a0fd54d6b2885888a7d88c",
-    "last_checked": "2026-06-22T14:57:19.278Z",
+    "last_checked": "2026-06-27T13:25:59.531Z",
     "race_id": "fujisan-marathon-2026"
   },
   "https://mtfujimarathon.com/access/": {
     "hash": "1a0d4147dd56d54a67ef214b84f4b935a28c7b5aa161375facd9d3faf60f9a96",
-    "last_checked": "2026-06-22T14:57:19.347Z",
+    "last_checked": "2026-06-27T13:25:59.593Z",
     "race_id": "fujisan-marathon-2026"
   },
   "https://fukuchiyama-marathon.com/outline/": {
     "hash": "57bca7f54c92f90fd9a23a149b312bcd7907ba8e285d8260f6b80786c480dd49",
-    "last_checked": "2026-06-22T14:57:19.669Z",
+    "last_checked": "2026-06-27T13:25:59.899Z",
     "race_id": "fukuchiyama-marathon-2026"
   },
   "https://fukuchiyama-marathon.com/course-map/": {
     "hash": "03b933782faa6d560c4b63671dbac6c82ee05ec276d8bac8d444e37c3be1ec0d",
-    "last_checked": "2026-06-22T14:57:19.925Z",
+    "last_checked": "2026-06-27T13:26:00.129Z",
     "race_id": "fukuchiyama-marathon-2026"
   },
   "https://fukuchiyama-marathon.com/entry/": {
     "hash": "557a5f678405f936737d195f1e1ae4624379f513b8741173c3b863ff02a4a697",
-    "last_checked": "2026-06-22T14:57:20.099Z",
+    "last_checked": "2026-06-27T13:26:00.310Z",
     "race_id": "fukuchiyama-marathon-2026"
   },
   "https://fukuchiyama-marathon.com/access/": {
     "hash": "359b8b1745a5775b1b572207e5d03b8127530377548a1c346843036ff5c24fee",
-    "last_checked": "2026-06-22T14:57:20.341Z",
+    "last_checked": "2026-06-27T13:26:00.555Z",
     "race_id": "fukuchiyama-marathon-2026"
   },
   "https://www.fukui-sakura-marathon.jp/about/": {
@@ -250,8 +250,8 @@
     "race_id": "fukui-sakura-marathon-2026"
   },
   "https://www.fukui-sakura-marathon.jp/runner/": {
-    "hash": "598a3b45eb21faa505a3cb0429fa094d4f006f54df892e7a18367e928793286a",
-    "last_checked": "2026-06-22T14:57:24.088Z",
+    "hash": "0b3e5d34eb08dbc8b4ed736ff84a77e49f932c5a803b619d362fb2292c0d0235",
+    "last_checked": "2026-06-27T13:26:04.422Z",
     "race_id": "fukui-sakura-marathon-2026"
   },
   "https://www.fukui-sakura-marathon.jp/stay/": {
@@ -260,13 +260,13 @@
     "race_id": "fukui-sakura-marathon-2026"
   },
   "https://www.fukuoka-international-marathon.jp/": {
-    "hash": "a572bef5b1041eca721c1b0b8742610d5ae821290e31b58acb324f8069317b9c",
-    "last_checked": "2026-06-22T14:57:25.265Z",
+    "hash": "3bad705b8d83e2f3f0c1357b22b5df49c372cdd4cee0e0f5138674ca72be7ef8",
+    "last_checked": "2026-06-27T13:26:05.683Z",
     "race_id": "fukuoka-international-marathon-2026"
   },
   "https://www.f-marathon.jp/about/": {
     "hash": "5f804e0b448f5a33cd660151ae746a6b6d541e96751a2f89b69658f81b7bc6f2",
-    "last_checked": "2026-06-22T14:57:25.376Z",
+    "last_checked": "2026-06-27T13:26:05.860Z",
     "race_id": "fukuoka-marathon-2026"
   },
   "https://www.f-marathon.jp/about/course.php/": {
@@ -286,117 +286,117 @@
   },
   "https://www.f-marathon.jp/traffic/": {
     "hash": "554240b617181c6b1b271d7f0e9e141f900323b3a74253ddb43458b18c9d27d7",
-    "last_checked": "2026-06-22T14:57:25.477Z",
+    "last_checked": "2026-06-27T13:26:05.965Z",
     "race_id": "fukuoka-marathon-2026"
   },
   "https://www.g-marathon.com/about-guide/": {
     "hash": "d5b90aeb3dd614ebaa9526e448e6eb06e5e08a957cfc174c3a426fcf7b937073",
-    "last_checked": "2026-06-22T14:57:25.586Z",
+    "last_checked": "2026-06-27T13:26:06.071Z",
     "race_id": "gunma-marathon-2026"
   },
   "https://www.g-marathon.com/course-full/": {
     "hash": "4d6a0b3e45226f859614450f34d4b9d33ad4e425b2a0bfe854df26a67de457ff",
-    "last_checked": "2026-06-22T14:57:25.601Z",
+    "last_checked": "2026-06-27T13:26:06.084Z",
     "race_id": "gunma-marathon-2026"
   },
   "https://www.kumagera.ne.jp/a100km/course.html": {
     "hash": "0400379c8d34d45b491e7e99362434403713d8af8276834a2611a90cd40bbf36",
-    "last_checked": "2026-06-22T14:57:09.668Z",
+    "last_checked": "2026-06-27T13:25:50.504Z",
     "race_id": "akita-nairiku-ultra-2026"
   },
   "https://www.kumagera.ne.jp/a100km/entry.html": {
     "hash": "ffa03b9ae7dde88a07c6b1cae1a61e529dd0d3d9d63ac3dda0b4b1dfe00b2fe2",
-    "last_checked": "2026-06-22T14:57:09.687Z",
+    "last_checked": "2026-06-27T13:25:50.523Z",
     "race_id": "akita-nairiku-ultra-2026"
   },
   "https://www.kumagera.ne.jp/a100km/essentia-point.html": {
     "hash": "85867aa1f1ca55f12cd112adabd2af0d5fa5272678c75a46a6d8efbe8ee0a45b",
-    "last_checked": "2026-06-22T14:57:09.707Z",
+    "last_checked": "2026-06-27T13:25:50.543Z",
     "race_id": "akita-nairiku-ultra-2026"
   },
   "https://www.kumagera.ne.jp/a100km/access.html": {
     "hash": "76fe52037b53f163dcfb97d86fb19e2b7e45986c3a598c8d14d500161b1559dc",
-    "last_checked": "2026-06-22T14:57:09.725Z",
+    "last_checked": "2026-06-27T13:25:50.564Z",
     "race_id": "akita-nairiku-ultra-2026"
   },
   "https://www.kumagera.ne.jp/a100km/question.html": {
     "hash": "51387e4c0186c96d06ecce0c4f9155d1e8234d09da0b82e31dc989d539ae0b13",
-    "last_checked": "2026-06-22T14:57:09.746Z",
+    "last_checked": "2026-06-27T13:25:50.584Z",
     "race_id": "akita-nairiku-ultra-2026"
   },
   "https://www.betsudai.com/wp-content/themes/betsudai/pdf/74/kou.pdf": {
     "hash": "f81fd537033822b64e8d4a11cc1e6c3ce2dbb2b44c607fb0330ac2b37bbc04e2",
-    "last_checked": "2026-06-22T14:57:13.705Z",
+    "last_checked": "2026-06-27T13:25:53.868Z",
     "race_id": "beppu-oita-marathon-2026"
   },
   "https://chiba-aqualine-marathon.com/tournament/course.html": {
     "hash": "1c209f39c9265e3356bbfdef19d45e84cd4ca11336ce53af9ea1a7b67a92a65c",
-    "last_checked": "2026-06-22T14:57:15.826Z",
+    "last_checked": "2026-06-27T13:25:55.979Z",
     "race_id": "chiba-aqualine-marathon-2026"
   },
   "https://chiba-aqualine-marathon.com/runner/entry.html": {
     "hash": "32662d99c9cfcda9876e63fb16e72988974179a34cd900335fd1b86bc743824d",
-    "last_checked": "2026-06-22T14:57:15.842Z",
+    "last_checked": "2026-06-27T13:25:55.996Z",
     "race_id": "chiba-aqualine-marathon-2026"
   },
   "https://chiba-aqualine-marathon.com/runner/guidelines.html": {
     "hash": "f91d0a4085aca57db9ce58a1e54a98553ff96ca7cb5ec290b5710c3dfdb4e3ba",
-    "last_checked": "2026-06-22T14:57:15.858Z",
+    "last_checked": "2026-06-27T13:25:56.015Z",
     "race_id": "chiba-aqualine-marathon-2026"
   },
   "https://www.f-marathon.jp/about/course.php": {
     "hash": "2b469ef4c3334e2f3bd80d478e13ec233a121351b044653f656e32b5a0399ca9",
-    "last_checked": "2026-06-22T14:57:25.401Z",
+    "last_checked": "2026-06-27T13:26:05.886Z",
     "race_id": "fukuoka-marathon-2026"
   },
   "https://www.f-marathon.jp/about/logo.php": {
     "hash": "96a62f5b79d5801681ae636456756a757c19f2506f838c7276d8b94c9b45fead",
-    "last_checked": "2026-06-22T14:57:25.426Z",
+    "last_checked": "2026-06-27T13:26:05.911Z",
     "race_id": "fukuoka-marathon-2026"
   },
   "https://www.f-marathon.jp/runner/apply.php": {
     "hash": "ad8d2ac5f818a98565944f8d7fb18b0cc8e0c7bd7e511f1d7e8ce2273ce2f0d2",
-    "last_checked": "2026-06-22T14:57:25.450Z",
+    "last_checked": "2026-06-27T13:26:05.938Z",
     "race_id": "fukuoka-marathon-2026"
   },
   "https://www.g-marathon.com/access/": {
     "hash": "ce82fdecda2f4a42974c310137af637b3a407d4d4b08817842770792694f4f71",
-    "last_checked": "2026-06-22T14:57:26.466Z",
+    "last_checked": "2026-06-27T13:26:06.901Z",
     "race_id": "gunma-marathon-2026"
   },
   "https://www.g-marathon.com/faq_runner/": {
     "hash": "0e400128b4c88af4237c2c970761ee28c4dc08ce8f5b639eaaeac60b805bc44f",
-    "last_checked": "2026-06-22T14:57:26.479Z",
+    "last_checked": "2026-06-27T13:26:07.144Z",
     "race_id": "gunma-marathon-2026"
   },
   "https://www.g-marathon.com/info/": {
     "hash": "4cb26155dfa0c4ebc98778fb8c90df0ff4ed3bf95ff3fa5ffc7cd19bb35c3806",
-    "last_checked": "2026-06-22T14:57:27.379Z",
+    "last_checked": "2026-06-27T13:26:08.025Z",
     "race_id": "gunma-marathon-2026"
   },
   "https://www.sakuranbo-m.jp/overview/": {
     "hash": "6bff5b397d9836fe8f6aca4ce74d28d672d822f9dbc82198ee15f1b3959fe869",
-    "last_checked": "2026-06-22T14:57:28.167Z",
+    "last_checked": "2026-06-27T13:26:08.801Z",
     "race_id": "higashine-sakuranbo-marathon-2026"
   },
   "https://www.sakuranbo-m.jp/course/": {
     "hash": "53feebaff16b36b31512acb795d83c6af843ea87a1e8d284b5b5ffbd05332a4c",
-    "last_checked": "2026-06-22T14:57:28.550Z",
+    "last_checked": "2026-06-27T13:26:09.329Z",
     "race_id": "higashine-sakuranbo-marathon-2026"
   },
   "https://www.sakuranbo-m.jp/access/": {
     "hash": "6282e51d84fd5905d5f3c0580e55068efcee2a1394e641dc21e79e82bcb80099",
-    "last_checked": "2026-06-22T14:57:29.067Z",
+    "last_checked": "2026-06-27T13:26:09.879Z",
     "race_id": "higashine-sakuranbo-marathon-2026"
   },
   "https://www.sakuranbo-m.jp/archives/2173/": {
     "hash": "aa765f38237b6086ebd7555c1def65589fb856cd17285d3250afb582bcf9a09f",
-    "last_checked": "2026-06-22T14:57:29.435Z",
+    "last_checked": "2026-06-27T13:26:10.299Z",
     "race_id": "higashine-sakuranbo-marathon-2026"
   },
   "https://www.sakuranbo-m.jp/qa/": {
     "hash": "8d23bfe85adfaeb122ceeb88c24f6d56dbb083986fc2764ac08d10cd4eabd38c",
-    "last_checked": "2026-06-22T14:57:29.839Z",
+    "last_checked": "2026-06-27T13:26:10.778Z",
     "race_id": "higashine-sakuranbo-marathon-2026"
   },
   "https://www.runningkanagawa.com/faq/": {
@@ -411,467 +411,467 @@
   },
   "https://www.himeji-marathon.jp/outline/index.html": {
     "hash": "f4265f62438cef80de0b6d9fd7d6db52669dcb138161eab099a69e239cd8f3c8",
-    "last_checked": "2026-06-22T14:57:30.693Z",
+    "last_checked": "2026-06-27T13:26:11.170Z",
     "race_id": "himeji-castle-marathon-2026"
   },
   "https://www.himeji-marathon.jp/course/index.html": {
     "hash": "99b79419961cc1b2ce864e8352c1cf43d0e386517caabdc69e701998ede72777",
-    "last_checked": "2026-06-22T14:57:30.710Z",
+    "last_checked": "2026-06-27T13:26:11.189Z",
     "race_id": "himeji-castle-marathon-2026"
   },
   "https://www.himeji-marathon.jp/access/index.html": {
     "hash": "20b518940c53f9845c33d60ddbcb5921785c0a4b3c0389d8e0a51224a4dbab91",
-    "last_checked": "2026-06-22T14:57:30.726Z",
+    "last_checked": "2026-06-27T13:26:11.207Z",
     "race_id": "himeji-castle-marathon-2026"
   },
   "https://www.himeji-marathon.jp/application/index.html": {
     "hash": "325abeb65e34f714433391b5013286ef730bb78e021ddef73ccd3036b3302be0",
-    "last_checked": "2026-06-22T14:57:30.744Z",
+    "last_checked": "2026-06-27T13:26:11.227Z",
     "race_id": "himeji-castle-marathon-2026"
   },
   "https://www.himeji-marathon.jp/participation/index.html": {
     "hash": "94472310f81f82d3051e646768bf4417949a75f5ed690c3fd54ffdc9a4c35e43",
-    "last_checked": "2026-06-22T14:57:30.762Z",
+    "last_checked": "2026-06-27T13:26:11.247Z",
     "race_id": "himeji-castle-marathon-2026"
   },
   "https://hitachi-marathon.jp/outline/": {
     "hash": "1774273bb3e5340439db1d09e4a6b7cc611aa8f8cf348872a347adae1d07c953",
-    "last_checked": "2026-06-22T14:57:30.940Z",
+    "last_checked": "2026-06-27T13:26:11.460Z",
     "race_id": "hitachi-seaside-marathon-2026"
   },
   "https://hitachi-marathon.jp/entry/": {
     "hash": "05abd320046072b14a51de9711b6b07c1f001d28e4457feb131770a5c188bbe1",
-    "last_checked": "2026-06-22T14:57:30.990Z",
+    "last_checked": "2026-06-27T13:26:11.517Z",
     "race_id": "hitachi-seaside-marathon-2026"
   },
   "https://hitachi-marathon.jp/2026/feature/": {
     "hash": "8ff0161771af9927f36ccfa125cd1ca5d27c54991e52bdea98ef52e303d7a418",
-    "last_checked": "2026-06-22T14:57:31.116Z",
+    "last_checked": "2026-06-27T13:26:11.658Z",
     "race_id": "hitachi-seaside-marathon-2026"
   },
   "https://hitachi-marathon.jp/2025/wp-content/uploads/2025/08/roadclosure2025.pdf": {
     "hash": "d6ddb860e55b36cf6d22086e51a9c87e2dc0aa7611109770a5866f8fabb00cc6",
-    "last_checked": "2026-06-22T14:57:31.182Z",
+    "last_checked": "2026-06-27T13:26:11.730Z",
     "race_id": "hitachi-seaside-marathon-2026"
   },
   "https://hofu-yomiuri.jp/outline/": {
-    "hash": "c1492d2b23dfd69ec0fccae04c803b895223199d9310f2c9ba4ec859b4877056",
-    "last_checked": "2026-06-22T14:57:32.034Z",
+    "hash": "a9fd67f396e15d2fc3bd562f42df1f854b3e79a3a0ad8b21acdadba3c19b295f",
+    "last_checked": "2026-06-27T13:26:12.466Z",
     "race_id": "hofu-yomiuri-marathon-2026"
   },
   "https://hofu-yomiuri.jp/course/": {
-    "hash": "9def01d05c4ec4fdba6d9accbb9f6a6b9a5099995c84217c5350c35824d8b64f",
-    "last_checked": "2026-06-22T14:57:32.061Z",
+    "hash": "e52d706e1aac18439d899797106514f31c36f7535598389a855e7d579d8a408a",
+    "last_checked": "2026-06-27T13:26:13.160Z",
     "race_id": "hofu-yomiuri-marathon-2026"
   },
   "https://hokkaido-marathon.com/overview/": {
-    "hash": "58290d2ad609c801af51d704c74d503a89c8e6be040f70d974680a406983c227",
-    "last_checked": "2026-06-22T14:57:32.178Z",
+    "hash": "9e6bb22185a99bbddaf2ac3068e85d2d59b4177b9a290a20291caf54919ce826",
+    "last_checked": "2026-06-27T13:26:13.274Z",
     "race_id": "hokkaido-marathon-2026"
   },
   "https://hokkaido-marathon.com/course/": {
     "hash": "0c99ad42132b50a2cfc70e2deb6033b1eb49443bd2effe8d3d59a5ea32ed586f",
-    "last_checked": "2026-06-22T14:57:32.871Z",
+    "last_checked": "2026-06-27T13:26:13.799Z",
     "race_id": "hokkaido-marathon-2026"
   },
   "https://hokkaido-marathon.com/entry/": {
     "hash": "cc73025bb4c9425cd4de7567421ccc4a82e0d2f9b436d46b386c45423cd9675b",
-    "last_checked": "2026-06-22T14:57:32.884Z",
+    "last_checked": "2026-06-27T13:26:14.343Z",
     "race_id": "hokkaido-marathon-2026"
   },
   "https://hokkaido-marathon.com/faq/": {
     "hash": "2c745e874dd3809547915a5106135ff7823a7835232fb3aad9ec161cd7d5b120",
-    "last_checked": "2026-06-22T14:57:32.902Z",
+    "last_checked": "2026-06-27T13:26:14.357Z",
     "race_id": "hokkaido-marathon-2026"
   },
   "https://hokkaido-marathon.com/info/12731/": {
     "hash": "aa1c2e790cff1338933860807048e969f4cf3262e9573ac04d474ebd4ceb4dbd",
-    "last_checked": "2026-06-22T14:57:33.549Z",
+    "last_checked": "2026-06-27T13:26:14.880Z",
     "race_id": "hokkaido-marathon-2026"
   },
   "https://ibusuki-nanohana.com/overview/": {
     "hash": "defba7ef1dcddcea85422b34d802e9a9a2732a6ff68c030763da8702e318eebf",
-    "last_checked": "2026-06-22T14:57:33.812Z",
+    "last_checked": "2026-06-27T13:26:15.429Z",
     "race_id": "ibusuki-nanohana-2026"
   },
   "https://ibusuki-nanohana.com/essentials/": {
     "hash": "b632a78b7efd51dc85cdfeee467a9bf2e7f2eef7189b4daf1a0782f48d3b284e",
-    "last_checked": "2026-06-22T14:57:33.935Z",
+    "last_checked": "2026-06-27T13:26:15.532Z",
     "race_id": "ibusuki-nanohana-2026"
   },
   "https://ibusuki-nanohana.com/question/": {
     "hash": "e954c4299a0b8aba04e5791e97f974807c62180d3754a188aacad21b16180c35",
-    "last_checked": "2026-06-22T14:57:34.041Z",
+    "last_checked": "2026-06-27T13:26:15.640Z",
     "race_id": "ibusuki-nanohana-2026"
   },
   "https://ibusuki-nanohana.com/course/": {
     "hash": "cd7318f060acdafb86ec761bc6a9c66e9f9b7448fe10aaade6c73324933d9d2d",
-    "last_checked": "2026-06-22T14:57:34.154Z",
+    "last_checked": "2026-06-27T13:26:15.748Z",
     "race_id": "ibusuki-nanohana-2026"
   },
   "https://ibusuki-nanohana.com/entry/": {
     "hash": "82dc3f79aeac37e1ea01ca71faa9a7d93725f3729bb45a82f46c048b332e5968",
-    "last_checked": "2026-06-22T14:57:34.251Z",
+    "last_checked": "2026-06-27T13:26:15.849Z",
     "race_id": "ibusuki-nanohana-2026"
   },
   "https://ichinoseki-half.jp/outline/": {
     "hash": "49e77c91c32552db83c8133a90b677287ad8b89e689eb631462c1aac1a731b1b",
-    "last_checked": "2026-06-22T14:57:34.387Z",
+    "last_checked": "2026-06-27T13:26:15.994Z",
     "race_id": "ichinoseki-half-marathon-2026"
   },
   "https://ichinoseki-half.jp/entry/": {
     "hash": "ab36f06c5e0842074308760f27038b5fa2d5e0893a1752a8f344a3fd84882891",
-    "last_checked": "2026-06-22T14:57:34.439Z",
+    "last_checked": "2026-06-27T13:26:16.043Z",
     "race_id": "ichinoseki-half-marathon-2026"
   },
   "https://ichinoseki-half.jp/course/": {
     "hash": "65211a2ce1e80346d8c7e9c1f0bab51a81c20e872d64f92ba2e4f37d2b0efdb8",
-    "last_checked": "2026-06-22T14:57:34.490Z",
+    "last_checked": "2026-06-27T13:26:16.091Z",
     "race_id": "ichinoseki-half-marathon-2026"
   },
   "https://iki-ultra.jp/about/": {
     "hash": "b2c74817edce1aafa651d2562121a5e6a70cdc9d1a897ac217d4839566f06782",
-    "last_checked": "2026-06-22T14:57:35.203Z",
+    "last_checked": "2026-06-27T13:26:16.617Z",
     "race_id": "iki-ultra-marathon-2026"
   },
   "https://iki-ultra.jp/qa/": {
     "hash": "2b639f644ee41e39d2ae352745dace53b49fe6887554d9d1eb0b3e320ccd0bf9",
-    "last_checked": "2026-06-22T14:57:35.291Z",
+    "last_checked": "2026-06-27T13:26:16.702Z",
     "race_id": "iki-ultra-marathon-2026"
   },
   "https://iki-ultra.jp/entry/": {
     "hash": "528ad6b5a6df859619219e0bdbe26b628cfa45bcd1e3944a6fedc2bfece96d50",
-    "last_checked": "2026-06-22T14:57:35.389Z",
+    "last_checked": "2026-06-27T13:26:16.795Z",
     "race_id": "iki-ultra-marathon-2026"
   },
   "https://iki-ultra.jp/course/": {
     "hash": "bba52a6c44494bbabcb87f774aa243042812eb0271606aff4a6f6b6c48bd695d",
-    "last_checked": "2026-06-22T14:57:35.514Z",
+    "last_checked": "2026-06-27T13:26:16.880Z",
     "race_id": "iki-ultra-marathon-2026"
   },
   "https://iki-ultra.jp/access/": {
     "hash": "3300e81c396f040ce77ab7c11468354185d2cabdca60655fd610dbe266620838",
-    "last_checked": "2026-06-22T14:57:35.592Z",
+    "last_checked": "2026-06-27T13:26:16.963Z",
     "race_id": "iki-ultra-marathon-2026"
   },
   "https://i-c-m.jp/guideline/": {
     "hash": "216ae96c96b6540073978c91ba78a343159573c4c97e195ab372e8beafd0bdcd",
-    "last_checked": "2026-06-22T14:57:35.744Z",
+    "last_checked": "2026-06-27T13:26:17.123Z",
     "race_id": "itabashi-city-marathon-2026"
   },
   "https://i-c-m.jp/entry/": {
     "hash": "9b5219e7e4bca0d0785847567d832f069a7df4211556cf4a4e6b578a4560a559",
-    "last_checked": "2026-06-22T14:57:35.794Z",
+    "last_checked": "2026-06-27T13:26:17.175Z",
     "race_id": "itabashi-city-marathon-2026"
   },
   "https://i-c-m.jp/access/": {
     "hash": "bb525451e3829df4092f24b46bc09ce8ddd55ef02e22176e7b91a660ea47ee66",
-    "last_checked": "2026-06-22T14:57:35.841Z",
+    "last_checked": "2026-06-27T13:26:17.248Z",
     "race_id": "itabashi-city-marathon-2026"
   },
   "https://i-c-m.jp/faq/": {
     "hash": "b0c5af3dd2a08b7240ef527fd7dab2590a5a6c6ed9f08282bf66240e2a71d812",
-    "last_checked": "2026-06-22T14:57:35.892Z",
+    "last_checked": "2026-06-27T13:26:17.300Z",
     "race_id": "itabashi-city-marathon-2026"
   },
   "https://iwaki-marathon.jp/outline/": {
     "hash": "18e79a78ee171d713500f23811869b7760dcb5b0dd083e124ec1dc6c88c7f218",
-    "last_checked": "2026-06-22T14:57:36.938Z",
-    "race_id": "iwaki-sunshine-marathon-2026"
+    "last_checked": "2026-06-27T13:26:20.490Z",
+    "race_id": "iwaki-sunshine-marathon-2027"
   },
   "https://iwaki-marathon.jp/course/": {
     "hash": "74571ab36caec5ed993ea910d1a29113e8bf6375125cab6ba6aed238cfd21ef0",
-    "last_checked": "2026-06-22T14:57:37.879Z",
-    "race_id": "iwaki-sunshine-marathon-2026"
+    "last_checked": "2026-06-27T13:26:20.980Z",
+    "race_id": "iwaki-sunshine-marathon-2027"
   },
   "https://iwaki-marathon.jp/outline/schedule/": {
     "hash": "d3b258947aee57930472f563ae60a9cd1ce31834e47f33223102e1eac4a10bd9",
-    "last_checked": "2026-06-22T14:57:38.884Z",
-    "race_id": "iwaki-sunshine-marathon-2026"
+    "last_checked": "2026-06-27T13:26:21.472Z",
+    "race_id": "iwaki-sunshine-marathon-2027"
   },
   "https://iwaki-marathon.jp/entry/": {
     "hash": "d32b560cb185b69b42b94530945b7ccfcbceb6d456eb684f15f314fa6cd334ed",
-    "last_checked": "2026-06-22T14:57:39.837Z",
-    "race_id": "iwaki-sunshine-marathon-2026"
+    "last_checked": "2026-06-27T13:26:21.940Z",
+    "race_id": "iwaki-sunshine-marathon-2027"
   },
   "https://iwaki-marathon.jp/access/": {
     "hash": "a5b21e2ada44765b4c5c128442f6dc70981c315207c2fe3b48718eb1b9b4b2a4",
-    "last_checked": "2026-06-22T14:57:40.830Z",
-    "race_id": "iwaki-sunshine-marathon-2026"
+    "last_checked": "2026-06-27T13:26:22.467Z",
+    "race_id": "iwaki-sunshine-marathon-2027"
   },
   "https://iwate-morioka-city-marathon.jp/outline/": {
     "hash": "1cb9994f7f2657f88202f4e3891a59674b9d4029bcee4c3fad89793df8e7bbd4",
-    "last_checked": "2026-06-22T14:57:41.051Z",
+    "last_checked": "2026-06-27T13:26:22.641Z",
     "race_id": "iwate-morioka-city-marathon-2026"
   },
   "https://iwate-morioka-city-marathon.jp/concept/": {
     "hash": "4621455739c8b5260ed2fab66df4b171ec073fd0c77428a4cf986737f9272048",
-    "last_checked": "2026-06-22T14:57:41.110Z",
+    "last_checked": "2026-06-27T13:26:22.700Z",
     "race_id": "iwate-morioka-city-marathon-2026"
   },
   "https://iwate-morioka-city-marathon.jp/entry/": {
     "hash": "4ad822ef8dbb71e49fc7b8f37999ffa82c771d758fe083c36f220739e7f61df9",
-    "last_checked": "2026-06-22T14:57:41.175Z",
+    "last_checked": "2026-06-27T13:26:22.766Z",
     "race_id": "iwate-morioka-city-marathon-2026"
   },
   "https://iwate-morioka-city-marathon.jp/course/": {
     "hash": "968159ae9b3f215574a958e1bd2deba55abfd6a6d4404ed0b8066ae592bbcb2a",
-    "last_checked": "2026-06-22T14:57:41.231Z",
+    "last_checked": "2026-06-27T13:26:22.822Z",
     "race_id": "iwate-morioka-city-marathon-2026"
   },
   "https://iwate-morioka-city-marathon.jp/faq_reception/": {
     "hash": "5ed100f83ef40ac924012183f75847f81d28c61aab854ebedd96e568fe09c4b4",
-    "last_checked": "2026-06-22T14:57:41.304Z",
+    "last_checked": "2026-06-27T13:26:22.885Z",
     "race_id": "iwate-morioka-city-marathon-2026"
   },
   "https://oshukirameki.jp/outline/": {
     "hash": "8debce1fe793af8a48186a926514b618a5caa11a179a2516b4b85157492fb8b7",
-    "last_checked": "2026-06-22T14:57:41.603Z",
+    "last_checked": "2026-06-27T13:26:23.179Z",
     "race_id": "iwate-oshu-kirameki-marathon-2026"
   },
   "https://oshukirameki.jp/entry/": {
     "hash": "a1fce03205b6d3ee10c3479fb64c69a4555667e5ff7b8a15231b8d3224e43b4c",
-    "last_checked": "2026-06-22T14:57:41.853Z",
+    "last_checked": "2026-06-27T13:26:23.417Z",
     "race_id": "iwate-oshu-kirameki-marathon-2026"
   },
   "https://oshukirameki.jp/info/": {
     "hash": "1c2479fd83116ec2ce2e3300e96f548ca9ebac68ad18583da7f01fcd61ceb0ba",
-    "last_checked": "2026-06-22T14:57:42.046Z",
+    "last_checked": "2026-06-27T13:26:23.616Z",
     "race_id": "iwate-oshu-kirameki-marathon-2026"
   },
   "https://oshukirameki.jp/course/": {
     "hash": "5f44be2e5330715d2054b3195db180c2ed595e52988a1af8daa106bafb596542",
-    "last_checked": "2026-06-22T14:57:42.208Z",
+    "last_checked": "2026-06-27T13:26:23.790Z",
     "race_id": "iwate-oshu-kirameki-marathon-2026"
   },
   "https://kagawa-marathon.com/faq/": {
-    "hash": "32d35c836557a971f3624d7782a70b92a159763ff0f5baa34fdab9eb3a32b4c4",
-    "last_checked": "2026-06-22T14:57:43.766Z",
+    "hash": "f39ab4e57f0ebbea62abae5e43c2a4c274179ec8e97df2aafc654b55f9d64ea0",
+    "last_checked": "2026-06-27T13:26:25.795Z",
     "race_id": "kagawa-marathon-2026"
   },
   "https://kagawa-marathon.com/information/essentials/": {
-    "hash": "2f9c04002f6cb0320613db5cfa0afbcdb481f8778c6bf797073decc821d1ab9d",
-    "last_checked": "2026-06-22T14:57:43.818Z",
+    "hash": "fe89dad45878a9da18af61148f79b119677d2dde2f0e9b266afdf9fd663359fb",
+    "last_checked": "2026-06-27T13:26:25.836Z",
     "race_id": "kagawa-marathon-2026"
   },
   "https://kagawa-marathon.com/information/access/": {
-    "hash": "158f17ad86cc0d588844719cbbb3fdd3940a02106b40319c4d7153ed4dfd618d",
-    "last_checked": "2026-06-22T14:57:43.865Z",
+    "hash": "16439a737c4ba7fb947e37f15d0745e4f29623c5edf459412998f881a7ba184d",
+    "last_checked": "2026-06-27T13:26:25.883Z",
     "race_id": "kagawa-marathon-2026"
   },
   "https://kagawa-marathon.com/information/course/": {
-    "hash": "a1511435390f5bbbf1aed2aa00a252cf5d43a517ed23056825509f6c0bc56813",
-    "last_checked": "2026-06-22T14:57:43.902Z",
+    "hash": "69ebef003d7c634caaa4653cf4064c5e19ca52acc2e874f6991f60c2ac46fd87",
+    "last_checked": "2026-06-27T13:26:25.925Z",
     "race_id": "kagawa-marathon-2026"
   },
   "https://kagawa-marathon.com/information/concept/": {
-    "hash": "fb0e511b2676814f53d5df988545636805110e882501e0faa282a37504d342ea",
-    "last_checked": "2026-06-22T14:57:43.975Z",
+    "hash": "284bbd5ec3bfc03cdf08e2b2f286de7133afdd0c677c5ae2d46325ccb60abc1e",
+    "last_checked": "2026-06-27T13:26:25.965Z",
     "race_id": "kagawa-marathon-2026"
   },
   "https://www.kagoshima-marathon.jp/about/": {
     "hash": "56f3fd660bc2d83dd14f2a9d051828280f0402bba0960022ceb79c5d3fc244e0",
-    "last_checked": "2026-06-22T14:57:44.105Z",
+    "last_checked": "2026-06-27T13:26:26.209Z",
     "race_id": "kagoshima-marathon-2026"
   },
   "https://www.kagoshima-marathon.jp/about/course/course-guidelines.html": {
     "hash": "3a4572c2ce99351475d03aaf5719d6f583d599a404e2a97a99394edbe6c4131c",
-    "last_checked": "2026-06-22T14:57:44.144Z",
+    "last_checked": "2026-06-27T13:26:26.252Z",
     "race_id": "kagoshima-marathon-2026"
   },
   "https://www.kagoshima-marathon.jp/entry/": {
     "hash": "0b6b63ee0e7f3bd3b42720f70f6b2b8720b46ea6ff8ba1079009579da3601333",
-    "last_checked": "2026-06-22T14:57:44.157Z",
+    "last_checked": "2026-06-27T13:26:26.266Z",
     "race_id": "kagoshima-marathon-2026"
   },
   "https://www.kagoshima-marathon.jp/traffic/index-mk.html": {
     "hash": "edc904b9af6099ad7cd335baa4fed449d43ce73b5bb240aff0a3820240d1387b",
-    "last_checked": "2026-06-22T14:57:44.169Z",
+    "last_checked": "2026-06-27T13:26:26.281Z",
     "race_id": "kagoshima-marathon-2026"
   },
   "https://www.kagoshima-marathon.jp/faq/": {
     "hash": "b6961a98180e0b6afe34fabc1d65550c9aac95d17f4d00d6ff9116dbfca5d730",
-    "last_checked": "2026-06-22T14:57:44.220Z",
+    "last_checked": "2026-06-27T13:26:26.297Z",
     "race_id": "kagoshima-marathon-2026"
   },
   "https://kaikyomarathon.jp/outline/": {
     "hash": "e5fd3c2b788a85e0d5da3e437c7531a8a60c5933ba68f822bf90d2dd02525852",
-    "last_checked": "2026-06-22T14:57:44.309Z",
+    "last_checked": "2026-06-27T13:26:27.194Z",
     "race_id": "kaikyo-marathon-2026"
   },
   "https://kaikyomarathon.jp/entry/": {
     "hash": "e90328d9a97947bfd6af49871cd5c5f7c500939acb022dd35f72e11ad3e36fbc",
-    "last_checked": "2026-06-22T14:57:44.321Z",
+    "last_checked": "2026-06-27T13:26:27.215Z",
     "race_id": "kaikyo-marathon-2026"
   },
   "https://kaikyomarathon.jp/course/": {
     "hash": "2ded800f3383e5f19a8b0911b3ddf50d29d8ca8d637a001682880a68d237058d",
-    "last_checked": "2026-06-22T14:57:44.334Z",
+    "last_checked": "2026-06-27T13:26:27.245Z",
     "race_id": "kaikyo-marathon-2026"
   },
   "https://kaikyomarathon.jp/access/": {
     "hash": "46ce85a8af0f0397cf02b8b4bbc33f320b2b5024db430d5d54701bac65858f26",
-    "last_checked": "2026-06-22T14:57:45.165Z",
+    "last_checked": "2026-06-27T13:26:28.105Z",
     "race_id": "kaikyo-marathon-2026"
   },
   "https://kaikyomarathon.jp/qa/": {
     "hash": "3d2245dcce554aa1752f4ec1ea0736b6b5b63b3b0250c775b212f08458e78fbb",
-    "last_checked": "2026-06-22T14:57:45.178Z",
+    "last_checked": "2026-06-27T13:26:28.960Z",
     "race_id": "kaikyo-marathon-2026"
   },
   "https://www.kanazawa-marathon.jp/outline/index.html?": {
     "hash": "f5dc074da74a2bd12fff700d9fb2f12352727c5f6aa70da28ffec178dc4d2304",
-    "last_checked": "2026-06-22T14:57:45.378Z",
+    "last_checked": "2026-06-27T13:26:29.165Z",
     "race_id": "kanazawa-marathon-2026"
   },
   "https://www.kanazawa-marathon.jp/course/index.html?": {
     "hash": "dabb288991ad21d39e878c8227e134db008fc273d2c9065be1991b54788a0103",
-    "last_checked": "2026-06-22T14:57:45.500Z",
+    "last_checked": "2026-06-27T13:26:29.289Z",
     "race_id": "kanazawa-marathon-2026"
   },
   "https://www.kanazawa-marathon.jp/point/index.html?": {
     "hash": "11bb369cc76a17d1933351cedebb561179acd1f50aeaf5a889d2aca069fc850e",
-    "last_checked": "2026-06-22T14:57:45.518Z",
+    "last_checked": "2026-06-27T13:26:29.307Z",
     "race_id": "kanazawa-marathon-2026"
   },
   "https://www.kanazawa-marathon.jp/entry/index.html?": {
     "hash": "56037b0c226dfaf4c848b79e6697ace2caf00eec75dea2bb9e95c1b51e74d5a3",
-    "last_checked": "2026-06-22T14:57:45.550Z",
+    "last_checked": "2026-06-27T13:26:29.342Z",
     "race_id": "kanazawa-marathon-2026"
   },
   "https://www.kanazawa-marathon.jp/qanda/index.html?": {
     "hash": "30aae79b340cd527232a09b090b65fb6367e59626d691999e8726eb1c36bda14",
-    "last_checked": "2026-06-22T14:57:45.602Z",
+    "last_checked": "2026-06-27T13:26:29.394Z",
     "race_id": "kanazawa-marathon-2026"
   },
   "https://www.kasa-mara.jp/outline/": {
     "hash": "fb1817a2b2fca702440b155028e0682a8a321d1693484c220457712697b3a9cf",
-    "last_checked": "2026-06-22T14:57:46.899Z",
+    "last_checked": "2026-06-27T13:26:29.559Z",
     "race_id": "kasama-togeinosato-half-2025-2025"
   },
   "https://www.kasa-mara.jp/entry/": {
     "hash": "66897f1ac5277fc3eae15d0581854fbc6390e9507f9c306ff3dddd62f20768a9",
-    "last_checked": "2026-06-22T14:57:46.990Z",
+    "last_checked": "2026-06-27T13:26:29.655Z",
     "race_id": "kasama-togeinosato-half-2025-2025"
   },
   "https://www.kasa-mara.jp/course/": {
     "hash": "485d60868eb012cd0ada5c378a8276da552b3f9393955894166cd7ab6a995a47",
-    "last_checked": "2026-06-22T14:57:47.086Z",
+    "last_checked": "2026-06-27T13:26:29.763Z",
     "race_id": "kasama-togeinosato-half-2025-2025"
   },
   "https://www.kasumigaura-marathon.jp/outline/": {
     "hash": "1f479d4161c530310c7d01bbb1acf2c3f147bd55a981523d0d022c167cff6131",
-    "last_checked": "2026-06-22T14:57:47.680Z",
+    "last_checked": "2026-06-27T13:26:30.347Z",
     "race_id": "kasumigaura-marathon-2026"
   },
   "https://www.kasumigaura-marathon.jp/access/": {
     "hash": "7a73df84d4d25b3c4b078ab10ed11145d094f883f3432cd4017840bc4aed10d8",
-    "last_checked": "2026-06-22T14:57:48.223Z",
+    "last_checked": "2026-06-27T13:26:30.910Z",
     "race_id": "kasumigaura-marathon-2026"
   },
   "https://www.kasumigaura-marathon.jp/course/": {
     "hash": "7a26d8bc432157870a2937a404adfc7b8863bd21094a6612f563bab8344320c8",
-    "last_checked": "2026-06-22T14:57:48.804Z",
+    "last_checked": "2026-06-27T13:26:31.448Z",
     "race_id": "kasumigaura-marathon-2026"
   },
   "https://www.kasumigaura-marathon.jp/entry/": {
     "hash": "3bb27b7b801b5bec3469eddaf3b210124709ce0abe15a8afa7a04d3f7357d6a2",
-    "last_checked": "2026-06-22T14:57:49.374Z",
+    "last_checked": "2026-06-27T13:26:32.292Z",
     "race_id": "kasumigaura-marathon-2026"
   },
   "https://www.kasumigaura-marathon.jp/faq/": {
     "hash": "ed80ca675ad7db58513e7aa64ab4e0479ad120a43615b2296e903f45c71ff0ab",
-    "last_checked": "2026-06-22T14:57:49.901Z",
+    "last_checked": "2026-06-27T13:26:33.168Z",
     "race_id": "kasumigaura-marathon-2026"
   },
   "https://katsutamarathon.jp/info/abbott/": {
     "hash": "0099aa7f010f9c4a7d3165c4de590e8b81da9b90369bb73aff492635c949dc50",
-    "last_checked": "2026-06-22T14:57:50.552Z",
+    "last_checked": "2026-06-27T13:26:33.233Z",
     "race_id": "katsuta-marathon-2026"
   },
   "https://katsutamarathon.jp/outline/": {
     "hash": "9af275615d3cfb49b64c74489a082aabb3574d7893fea486e247fe80bc8a3232",
-    "last_checked": "2026-06-22T14:57:50.568Z",
+    "last_checked": "2026-06-27T13:26:33.245Z",
     "race_id": "katsuta-marathon-2026"
   },
   "https://katsutamarathon.jp/entry/": {
     "hash": "81506c2122b5699287da98f29d042bff8b81d1502a721ebada63e6ce62114128",
-    "last_checked": "2026-06-22T14:57:50.798Z",
+    "last_checked": "2026-06-27T13:26:34.089Z",
     "race_id": "katsuta-marathon-2026"
   },
   "https://katsutamarathon.jp/course/": {
     "hash": "b6cf1944daaab596a5e80ca87718050b1cd6e003bd7df9dc77f1d2d28dbbc59f",
-    "last_checked": "2026-06-22T14:57:51.459Z",
+    "last_checked": "2026-06-27T13:26:34.101Z",
     "race_id": "katsuta-marathon-2026"
   },
   "https://kitakyushu-marathon.jp/about/": {
     "hash": "b4e70364017579c4a0f5c6f4ab6ddc41133f247a5c9557f9750f72e01e3f1f17",
-    "last_checked": "2026-06-22T14:57:51.984Z",
+    "last_checked": "2026-06-27T13:26:34.154Z",
     "race_id": "kitakyushu-marathon-2026"
   },
   "https://kitakyushu-marathon.jp/course/": {
     "hash": "013c36cae722db2701a1214d67ce9be05b36bac710dc9211b55492ce3caaee3b",
-    "last_checked": "2026-06-22T14:57:52.814Z",
+    "last_checked": "2026-06-27T13:26:34.166Z",
     "race_id": "kitakyushu-marathon-2026"
   },
   "https://kitakyushu-marathon.jp/step/": {
     "hash": "71577bf4364bcb9a613e420eb6f1423c48c08046710b54b5ee7604c9fc1cd148",
-    "last_checked": "2026-06-22T14:57:53.344Z",
+    "last_checked": "2026-06-27T13:26:34.849Z",
     "race_id": "kitakyushu-marathon-2026"
   },
   "https://kitakyushu-marathon.jp/access/": {
     "hash": "03b74889f2b98ab2a04db648e2b1458e87c754264adad2423a4218ea34039807",
-    "last_checked": "2026-06-22T14:57:54.022Z",
+    "last_checked": "2026-06-27T13:26:35.497Z",
     "race_id": "kitakyushu-marathon-2026"
   },
   "https://kitakyushu-marathon.jp/qa/": {
     "hash": "9acca89a0c670920f964f68cc39c675c96f270986708f87c9ed99b3d6ef79cf6",
-    "last_checked": "2026-06-22T14:57:54.885Z",
+    "last_checked": "2026-06-27T13:26:36.455Z",
     "race_id": "kitakyushu-marathon-2026"
   },
   "http://www.senshu-marathon.jp/guidance/": {
     "hash": "5c0ac11e9602730c077fb11fd708e1e7fb499db74540e30990c529e55c98e0d0",
-    "last_checked": "2026-06-22T14:57:56.327Z",
+    "last_checked": "2026-06-27T13:26:36.878Z",
     "race_id": "kix-senshu-marathon-2026"
   },
   "http://www.senshu-marathon.jp/course/": {
     "hash": "953caa09fdead77e470b1f425b4f0f8deba73defbc34d5067b090fd2375cf53e",
-    "last_checked": "2026-06-22T14:57:56.654Z",
+    "last_checked": "2026-06-27T13:26:37.203Z",
     "race_id": "kix-senshu-marathon-2026"
   },
   "http://www.senshu-marathon.jp/access/": {
     "hash": "6f49540972eb159c0f03d6bdf1675229540632609030c81d37a24908eec04f12",
-    "last_checked": "2026-06-22T14:57:56.974Z",
+    "last_checked": "2026-06-27T13:26:37.547Z",
     "race_id": "kix-senshu-marathon-2026"
   },
   "http://www.senshu-marathon.jp/entry/": {
     "hash": "98c45e422ce4f851cf88540ddc8bdc21a9c8d2e093f00a692d83b18d59936d43",
-    "last_checked": "2026-06-22T14:57:57.296Z",
+    "last_checked": "2026-06-27T13:26:37.871Z",
     "race_id": "kix-senshu-marathon-2026"
   },
   "https://www.kobe-marathon.net/2026/faq/": {
-    "hash": "3e1d5edb5f09138223e9c58d62b4d050c62fc6f712a3bcef6c32759b132369b3",
-    "last_checked": "2026-06-22T14:57:57.400Z",
+    "hash": "27558d14ca5946f34b07db87d68bf8daa331527ce9f276abe7a85e7ff51076b2",
+    "last_checked": "2026-06-27T13:26:38.002Z",
     "race_id": "kobe-marathon-2026"
   },
   "https://www.kobe-marathon.net/2026/race/essentials/": {
-    "hash": "2e0f3310b9fdd4e92fadad80c40822dd0d038c5fd1872adb123742d7b8dbcc7d",
-    "last_checked": "2026-06-22T14:57:57.463Z",
+    "hash": "0d819c2e2a61739f5a541e43f9a8b6e892a6fe306c6dc383d462f5a921a10b61",
+    "last_checked": "2026-06-27T13:26:38.059Z",
     "race_id": "kobe-marathon-2026"
   },
   "https://www.kobe-marathon.net/2026/runner/entry/": {
-    "hash": "b705b799bde5f28368dd9d7dc287e396340109f8ce05eeaf1c4859c1de732342",
-    "last_checked": "2026-06-22T14:57:57.474Z",
+    "hash": "9c195202a5ce7df7dfe3c8d03cc2b726f9a48e8a2673844a7ca8ab92c21f7939",
+    "last_checked": "2026-06-27T13:26:38.069Z",
     "race_id": "kobe-marathon-2026"
   },
   "https://www.kobe-marathon.net/2026/runner/course/": {
-    "hash": "145de3b2b573e55f4ec9b23a2dbd63f6c8a6f526d59e2dc8738c41063865c27f",
-    "last_checked": "2026-06-22T14:57:57.484Z",
+    "hash": "d12dd4359a0f9ca1ef3f57c13ad65c8be04d9acc966ab2a3ac989e3bc10b47b9",
+    "last_checked": "2026-06-27T13:26:38.078Z",
     "race_id": "kobe-marathon-2026"
   },
   "https://www.kobe-marathon.net/2026/support/expo/expoinfo/": {
-    "hash": "926c51d4e42cf7b2abae865c537b2fc06007617c05bc5b8db9aab5f9bfdc3b6a",
-    "last_checked": "2026-06-22T14:57:57.492Z",
+    "hash": "d909f664628c2bcca1e68fbc3a70ffb325c5e530060d3dbb5b57d5cb378579cc",
+    "last_checked": "2026-06-27T13:26:38.089Z",
     "race_id": "kobe-marathon-2026"
   },
   "https://ryoma-marathon.jp/outline/": {
@@ -901,38 +901,38 @@
   },
   "https://kumamotojyo-marathon.jp/outline.php": {
     "hash": "acb7d4a238df284eee725b04c725be725cdf059180781cfa40426094b44cab44",
-    "last_checked": "2026-06-22T14:57:58.108Z",
+    "last_checked": "2026-06-27T13:26:38.643Z",
     "race_id": "kumamoto-castle-marathon-2026"
   },
   "https://kumamotojyo-marathon.jp/course.php": {
     "hash": "4ef74d49c904af43be3e9fcab5131f8e3a0ab430f0c430640a15b7e49f6ddfd0",
-    "last_checked": "2026-06-22T14:57:58.178Z",
+    "last_checked": "2026-06-27T13:26:38.716Z",
     "race_id": "kumamoto-castle-marathon-2026"
   },
   "https://kumamotojyo-marathon.jp/entry.php": {
     "hash": "b32650e2835ef9192b6a4816d992a770c30289cd4800a342b45c32c4423e62b5",
-    "last_checked": "2026-06-22T14:57:58.271Z",
+    "last_checked": "2026-06-27T13:26:38.807Z",
     "race_id": "kumamoto-castle-marathon-2026"
   },
   "https://kumamotojyo-marathon.jp/volunteer.php": {
     "hash": "0c14a2f9ee4ca22d9ff432b0547582fc93317189cf1fd53500f45b3329b5adce",
-    "last_checked": "2026-06-22T14:57:58.342Z",
+    "last_checked": "2026-06-27T13:26:38.882Z",
     "race_id": "kumamoto-castle-marathon-2026"
   },
   "https://kumamotojyo-marathon.jp/traffic.php": {
     "hash": "053dd1c0feb6c15482bdaddc8dc41938a6724a4f0c9750f3b8efe8122c5c7772",
-    "last_checked": "2026-06-22T14:57:58.415Z",
+    "last_checked": "2026-06-27T13:26:38.953Z",
     "race_id": "kumamoto-castle-marathon-2026"
   },
   "https://kyoto-marathon.com/info/": {
     "hash": "17a13250a81d642b26024fd5585df6106871e4cb84123bf0aeaf7973d3f21ac6",
-    "last_checked": "2026-06-22T14:57:58.473Z",
-    "race_id": "kyoto-marathon-2026"
+    "last_checked": "2026-06-27T13:26:39.410Z",
+    "race_id": "kyoto-marathon-2027"
   },
   "https://kyoto-marathon.com/info/course/": {
     "hash": "765d7eb1af1f108e82cab4811552fbfe21a0766ecb2e701e1c0f9467e2c32c41",
-    "last_checked": "2026-06-22T14:57:58.485Z",
-    "race_id": "kyoto-marathon-2026"
+    "last_checked": "2026-06-27T13:26:39.422Z",
+    "race_id": "kyoto-marathon-2027"
   },
   "https://kyoto-marathon.com/info/concept/": {
     "hash": "bc76a1067c3a5c16c6d6eebc4fa2006f776c44b0fdacd20ade297e2c3132ac14",
@@ -946,857 +946,857 @@
   },
   "https://kyoto-marathon.com/faq/": {
     "hash": "6325f473c395730406befaa5aad6a3ab9f00d2ccacff82e0b6ffb83e77ac29c8",
-    "last_checked": "2026-06-22T14:57:59.062Z",
-    "race_id": "kyoto-marathon-2026"
+    "last_checked": "2026-06-27T13:26:39.928Z",
+    "race_id": "kyoto-marathon-2027"
   },
   "https://mie-matsusaka-marathon.jp/essential/": {
-    "hash": "505448755acce7142719ea79311ad69cbd0630e6259b687070ed091e8cea0bc3",
-    "last_checked": "2026-06-22T14:57:59.404Z",
+    "hash": "e6332ecbf2198c385555ed576fefe7f58904a74d59748adcd06b725848dc2a69",
+    "last_checked": "2026-06-27T13:26:40.422Z",
     "race_id": "mie-matsusaka-marathon-2026"
   },
   "https://mie-matsusaka-marathon.jp/course/": {
-    "hash": "9ae63da69c6d0d22e4663fc5f949d63b08c21e34d6a1909f91d269850754746d",
-    "last_checked": "2026-06-22T14:57:59.710Z",
+    "hash": "2777015b363243b24511375a37b2a5fb8216b0c60b88e4a0aff2ac5eeac6bbb3",
+    "last_checked": "2026-06-27T13:26:40.909Z",
     "race_id": "mie-matsusaka-marathon-2026"
   },
   "https://mie-matsusaka-marathon.jp/charm/": {
-    "hash": "42818dfe3a520ccc74a230566309462e7fc1c35a3846a40ddb96ec937049df64",
-    "last_checked": "2026-06-22T14:57:59.953Z",
+    "hash": "a43b1e077f0ae237ea3d3bac4f1482116afbae9d556ed277a5e93e33051eb886",
+    "last_checked": "2026-06-27T13:26:41.249Z",
     "race_id": "mie-matsusaka-marathon-2026"
   },
   "https://mie-matsusaka-marathon.jp/venue/": {
-    "hash": "bf7d86a3f439490e21be29ec4bb0e66eb46f2ac3bf46b8188d2ecab5c5b6573d",
-    "last_checked": "2026-06-22T14:58:00.167Z",
+    "hash": "4d3ba6f412c01beb3186741e33e345e2323396ba8520bc58b8417a658db0eecd",
+    "last_checked": "2026-06-27T13:26:41.731Z",
     "race_id": "mie-matsusaka-marathon-2026"
   },
   "https://mie-matsusaka-marathon.jp/runner/": {
-    "hash": "f647686c94a3ddb81cceac546522d48edccead7ab899ab04d0cd617804bb5e10",
-    "last_checked": "2026-06-22T14:58:00.377Z",
+    "hash": "09f617d26ca9c561140d33cba0511d41ece2a077560bb7dc44a257313c81131e",
+    "last_checked": "2026-06-27T13:26:42.137Z",
     "race_id": "mie-matsusaka-marathon-2026"
   },
   "https://www.mitokomon-manyu-marathon.com/about/index.html": {
     "hash": "cee45bd71cece69201b1508be394256cc60de7716b9f174ff44be7683c6040d7",
-    "last_checked": "2026-06-22T14:58:00.501Z",
+    "last_checked": "2026-06-27T13:26:42.419Z",
     "race_id": "mito-komon-manyu-marathon-2026"
   },
   "https://www.mitokomon-manyu-marathon.com/entry/index.html": {
-    "hash": "7b84edd1a2adfd9cbe54dad746928d4d56836b34d1c185daac24f49d0ae377e0",
-    "last_checked": "2026-06-22T14:58:00.531Z",
+    "hash": "c251a307beadb1dfb05c046f6ff6562023776d89784e1c5ddce9a4496d79cfe8",
+    "last_checked": "2026-06-27T13:26:42.452Z",
     "race_id": "mito-komon-manyu-marathon-2026"
   },
   "https://www.mitokomon-manyu-marathon.com/venue/index.html": {
     "hash": "0e2edb3d9edefa4b59f2a44dd1ee8b3760c5e72482251f19ec9a28af6842b2c0",
-    "last_checked": "2026-06-22T14:58:00.560Z",
+    "last_checked": "2026-06-27T13:26:42.487Z",
     "race_id": "mito-komon-manyu-marathon-2026"
   },
   "https://www.mitokomon-manyu-marathon.com/venue/supply.html": {
     "hash": "b8dc88004de15a58e3e3be2eaf6b3505df5fa32ab4184bc3a5d7d80d9f1825db",
-    "last_checked": "2026-06-22T14:58:00.588Z",
+    "last_checked": "2026-06-27T13:26:42.520Z",
     "race_id": "mito-komon-manyu-marathon-2026"
   },
   "https://www.mitokomon-manyu-marathon.com/qa/index.html": {
     "hash": "295b5d635687ac1f01dd4f452b70e85b441bc3fe85124984192d00f2bca13819",
-    "last_checked": "2026-06-22T14:58:00.618Z",
+    "last_checked": "2026-06-27T13:26:42.554Z",
     "race_id": "mito-komon-manyu-marathon-2026"
   },
   "https://mtfujiclimbrun.com/outline/": {
     "hash": "9c94cce401b77d366a24aab247386bf1cff010d365878f310bb6ac2dfcf97c36",
-    "last_checked": "2026-06-22T14:58:00.756Z",
+    "last_checked": "2026-06-27T13:26:42.779Z",
     "race_id": "mtfuji-climb-run-2026"
   },
   "https://mtfujiclimbrun.com/entry/": {
     "hash": "ee412df38b1ebd4a291e6b43531599ad3ccc76af72ffc7c0974197ab55e2470a",
-    "last_checked": "2026-06-22T14:58:00.908Z",
+    "last_checked": "2026-06-27T13:26:42.830Z",
     "race_id": "mtfuji-climb-run-2026"
   },
   "https://mtfujiclimbrun.com/course/": {
     "hash": "a90c469339bb28024bfe42de49b583a7f3961a1440e278de562f9fc97fdd9aa2",
-    "last_checked": "2026-06-22T14:58:00.956Z",
+    "last_checked": "2026-06-27T13:26:42.878Z",
     "race_id": "mtfuji-climb-run-2026"
   },
   "https://mtfujiclimbrun.com/access/": {
     "hash": "8620b12134b60c1a2a6ecb958580fb5026c1f96814fd0cd923e7ea6856eb3fb7",
-    "last_checked": "2026-06-22T14:58:01.006Z",
+    "last_checked": "2026-06-27T13:26:42.926Z",
     "race_id": "mtfuji-climb-run-2026"
   },
   "https://mtfujiclimbrun.com/qa/": {
     "hash": "64cfec35516f89c29a8fb9491c6f662ca1d099e51115a8b0633d9f5c5c44f62f",
-    "last_checked": "2026-06-22T14:58:01.055Z",
+    "last_checked": "2026-06-27T13:26:42.973Z",
     "race_id": "mtfuji-climb-run-2026"
   },
   "https://nagai-marathon.jp/news-cat/infomartion/": {
     "hash": "c7ae0d3b85073f1c3480cb09030ab3d79f9979d0388c47de65125f7fb3d28a86",
-    "last_checked": "2026-06-22T14:58:01.914Z",
+    "last_checked": "2026-06-27T13:26:45.491Z",
     "race_id": "nagai-marathon-2026"
   },
   "https://nagai-marathon.jp/news/2026/402/": {
     "hash": "4c03be4770b6ce370c4d401073fc3d0ea71631bcd462c8ddf25c0deef49e5bc5",
-    "last_checked": "2026-06-22T14:58:03.743Z",
+    "last_checked": "2026-06-27T13:26:47.596Z",
     "race_id": "nagai-marathon-2026"
   },
   "https://nagai-marathon.jp/wp/wp-content/themes/source_tcd045-child/pdf/nagaimararhon2026_yoko.pdf": {
     "hash": "1938ce85ae6df77df6ca317164b19d4e45ca2b44275d3d713d4142c93d5fbe97",
-    "last_checked": "2026-06-22T14:58:03.937Z",
+    "last_checked": "2026-06-27T13:26:47.817Z",
     "race_id": "nagai-marathon-2026"
   },
   "https://www.naganomarathon.gr.jp/information/": {
     "hash": "011e0f8077b6f9fdbec943ca44e3fe1a364faefe10fd21e2c8b97577012d37d6",
-    "last_checked": "2026-06-22T14:58:04.335Z",
+    "last_checked": "2026-06-27T13:26:48.241Z",
     "race_id": "nagano-marathon-2026"
   },
   "https://www.naganomarathon.gr.jp/information/course/": {
     "hash": "51eb789edc47152c37e9f72c6097cd696c1e186a64deaaf965192f1fe9098d70",
-    "last_checked": "2026-06-22T14:58:04.568Z",
+    "last_checked": "2026-06-27T13:26:48.440Z",
     "race_id": "nagano-marathon-2026"
   },
   "https://www.naganomarathon.gr.jp/entry/": {
     "hash": "9f131012d4a2f0b3a87abcb7dedefbf880afe3e1f038c6a31b2a88b14d240088",
-    "last_checked": "2026-06-22T14:58:04.792Z",
+    "last_checked": "2026-06-27T13:26:48.636Z",
     "race_id": "nagano-marathon-2026"
   },
   "https://www.naganomarathon.gr.jp/entrant/requirements/": {
     "hash": "a2e369f983c0009dd5bd7faa1d1c65db5792cfd0bfb1053c226f622f311497c2",
-    "last_checked": "2026-06-22T14:58:05.008Z",
+    "last_checked": "2026-06-27T13:26:48.841Z",
     "race_id": "nagano-marathon-2026"
   },
   "https://www.naganomarathon.gr.jp/stay/": {
     "hash": "303e2ad9e99c91054226adb505e792848e54f41589d1c56454eded37fd46e5f1",
-    "last_checked": "2026-06-22T14:58:05.211Z",
+    "last_checked": "2026-06-27T13:26:49.035Z",
     "race_id": "nagano-marathon-2026"
   },
   "https://womens-marathon.nagoya/en/outline/chinese1/": {
     "hash": "c67c635bc70c94306a040acacde7710db38c2a018e1a5fe9c68f00c2a73d434e",
-    "last_checked": "2026-06-22T14:58:05.316Z",
+    "last_checked": "2026-06-27T13:26:49.320Z",
     "race_id": "nagoya-womens-marathon-2026"
   },
   "https://womens-marathon.nagoya/outline/": {
     "hash": "bfe07baed6571937be166d72ba76d9456bc083eeb92d650ccf2de9651640c3aa",
-    "last_checked": "2026-06-22T14:58:05.366Z",
+    "last_checked": "2026-06-27T13:26:49.368Z",
     "race_id": "nagoya-womens-marathon-2026"
   },
   "https://womens-marathon.nagoya/faq/": {
     "hash": "199f8fd39a6f81cf4fdf61d0f1939e8a0f9adbd698646323f011483a26518527",
-    "last_checked": "2026-06-22T14:58:05.388Z",
+    "last_checked": "2026-06-27T13:26:49.392Z",
     "race_id": "nagoya-womens-marathon-2026"
   },
   "https://womens-marathon.nagoya/entry/": {
     "hash": "7a6ff2045fed1c740a7fb1a00915636b22dc91f4f32fe493bb0df549c129f930",
-    "last_checked": "2026-06-22T14:58:05.407Z",
+    "last_checked": "2026-06-27T13:26:49.412Z",
     "race_id": "nagoya-womens-marathon-2026"
   },
   "https://womens-marathon.nagoya/course/": {
     "hash": "3fde8087647db5939e3068889260771935c1bb762200154f56fce084f3709774",
-    "last_checked": "2026-06-22T14:58:05.419Z",
+    "last_checked": "2026-06-27T13:26:49.429Z",
     "race_id": "nagoya-womens-marathon-2026"
   },
   "https://naha-marathon.jp/info/": {
-    "hash": "6677bab9cfd1971588456cdad4fc6cdeb99e8495ee9c439c8f395dbf336e4892",
-    "last_checked": "2026-06-22T14:58:05.642Z",
+    "hash": "43bc1de2c0b4684d7e12d7db8eb7f5961e1585c1d3529f356e25de7207a31c94",
+    "last_checked": "2026-06-27T13:26:49.613Z",
     "race_id": "naha-marathon-2026"
   },
   "https://naha-marathon.jp/entry/": {
     "hash": "b51c01ba73f7514886418b13cf11e04a29de58f00a8648bf4d3e4f6ca035462a",
-    "last_checked": "2026-06-22T14:58:05.758Z",
+    "last_checked": "2026-06-27T13:26:49.714Z",
     "race_id": "naha-marathon-2026"
   },
   "https://naha-marathon.jp/course/": {
     "hash": "6c6218cb3c09f3d0640d77ef37bf627557410df0e937f49fa71658fad3a6b07b",
-    "last_checked": "2026-06-22T14:58:05.870Z",
+    "last_checked": "2026-06-27T13:26:49.841Z",
     "race_id": "naha-marathon-2026"
   },
   "https://naha-marathon.jp/contact/": {
     "hash": "8ff3ff83d883a8cbd74179fdd0ad3705947e73e1ab4718ecec0fc582dc2c1991",
-    "last_checked": "2026-06-22T14:58:05.991Z",
+    "last_checked": "2026-06-27T13:26:49.998Z",
     "race_id": "naha-marathon-2026"
   },
   "https://www.nara-marathon.jp/guidelines.html": {
     "hash": "8768f3f47b610ab991ca491dfe981fbb0eed2612143da9a3da3fc6d0f586874e",
-    "last_checked": "2026-06-22T14:58:06.048Z",
+    "last_checked": "2026-06-27T13:26:50.060Z",
     "race_id": "nara-marathon-2026"
   },
   "https://www.nara-marathon.jp/course.html": {
     "hash": "f990e1e8053f4e5608a3ad3fe1298f7078c7eb0085684d6f85de3852808f23e6",
-    "last_checked": "2026-06-22T14:58:06.062Z",
+    "last_checked": "2026-06-27T13:26:50.074Z",
     "race_id": "nara-marathon-2026"
   },
   "https://www.nara-marathon.jp/access.html": {
     "hash": "a5876ba8bde6c6471e6756aca3079850ef9b4ba085f3e9d5265fca186f0b69ad",
-    "last_checked": "2026-06-22T14:58:06.078Z",
+    "last_checked": "2026-06-27T13:26:50.086Z",
     "race_id": "nara-marathon-2026"
   },
   "https://www.nara-marathon.jp/qa.html": {
     "hash": "f29e53311146f4a8701af779595493adcca156b9f46766c354cd3e11eb2fb2bf",
-    "last_checked": "2026-06-22T14:58:06.095Z",
+    "last_checked": "2026-06-27T13:26:50.102Z",
     "race_id": "nara-marathon-2026"
   },
   "https://www.nara-marathon.jp/entry.html": {
     "hash": "dc2df6213cf51782c131435085dacc40a546fd053992a521edffffb49b8fba57",
-    "last_checked": "2026-06-22T14:58:06.109Z",
+    "last_checked": "2026-06-27T13:26:50.140Z",
     "race_id": "nara-marathon-2026"
   },
   "https://runfes-niigata.com/requirements/": {
     "hash": "7402b1518c9dd8f527f93314aaae32a4ba2accbb8ebba6844f01e0784a26f7c4",
-    "last_checked": "2026-06-22T14:58:06.993Z",
+    "last_checked": "2026-06-27T13:26:50.347Z",
     "race_id": "niigata-city-marathon-2026"
   },
   "https://runfes-niigata.com/2026/05/19/%e3%80%8c%e3%83%95%e3%82%a1%e3%83%b3%e3%83%a9%e3%83%b3%e3%80%8d%e3%82%a8%e3%83%b3%e3%83%88%e3%83%aa%e3%83%bc%e7%b7%a0%e3%82%81%e5%88%87%e3%82%8a%e3%81%ae%e3%81%8a%e7%9f%a5%e3%82%89%e3%81%9b/": {
-    "hash": "e9ae42e7dd1797e9d42d5c0911f93696cbb36c6666ad18a1308f9d662986b309",
-    "last_checked": "2026-06-22T14:58:07.284Z",
+    "hash": "ef337ce9b3b4da42607f04cc77131170a17c6b0a2cb2444fec4ad8373efb7e68",
+    "last_checked": "2026-06-27T13:26:50.461Z",
     "race_id": "niigata-city-marathon-2026"
   },
   "https://nishio-marathon.jp": {
-    "hash": "cab428851efc65dab3eb52dff16e89385ceb435a4802ce6e45cd033ea415d906",
-    "last_checked": "2026-06-22T14:58:07.911Z",
+    "hash": "38917f54002bfaf4292f4213e36c88a4603766539489921386024ebde67a9186",
+    "last_checked": "2026-06-27T13:26:51.748Z",
     "race_id": "nishio-marathon-2026"
   },
   "https://www.okayamamarathon.jp/event-information/guideline/": {
     "hash": "e9f1e6e1bc384085cf89d13d6d1c16e5835e199ccd8d3e60f93563fd3c259595",
-    "last_checked": "2026-06-22T14:58:09.076Z",
+    "last_checked": "2026-06-27T13:26:53.118Z",
     "race_id": "okayama-marathon-2026"
   },
   "https://www.okayamamarathon.jp/event-information/access/": {
     "hash": "d969e83e960c58bedc04eef569c4462a13ad9c4073c98792eefcf8df74c679cf",
-    "last_checked": "2026-06-22T14:58:09.235Z",
+    "last_checked": "2026-06-27T13:26:53.145Z",
     "race_id": "okayama-marathon-2026"
   },
   "https://www.okayamamarathon.jp/event-information/course/": {
     "hash": "8b9756b00c40a858320ccdab59ca759bd1bf2cfabc8b6850d57d37032d8058f5",
-    "last_checked": "2026-06-22T14:58:09.395Z",
+    "last_checked": "2026-06-27T13:26:53.171Z",
     "race_id": "okayama-marathon-2026"
   },
   "https://www.okayamamarathon.jp/runner/entry/": {
     "hash": "0d1291c72d2452b7c1a2b49c2556f0b102dfbd9f46c57001799679c28c5a386a",
-    "last_checked": "2026-06-22T14:58:09.423Z",
+    "last_checked": "2026-06-27T13:26:53.198Z",
     "race_id": "okayama-marathon-2026"
   },
   "https://www.okayamamarathon.jp/faq/": {
     "hash": "e5de1546389cff19267653009615195d5f92f65e1d02977972f3ae35675196cc",
-    "last_checked": "2026-06-22T14:58:09.452Z",
+    "last_checked": "2026-06-27T13:26:53.385Z",
     "race_id": "okayama-marathon-2026"
   },
   "https://okushinano100.com/concept/": {
     "hash": "e0d258d0323d91a33bd17f27b12dea6c9c793b3e0ffcf9fb7e34f013ee072bf4",
-    "last_checked": "2026-06-22T14:58:09.600Z",
+    "last_checked": "2026-06-27T13:26:53.530Z",
     "race_id": "okushinano100-2026"
   },
   "https://okushinano100.com/coursemap/": {
     "hash": "bf765055dda4034652be0700f76372cea55129dd7741b941046cedfe0ab18e1b",
-    "last_checked": "2026-06-22T14:58:09.676Z",
+    "last_checked": "2026-06-27T13:26:53.572Z",
     "race_id": "okushinano100-2026"
   },
   "https://okushinano100.com/access/": {
     "hash": "9808349de7f90e60a8a45bf536f18a1c7b167571f0f99d08417e84bc77e9d16c",
-    "last_checked": "2026-06-22T14:58:09.697Z",
+    "last_checked": "2026-06-27T13:26:53.595Z",
     "race_id": "okushinano100-2026"
   },
   "https://okushinano100.com/faq/": {
     "hash": "481cb1770f91bf5e19bf8eebc41744d24f8908d8ae993606e01049c56694d20b",
-    "last_checked": "2026-06-22T14:58:09.717Z",
+    "last_checked": "2026-06-27T13:26:53.618Z",
     "race_id": "okushinano100-2026"
   },
   "https://okushinano100.com/entry/": {
     "hash": "a5aa6234acf781ba12136f9a8104f5c9af3f34ee49faf8927e0cf925b78f3243",
-    "last_checked": "2026-06-22T14:58:09.740Z",
+    "last_checked": "2026-06-27T13:26:53.640Z",
     "race_id": "okushinano100-2026"
   },
   "https://www.osaka-marathon.com/2026/info/gist/": {
     "hash": "33f0001647e867edaf5b93c99654db3c28a1c05ed83c02e9439f5510ef35cee7",
-    "last_checked": "2026-06-22T14:58:09.845Z",
+    "last_checked": "2026-06-27T13:26:53.748Z",
     "race_id": "osaka-marathon-2026"
   },
   "https://www.osaka-marathon.com/2026/info/sponsor/": {
     "hash": "e771e0f5a2d27646b9cafcdd64a8a1086e12ef14a98b56f25962085e6f298e13",
-    "last_checked": "2026-06-22T14:58:09.863Z",
+    "last_checked": "2026-06-27T13:26:53.766Z",
     "race_id": "osaka-marathon-2026"
   },
   "https://www.osaka-marathon.com/2026/info/course/": {
     "hash": "a0a91f8f6cb5bc88fc6976abf5cc16e4041b31420c92cfbd4f9002e0742dba19",
-    "last_checked": "2026-06-22T14:58:09.881Z",
+    "last_checked": "2026-06-27T13:26:53.786Z",
     "race_id": "osaka-marathon-2026"
   },
   "https://www.osaka-marathon.com/2026/runner/entry/": {
     "hash": "97588ad876f3bf2facf4d2329e03d8e04d4039624ae2be792776d2e791a90f88",
-    "last_checked": "2026-06-22T14:58:09.898Z",
+    "last_checked": "2026-06-27T13:26:53.804Z",
     "race_id": "osaka-marathon-2026"
   },
   "https://www.osaka-marathon.com/2026/expo/outline/": {
     "hash": "4d1bb8d513d5d668ea2b2910f59160635e29239a7e16170023d0875f666e53fd",
-    "last_checked": "2026-06-22T14:58:09.915Z",
+    "last_checked": "2026-06-27T13:26:53.822Z",
     "race_id": "osaka-marathon-2026"
   },
   "https://www.osaka42195.com/category/info/": {
-    "hash": "ccf986872260586c5ea6cf46308f87dc6e1034509b7fa9c09c0093bae2ab3a00",
-    "last_checked": "2026-06-22T14:58:10.168Z",
+    "hash": "95f43728286c9431ee4b198c183413128ba4fe24c3c86ee8ee4426f13e7247ca",
+    "last_checked": "2026-06-27T13:26:54.094Z",
     "race_id": "osaka-yodo-river-citizens-marathon-2026"
   },
   "https://www.osaka42195.com/category/traffic/": {
-    "hash": "69149bb48f391102e5be3e5d70795f1f96e4b99d5df261a99659e859b226bef0",
-    "last_checked": "2026-06-22T14:58:10.305Z",
+    "hash": "e10fb0183332a61a572e5952e6d05b07c9518919f1c4f1db2fee73756944a540",
+    "last_checked": "2026-06-27T13:26:54.419Z",
     "race_id": "osaka-yodo-river-citizens-marathon-2026"
   },
   "https://www.osaka42195.com/event/about/": {
     "hash": "3be2bed66a0b5afd8ed0fcac63f20c399edf4f19b285f6e05d9a486d9c13d67b",
-    "last_checked": "2026-06-22T14:58:10.468Z",
+    "last_checked": "2026-06-27T13:26:54.746Z",
     "race_id": "osaka-yodo-river-citizens-marathon-2026"
   },
   "https://www.osaka42195.com/event/couse/": {
-    "hash": "be3c6200d8b05cfda444f011e4e82e0e4cf3f0601ce0587f88d8f27630df12b8",
-    "last_checked": "2026-06-22T14:58:10.527Z",
+    "hash": "9b790d82e6da0823570bfe63aef8fee953ba0f9755c4de298e6da9a0b19c81da",
+    "last_checked": "2026-06-27T13:26:54.807Z",
     "race_id": "osaka-yodo-river-citizens-marathon-2026"
   },
   "https://www.osaka42195.com/runner/entry/": {
     "hash": "88d30882cc5be61c77331a5e66a6a6567ff36243c982468f0706b0e817c63923",
-    "last_checked": "2026-06-22T14:58:10.567Z",
+    "last_checked": "2026-06-27T13:26:54.856Z",
     "race_id": "osaka-yodo-river-citizens-marathon-2026"
   },
   "https://www.outdoorsportsjapan.com/trail/ontake100/race-ontake100/": {
     "hash": "71624c3662cf6195b3079d21f6bb4797eb7b39cd0d9d81cc97de35e67c57e3b0",
-    "last_checked": "2026-06-22T14:58:11.172Z",
+    "last_checked": "2026-06-27T13:26:55.436Z",
     "race_id": "osj-ontake100-2026"
   },
   "https://www.outdoorsportsjapan.com/trail/ontake100/course-ontake100/": {
     "hash": "86a669f4793d759b5e75dab67e6a34e349ad6a7504e32e1e7e9aa95f13c60e91",
-    "last_checked": "2026-06-22T14:58:11.599Z",
+    "last_checked": "2026-06-27T13:26:55.940Z",
     "race_id": "osj-ontake100-2026"
   },
   "https://www.outdoorsportsjapan.com/trail/ontake100/access-ontake100/": {
     "hash": "b6e162b9476250f881f57bfed4dc9321a6837344f40fc2b512f7721ea12cdf35",
-    "last_checked": "2026-06-22T14:58:12.091Z",
+    "last_checked": "2026-06-27T13:26:56.438Z",
     "race_id": "osj-ontake100-2026"
   },
   "https://www.outdoorsportsjapan.com/trail/ontake100/entry-list-ontake100/": {
     "hash": "5457a89c9777d2acce79b0f568e82eccb055b44d6e4e4430fc05db946d079586",
-    "last_checked": "2026-06-22T14:58:12.536Z",
+    "last_checked": "2026-06-27T13:26:56.903Z",
     "race_id": "osj-ontake100-2026"
   },
   "https://sagasakura-marathon.jp/outline/": {
     "hash": "22c7f89f56a7c3a955955e4367aaf421bf4b44dd2aab5fe092f3132917477e30",
-    "last_checked": "2026-06-22T14:58:13.691Z",
+    "last_checked": "2026-06-27T13:26:57.880Z",
     "race_id": "saga-sakura-marathon-2026"
   },
   "https://sagasakura-marathon.jp/entry/": {
     "hash": "74e11e0d4e069b619b2689bce2c0fec9a196e67ef30924e4d538e532eda46127",
-    "last_checked": "2026-06-22T14:58:14.564Z",
+    "last_checked": "2026-06-27T13:26:58.844Z",
     "race_id": "saga-sakura-marathon-2026"
   },
   "https://sagasakura-marathon.jp/info/medical-runner/": {
     "hash": "710ff45b0d3885d6ed545760072ea49c6d663d0322b9f888a4d3a36695330000",
-    "last_checked": "2026-06-22T14:58:15.300Z",
+    "last_checked": "2026-06-27T13:26:59.671Z",
     "race_id": "saga-sakura-marathon-2026"
   },
   "https://sagasakura-marathon.jp/course/": {
     "hash": "98bb5e73d7c0c71ea77ccfa988d93196cd1e7aad6d49219463f1cf7019ae3153",
-    "last_checked": "2026-06-22T14:58:15.986Z",
+    "last_checked": "2026-06-27T13:27:00.495Z",
     "race_id": "saga-sakura-marathon-2026"
   },
   "https://sagasakura-marathon.jp/traffic/": {
     "hash": "87204d59063e2836bec6b3a67400f57efbb92d535cd611afd2fc8bafbb524618",
-    "last_checked": "2026-06-22T14:58:16.833Z",
+    "last_checked": "2026-06-27T13:27:00.510Z",
     "race_id": "saga-sakura-marathon-2026"
   },
   "https://saitama-marathon.jp/about/": {
-    "hash": "416f339b85a55a4d5aa06318e44ae2e891004832e67881b26f6f01646c77d7d9",
-    "last_checked": "2026-06-22T14:58:17.858Z",
+    "hash": "e9266796067006fda5c752a85f1ca6cd53b243bfc0f4f4b13c87fbf35eb41f11",
+    "last_checked": "2026-06-27T13:27:01.226Z",
     "race_id": "saitama-marathon-2026"
   },
   "https://saitama-marathon.jp/about/guest/": {
-    "hash": "dd57eb27fd558e1d7874df06b108830650c6fc4439caf67d73892bebd7a4d98e",
-    "last_checked": "2026-06-22T14:58:18.649Z",
+    "hash": "031f0cfa4ace88d5906889a9f8d9c8223e77346c9a99c6bde5a1de24b73ec471",
+    "last_checked": "2026-06-27T13:27:01.920Z",
     "race_id": "saitama-marathon-2026"
   },
   "https://saitama-marathon.jp/about/map/": {
-    "hash": "37710abeb349f411af96953955714dcc5e9578b06f72b0ee4f9f68bd09f9d56f",
-    "last_checked": "2026-06-22T14:58:19.474Z",
+    "hash": "4c56453d4b535cab3cf853c4a57a17669dabd5dbdfb16c8584fe0c2f8e7d5032",
+    "last_checked": "2026-06-27T13:27:02.569Z",
     "race_id": "saitama-marathon-2026"
   },
   "https://saitama-marathon.jp/entry/": {
-    "hash": "d56a3a91cbb4528d636eb17258671efb6ccb2ab1daca22bd740990f02557a27b",
-    "last_checked": "2026-05-31T13:52:51.725Z",
+    "hash": "76c4351711fd858e370bc99485cb76c6e4327bf652b40268df7655b2a0d90e29",
+    "last_checked": "2026-06-27T13:27:03.241Z",
     "race_id": "saitama-marathon-2026"
   },
   "https://satumara.sapporo-sport.jp/outline.html": {
     "hash": "1f9cb65fe7f32caaf31f037a1a451c7b05585591b66930d4f7a906c07248c5d9",
-    "last_checked": "2026-06-22T14:58:20.292Z",
+    "last_checked": "2026-06-27T13:27:03.391Z",
     "race_id": "sapporo-marathon-2026"
   },
   "https://satumara.sapporo-sport.jp/entry.html": {
     "hash": "3650c27ba3eac6c5e0209faaa237f82b441544c2f2a9514b47f14c3071a68111",
-    "last_checked": "2026-06-22T14:58:20.308Z",
+    "last_checked": "2026-06-27T13:27:03.420Z",
     "race_id": "sapporo-marathon-2026"
   },
   "https://satumara.sapporo-sport.jp/course.html": {
     "hash": "9cfc60def5ada24037497fc12689864e3d92cdd083a7d56d3c152e4e197eb049",
-    "last_checked": "2026-06-22T14:58:20.326Z",
+    "last_checked": "2026-06-27T13:27:03.459Z",
     "race_id": "sapporo-marathon-2026"
   },
   "https://satumara.sapporo-sport.jp/access.html": {
     "hash": "035282e4c28ede9ddd982bf845a42f5c3125cf0312d970b900a99a19f7baa6bc",
-    "last_checked": "2026-06-22T14:58:20.344Z",
+    "last_checked": "2026-06-27T13:27:03.478Z",
     "race_id": "sapporo-marathon-2026"
   },
   "https://satumara.sapporo-sport.jp/faq.html": {
     "hash": "8eca143d1f48aa455751a691e4fc3c5fc256dcaa3eb002e4b8e41f3e706eb4f8",
-    "last_checked": "2026-06-22T14:58:20.363Z",
+    "last_checked": "2026-06-27T13:27:03.507Z",
     "race_id": "sapporo-marathon-2026"
   },
   "https://www.nature-scene.net/shiga100/concept/": {
     "hash": "f7dd772c5571530f47c34ed1a1b9d6c952ba62439cd9712ac63c808f535817bd",
-    "last_checked": "2026-06-22T14:58:20.549Z",
+    "last_checked": "2026-06-27T13:27:03.689Z",
     "race_id": "shiga-kogen100-2026"
   },
   "https://www.nature-scene.net/shiga100/coursemap/": {
     "hash": "0a43e00575391080216506e63838e9f74be417cec6f799e3ad32edd714f3d80e",
-    "last_checked": "2026-06-22T14:58:20.692Z",
+    "last_checked": "2026-06-27T13:27:03.829Z",
     "race_id": "shiga-kogen100-2026"
   },
   "https://www.nature-scene.net/shiga100/entry/": {
     "hash": "b66f29060e0d325ea9e472dd5c835a4e8b5355ceb4b54f7a5841c3f9dbc96e79",
-    "last_checked": "2026-06-22T14:58:20.742Z",
+    "last_checked": "2026-06-27T13:27:03.876Z",
     "race_id": "shiga-kogen100-2026"
   },
   "https://www.shimada-marathon.jp/m-information/course.html": {
     "hash": "0d6e07f07d44d95f920dc9cc12682dfefebb7e9b63d283498cc49eb00aa45ad5",
-    "last_checked": "2026-06-22T14:58:20.858Z",
+    "last_checked": "2026-06-27T13:27:03.977Z",
     "race_id": "shimada-oigawa-marathon-2026"
   },
   "https://www.shimada-marathon.jp/entry.html": {
     "hash": "637c5c2648b98a41ae3caedc1c4e8803bc4cea45ea5e776585b12462aa441c3e",
-    "last_checked": "2026-06-22T14:58:20.889Z",
+    "last_checked": "2026-06-27T13:27:04.010Z",
     "race_id": "shimada-oigawa-marathon-2026"
   },
   "https://www.shimada-marathon.jp/access.html": {
     "hash": "85f00455b40002189ca89bc14c43b7c14e81a30097ed4d4c79a3aabbd05f98db",
-    "last_checked": "2026-06-22T14:58:20.928Z",
+    "last_checked": "2026-06-27T13:27:04.051Z",
     "race_id": "shimada-oigawa-marathon-2026"
   },
   "https://www.shimada-marathon.jp/faq.html": {
     "hash": "ba844b07d52e1fd2815868a03d975b56f3a758ad2a32c695253eacc9109f893f",
-    "last_checked": "2026-06-22T14:58:20.960Z",
+    "last_checked": "2026-06-27T13:27:04.082Z",
     "race_id": "shimada-oigawa-marathon-2026"
   },
   "https://sfmt100.com/about-shinetsu/": {
     "hash": "125298f93fed9cef622f2b9a008e1d3b2d87f2b3f97b5eb68cc5807f64cf67b3",
-    "last_checked": "2026-06-22T14:58:21.278Z",
+    "last_checked": "2026-06-27T13:27:04.297Z",
     "race_id": "shinetsu5mountains-trail-100-2026"
   },
   "https://sfmt100.com/access/": {
     "hash": "3a13709290275e8f8034142e919ce7411f5b25f8c8b693017b185455f4a42492",
-    "last_checked": "2026-06-22T14:58:21.521Z",
+    "last_checked": "2026-06-27T13:27:04.443Z",
     "race_id": "shinetsu5mountains-trail-100-2026"
   },
   "https://sfmt100.com/about/outline/": {
     "hash": "5469a2c13a3d33651eee0a167782ded8d690929f688b99649883d8ce5c0c71bb",
-    "last_checked": "2026-06-22T14:58:21.689Z",
+    "last_checked": "2026-06-27T13:27:04.623Z",
     "race_id": "shinetsu5mountains-trail-100-2026"
   },
   "https://sfmt100.com/about/entry/": {
     "hash": "631d49b450599cf5b61f174dfd3d583ed3120027e6285b7f16c7cda2548d47df",
-    "last_checked": "2026-06-22T14:58:21.953Z",
+    "last_checked": "2026-06-27T13:27:04.765Z",
     "race_id": "shinetsu5mountains-trail-100-2026"
   },
   "https://sfmt100.com/map/": {
     "hash": "7a156309f239ef68a43c53fbdeafef3850815a71b23b963053dc5ac463dbe28c",
-    "last_checked": "2026-06-22T14:58:22.204Z",
+    "last_checked": "2026-06-27T13:27:04.915Z",
     "race_id": "shinetsu5mountains-trail-100-2026"
   },
   "https://www.shizuoka-marathon.com/2026/info": {
     "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-    "last_checked": "2026-06-22T14:58:22.478Z",
+    "last_checked": "2026-06-27T13:27:05.199Z",
     "race_id": "shizuoka-marathon-2026"
   },
   "https://www.shizuoka-marathon.com/2026/entry": {
     "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-    "last_checked": "2026-06-22T14:58:22.635Z",
+    "last_checked": "2026-06-27T13:27:05.336Z",
     "race_id": "shizuoka-marathon-2026"
   },
   "https://www.shizuoka-marathon.com/2026/info/course": {
     "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-    "last_checked": "2026-06-22T14:58:22.790Z",
+    "last_checked": "2026-06-27T13:27:05.494Z",
     "race_id": "shizuoka-marathon-2026"
   },
   "https://www.shizuoka-marathon.com/2026/faq": {
     "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-    "last_checked": "2026-06-22T14:58:22.962Z",
+    "last_checked": "2026-06-27T13:27:05.632Z",
     "race_id": "shizuoka-marathon-2026"
   },
   "https://www.shizuoka-marathon.com/2026/info/feature": {
     "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-    "last_checked": "2026-06-22T14:58:23.127Z",
+    "last_checked": "2026-06-27T13:27:05.792Z",
     "race_id": "shizuoka-marathon-2026"
   },
   "https://www.shonan-kokusai.jp/entry/": {
     "hash": "a0783bb8137f38e3e6e8d7dce9ec664ce49bbbb2ce41be956a7e6f956d273051",
-    "last_checked": "2026-06-22T14:58:23.271Z",
+    "last_checked": "2026-06-27T13:27:06.030Z",
     "race_id": "shonan-international-marathon-2026"
   },
   "https://www.shonan-kokusai.jp/outline/": {
     "hash": "f501504ad73942145737080659f5e20d1b3fb3fb640ec765e0c7a33472820cc0",
-    "last_checked": "2026-06-22T14:58:23.340Z",
+    "last_checked": "2026-06-27T13:27:06.084Z",
     "race_id": "shonan-international-marathon-2026"
   },
   "https://www.shonan-kokusai.jp/access/": {
     "hash": "4607b5daf6aa08310112a60cb497ea2c41aefc497dacabbf5bd13eb173d3263c",
-    "last_checked": "2026-06-22T14:58:23.527Z",
+    "last_checked": "2026-06-27T13:27:06.209Z",
     "race_id": "shonan-international-marathon-2026"
   },
   "https://www.shonan-kokusai.jp/course/": {
     "hash": "4460657d8b5ae89194704de42d8097200590e327114554394293fffa03d56b5d",
-    "last_checked": "2026-06-22T14:58:23.693Z",
+    "last_checked": "2026-06-27T13:27:06.354Z",
     "race_id": "shonan-international-marathon-2026"
   },
   "https://www.shonan-kokusai.jp/faq/": {
     "hash": "875c7780a6dddea6cdca5e91366b4a68d1906e274ae16416df64e5c14072bae5",
-    "last_checked": "2026-06-22T14:58:23.827Z",
+    "last_checked": "2026-06-27T13:27:06.455Z",
     "race_id": "shonan-international-marathon-2026"
   },
   "https://soja-kibijimarathon.jp/wp/event-details/": {
     "hash": "8c6d7dba04772bad25e6abab71a827c8b44ef88ba96f69f692c842ef7ac3eb5f",
-    "last_checked": "2026-06-22T14:58:24.373Z",
+    "last_checked": "2026-06-27T13:27:07.008Z",
     "race_id": "soja-kibiji-marathon-2026"
   },
   "https://soja-kibijimarathon.jp/wp/course/": {
     "hash": "077dd87bf021a5a392e87578c96129aa1ad36b8f8a97791a20393994b904760e",
-    "last_checked": "2026-06-22T14:58:24.726Z",
+    "last_checked": "2026-06-27T13:27:07.328Z",
     "race_id": "soja-kibiji-marathon-2026"
   },
   "https://soja-kibijimarathon.jp/wp/entry/": {
     "hash": "be1117250ae729a13c6a919235a60368b3e89451c00bf2ef86fe228babebf5ba",
-    "last_checked": "2026-06-22T14:58:25.136Z",
+    "last_checked": "2026-06-27T13:27:07.675Z",
     "race_id": "soja-kibiji-marathon-2026"
   },
   "https://soja-kibijimarathon.jp/wp/qa/": {
     "hash": "5dab1b0c87ecc900e33181b67df17d99034edd5570cf9e483733e3d3cbaa9bea",
-    "last_checked": "2026-06-22T14:58:25.521Z",
+    "last_checked": "2026-06-27T13:27:08.021Z",
     "race_id": "soja-kibiji-marathon-2026"
   },
   "https://soja-kibijimarathon.jp/wp/access/": {
     "hash": "b5f15817639961453dc8f05b38d5287a037a6ec60d1986eeb9fe3955a3e31a7d",
-    "last_checked": "2026-06-22T14:58:25.900Z",
+    "last_checked": "2026-06-27T13:27:08.328Z",
     "race_id": "soja-kibiji-marathon-2026"
   },
   "https://tambasasayama-abc-marathon.jp/outline/": {
     "hash": "176947ebdda404c3c18c74d58c1440cef1bf4aeeb5a71a4bea5b2dce5e97db81",
-    "last_checked": "2026-06-22T14:58:26.211Z",
+    "last_checked": "2026-06-27T13:27:08.624Z",
     "race_id": "tamba-sasayama-abc-marathon-2026"
   },
   "https://tambasasayama-abc-marathon.jp/course/": {
     "hash": "1dd67da3dc2f0c48df3649ae72bbe12bb97f32f183eb6a259caff44d8b873702",
-    "last_checked": "2026-06-22T14:58:26.460Z",
+    "last_checked": "2026-06-27T13:27:08.869Z",
     "race_id": "tamba-sasayama-abc-marathon-2026"
   },
   "https://tambasasayama-abc-marathon.jp/entry/": {
     "hash": "a7358ef735b8e3aeeb4bf06f45aa0e59678e36a8b6246fcf6d9c15cac1297d81",
-    "last_checked": "2026-06-22T14:58:26.649Z",
+    "last_checked": "2026-06-27T13:27:09.028Z",
     "race_id": "tamba-sasayama-abc-marathon-2026"
   },
   "https://tambasasayama-abc-marathon.jp/faq/": {
     "hash": "23b3dfe2b7eaf2bac73a1219a1a9633a326fc5121a6e454bbc03cd6f8e75f26e",
-    "last_checked": "2026-06-22T14:58:26.829Z",
+    "last_checked": "2026-06-27T13:27:09.196Z",
     "race_id": "tamba-sasayama-abc-marathon-2026"
   },
   "https://tateyama-wakasio.jp/outline/": {
     "hash": "fe46356565add6c88c181cb01d5124f0cef5a0a62de81a76139f7019a9630eea",
-    "last_checked": "2026-06-22T14:58:26.994Z",
+    "last_checked": "2026-06-27T13:27:09.346Z",
     "race_id": "tateyama-wakashio-2026"
   },
   "https://tateyama-wakasio.jp/course/": {
     "hash": "d8fd69ddb615417018e88d0c195189c2d43491a1c9fe21608122ef84f8cf96fb",
-    "last_checked": "2026-06-22T14:58:27.047Z",
+    "last_checked": "2026-06-27T13:27:09.414Z",
     "race_id": "tateyama-wakashio-2026"
   },
   "https://tateyama-wakasio.jp/entry/": {
     "hash": "2e1051f06670c87d065281490fad61ebd5e0a7291e0e71d93ff20d5c255ac1c9",
-    "last_checked": "2026-06-22T14:58:27.172Z",
+    "last_checked": "2026-06-27T13:27:09.468Z",
     "race_id": "tateyama-wakashio-2026"
   },
   "https://tateyama-wakasio.jp/faq/": {
     "hash": "d39b8637a06a2f2b012cf05895161da7e95d00abd68c30514f1be37e3b809d7a",
-    "last_checked": "2026-06-22T14:58:27.220Z",
+    "last_checked": "2026-06-27T13:27:09.523Z",
     "race_id": "tateyama-wakashio-2026"
   },
   "https://tazawako-marathon.com/info/": {
     "hash": "5c6a64a767f3531f93c9d5dbf51f0a06df5011d2c0b414ee168be054b41cee88",
-    "last_checked": "2026-06-22T14:58:27.439Z",
+    "last_checked": "2026-06-27T13:27:09.630Z",
     "race_id": "tazawako-marathon-2026"
   },
   "https://tazawako-marathon.com/track/": {
     "hash": "fbf506f30667799be4fc0e92a164fe27204480daf0bcb54833273ad8513d1875",
-    "last_checked": "2026-06-22T14:58:27.456Z",
+    "last_checked": "2026-06-27T13:27:09.648Z",
     "race_id": "tazawako-marathon-2026"
   },
   "https://tazawako-marathon.com/concept/": {
     "hash": "2e211f42f118de4effc53d67d99ed041791997d1d51c369b8c5cea79910e2b03",
-    "last_checked": "2026-06-22T14:58:27.473Z",
+    "last_checked": "2026-06-27T13:27:09.667Z",
     "race_id": "tazawako-marathon-2026"
   },
   "https://tazawako-marathon.com/question/": {
     "hash": "a4b671289ae3e557936a1390cf51c4fbda1a47dc35ac125543e07d1196437914",
-    "last_checked": "2026-06-22T14:58:27.492Z",
+    "last_checked": "2026-06-27T13:27:09.685Z",
     "race_id": "tazawako-marathon-2026"
   },
   "https://tazawako-marathon.com/entry/": {
     "hash": "2b45223e6ea89491a9d9da8f14c2087fb29c18c761cda60818c06cc6f40fd54d",
-    "last_checked": "2026-06-22T14:58:27.511Z",
+    "last_checked": "2026-06-27T13:27:09.703Z",
     "race_id": "tazawako-marathon-2026"
   },
   "https://www.tokushima-marathon.jp/info/": {
     "hash": "d640a96739f16d8cccca5d8c44043383bc2cf21a1815f4828993de79bac0563a",
-    "last_checked": "2026-06-22T14:58:27.638Z",
+    "last_checked": "2026-06-27T13:27:09.848Z",
     "race_id": "tokushima-marathon-2026"
   },
   "https://www.tokushima-marathon.jp/info/course.html": {
     "hash": "bfb8da0d0b20b069626904436e7cd902ac4cf1b4ca0c384def7786bedc293515",
-    "last_checked": "2026-06-22T14:58:28.204Z",
+    "last_checked": "2026-06-27T13:27:09.935Z",
     "race_id": "tokushima-marathon-2026"
   },
   "https://www.tokushima-marathon.jp/info/guest.html": {
     "hash": "30d2f36d9315c9aee93e5f58bbc0c77724a4ebb53e78c8416ea9d3436870b51d",
-    "last_checked": "2026-06-22T14:58:28.278Z",
+    "last_checked": "2026-06-27T13:27:09.984Z",
     "race_id": "tokushima-marathon-2026"
   },
   "https://www.tokushima-marathon.jp/join/entry.html": {
     "hash": "c029dbde773166f9a203f6d840954b00968014d70ecdddbd6f2a067d2238469e",
-    "last_checked": "2026-06-22T14:58:28.450Z",
+    "last_checked": "2026-06-27T13:27:10.070Z",
     "race_id": "tokushima-marathon-2026"
   },
   "https://www.tokushima-marathon.jp/regulation/": {
     "hash": "c5fdd6254250c413c38c0800b8e47fecf586b5b2360e87783048446520cad58c",
-    "last_checked": "2026-06-22T14:58:28.514Z",
+    "last_checked": "2026-06-27T13:27:10.118Z",
     "race_id": "tokushima-marathon-2026"
   },
   "https://legacyhalf.tokyo/volunteer/index.html": {
     "hash": "8bb71d6a9842f8e619af8abbc655c1a02099f7d2b8923221824b671cd9830b05",
-    "last_checked": "2026-06-22T14:58:28.617Z",
+    "last_checked": "2026-06-27T13:27:10.204Z",
     "race_id": "tokyo-legacy-half-2026"
   },
   "https://legacyhalf.tokyo/about/main-visual/index.html": {
     "hash": "610f81fc7778168608f815de743bc5168feb39be160869a4b0bfeafdd9c49749",
-    "last_checked": "2026-06-22T14:58:28.718Z",
+    "last_checked": "2026-06-27T13:27:10.271Z",
     "race_id": "tokyo-legacy-half-2026"
   },
   "https://legacyhalf.tokyo/news/detail/news_0248.html": {
     "hash": "9e837ebdb5a88cf1cbef114c3fcaeb7d0cc47d1f7a5849e17eb7d18470839d5d",
-    "last_checked": "2026-06-22T14:58:28.782Z",
+    "last_checked": "2026-06-27T13:27:10.320Z",
     "race_id": "tokyo-legacy-half-2026"
   },
   "https://www.marathon.tokyo/volunteer/about/": {
-    "hash": "5571631b82ff8f559ea381761dadcae113437fced4d1b86fc49385b7e9821aca",
-    "last_checked": "2026-06-22T14:58:28.927Z",
+    "hash": "f3c9774518060d10a1fd0cd16d08cedfa0e982adc7ab0c5face5199aaa386204",
+    "last_checked": "2026-06-27T13:27:10.585Z",
     "race_id": "tokyo-marathon-2027"
   },
   "https://www.marathon.tokyo/faq/": {
-    "hash": "314a443e94248e91cd20743cb1e8ba4e2ece9dfa57c4a3bdd67aced6b8513acc",
-    "last_checked": "2026-06-22T14:58:28.946Z",
+    "hash": "3f0ed47556576d1fb4e28c3f2c6be795a7232a5c1fa9ee549d8364b1f237c9f4",
+    "last_checked": "2026-06-27T13:27:10.600Z",
     "race_id": "tokyo-marathon-2027"
   },
   "https://www.marathon.tokyo/about/outline/": {
-    "hash": "8e56697169dca51df03d3fd60696fca58ecbde090d32e594da74f49151fa749e",
-    "last_checked": "2026-06-22T14:58:28.957Z",
+    "hash": "b8b451ffb833f4c915a3a3bc56df065fc8164e18ba5eb6201b26275176c23f31",
+    "last_checked": "2026-06-27T13:27:10.613Z",
     "race_id": "tokyo-marathon-2027"
   },
   "https://www.marathon.tokyo/about/course/": {
-    "hash": "f023fa075a6a20f74630ffd9998ebf4bd1bd86726ddf41fe2bbbe8718162360e",
-    "last_checked": "2026-06-22T14:58:28.970Z",
+    "hash": "54eacb488e9cf2fb9f4ef0e2269053b35c91e0f68f991365cfa466b11c096ae8",
+    "last_checked": "2026-06-27T13:27:10.624Z",
     "race_id": "tokyo-marathon-2027"
   },
   "https://www.marathon.tokyo/participants/": {
-    "hash": "8b667e747e80c565d50473406360ea49d73cd2e561e98532d8ed0d3b5c178c86",
-    "last_checked": "2026-06-22T14:58:28.985Z",
+    "hash": "b6f0ee42d3c8e1f8971e7b701be108187ca8eda6d72cbd7c614b3a15416c4c8b",
+    "last_checked": "2026-06-27T13:27:10.636Z",
     "race_id": "tokyo-marathon-2027"
   },
   "https://tomisato-suikaroad.jp/outline/": {
-    "hash": "a7324eedb092deb1c297490766a46378b80d48a61f307732ba4b522ebb8b278e",
-    "last_checked": "2026-06-22T14:58:29.555Z",
+    "hash": "ace1081f6b732f8b70248db8c24f8a87a97dc9b425400b05ad41ee81e2b7f35c",
+    "last_checked": "2026-06-27T13:27:11.202Z",
     "race_id": "tomisato-suikaroad-2026"
   },
   "https://tomisato-suikaroad.jp/course/": {
-    "hash": "8953997941c2dea0a3a1818d0c06abffb2b82aaf161358202bf34d7e0dcd0759",
-    "last_checked": "2026-06-22T14:58:29.718Z",
+    "hash": "3715b631ace36e417111c8bb11fec39cae0179e8c40f41d639717c7f7cd86a81",
+    "last_checked": "2026-06-27T13:27:11.382Z",
     "race_id": "tomisato-suikaroad-2026"
   },
   "https://tomisato-suikaroad.jp/entry/": {
-    "hash": "67b74fbad6db1e1ebf10c19b21f9ea866e5e341301c32dfcb31abc3600f25611",
-    "last_checked": "2026-06-22T14:58:29.885Z",
+    "hash": "a328785bc60851de83bc7368253a0482812561a7b0488a9f54e82094d9bc5fe6",
+    "last_checked": "2026-06-27T13:27:11.542Z",
     "race_id": "tomisato-suikaroad-2026"
   },
   "https://tomisato-suikaroad.jp/mycapinfo/": {
-    "hash": "66732c4bb703bf513cc8d57edd1c75a05f833e7f4e114adcf280ad50def8c5d8",
-    "last_checked": "2026-06-22T14:58:30.041Z",
+    "hash": "d9f1421e8005e87e25b59fe4646f94b72a4d1bbad099f474de63f343b5fb8dff",
+    "last_checked": "2026-06-27T13:27:11.750Z",
     "race_id": "tomisato-suikaroad-2026"
   },
   "https://tomisato-suikaroad.jp/archives/770/": {
-    "hash": "63c36675b32d8f6dbd888b8065ecab2ed1ebaa777f6ab2ed70a4769e1cea76d3",
-    "last_checked": "2026-06-22T14:58:30.214Z",
+    "hash": "aa947394b75f598257c81fc9061f8bcac8b9bd904498f665a7613a1facb713d1",
+    "last_checked": "2026-06-27T13:27:11.919Z",
     "race_id": "tomisato-suikaroad-2026"
   },
   "https://tottori-marathon.jp/about/": {
     "hash": "422987f6177a0c01e7f54bf6c37a1e753d6a859eeeb6171764f1ed813ed94ba2",
-    "last_checked": "2026-06-22T14:58:30.478Z",
+    "last_checked": "2026-06-27T13:27:13.196Z",
     "race_id": "tottori-marathon-2026"
   },
   "https://tottori-marathon.jp/course/": {
     "hash": "128018a29b74c3a846d065276e9ecc4b8606abce9ee747ff25ab853675ab1409",
-    "last_checked": "2026-06-22T14:58:30.674Z",
+    "last_checked": "2026-06-27T13:27:13.398Z",
     "race_id": "tottori-marathon-2026"
   },
   "https://tottori-marathon.jp/access/": {
     "hash": "b08bee856b5be4eb9100542912c4bc087d74d65e8e1204041a41ee08e6760e7a",
-    "last_checked": "2026-06-22T14:58:30.798Z",
+    "last_checked": "2026-06-27T13:27:13.525Z",
     "race_id": "tottori-marathon-2026"
   },
   "https://tottori-marathon.jp/faq/": {
     "hash": "07787ac0390148f131be079c0f150d43ba34d4fe1e9528e76b5bf302a1511f0f",
-    "last_checked": "2026-06-22T14:58:30.916Z",
+    "last_checked": "2026-06-27T13:27:13.661Z",
     "race_id": "tottori-marathon-2026"
   },
   "https://www.toyako-marathon.jp/outline/": {
     "hash": "04aae16ca12370f252f99e7fbb6f3edfa00df10c2851e891fa061f5c447a2f1c",
-    "last_checked": "2026-06-22T14:58:31.216Z",
+    "last_checked": "2026-06-27T13:27:13.967Z",
     "race_id": "toyako-marathon-2026"
   },
   "https://www.toyako-marathon.jp/entry/": {
     "hash": "8a251f00105de0a7168106bb47c8993ef20cab5d49eb74c0bfc81e5af5193ee5",
-    "last_checked": "2026-06-22T14:58:31.451Z",
+    "last_checked": "2026-06-27T13:27:14.201Z",
     "race_id": "toyako-marathon-2026"
   },
   "https://www.toyako-marathon.jp/course/": {
     "hash": "5aff71c01fbc2b0dd9d81f816c006d68582e525068d28040fbf07e151c07f561",
-    "last_checked": "2026-06-22T14:58:31.606Z",
+    "last_checked": "2026-06-27T13:27:14.371Z",
     "race_id": "toyako-marathon-2026"
   },
   "https://www.toyamamarathon.com/about/": {
     "hash": "41cfcd74c0bbd8424379eb941a0c0d8f38954667ea5986b20cbb098d88356df1",
-    "last_checked": "2026-06-22T14:58:31.823Z",
+    "last_checked": "2026-06-27T13:27:14.581Z",
     "race_id": "toyama-marathon-2026"
   },
   "https://www.toyamamarathon.com/about/course/": {
     "hash": "3c3381d295f907e258ec1e5d7a69d3e62f13e1f58ff57d96488c9053e5c46af4",
-    "last_checked": "2026-06-22T14:58:31.954Z",
+    "last_checked": "2026-06-27T13:27:14.716Z",
     "race_id": "toyama-marathon-2026"
   },
   "https://www.toyamamarathon.com/runner/stayplan/": {
     "hash": "ce8f4a7b184ee0f6a63933cd5a77f218808af8a174a159b356a41da84192ea82",
-    "last_checked": "2026-06-22T14:58:32.087Z",
+    "last_checked": "2026-06-27T13:27:14.837Z",
     "race_id": "toyama-marathon-2026"
   },
   "https://www.toyamamarathon.com/traffic/": {
     "hash": "15e7a272537b61860d6fd888ed5e924ecd6459c2187be2d39da93bbcce2c920a",
-    "last_checked": "2026-06-22T14:58:32.230Z",
+    "last_checked": "2026-06-27T13:27:14.972Z",
     "race_id": "toyama-marathon-2026"
   },
   "https://www.toyamamarathon.com/faq/": {
     "hash": "ed15a307cc170e574b9c7cb6df3d013901a3a311891b5295ae162c78c549428a",
-    "last_checked": "2026-06-22T14:58:32.390Z",
+    "last_checked": "2026-06-27T13:27:15.116Z",
     "race_id": "toyama-marathon-2026"
   },
   "https://www.tsukuba-marathon.com/page/dir000007.html": {
     "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-    "last_checked": "2026-06-22T14:58:32.472Z",
+    "last_checked": "2026-06-27T13:27:15.190Z",
     "race_id": "tsukuba-marathon-2026"
   },
   "https://www.tsukuba-marathon.com/faq.php": {
     "hash": "65524ba36bb60fc7d724f43b20a95152b20ed2c8e66759b5aceaa72ea28c5e9f",
-    "last_checked": "2026-06-22T14:58:32.523Z",
+    "last_checked": "2026-06-27T13:27:15.273Z",
     "race_id": "tsukuba-marathon-2026"
   },
   "https://www.tsukuba-marathon.com/page/page000280.html": {
     "hash": "6c2f8519a88761a574373882ea94799a81922a2830ee617784e0150e89465b2e",
-    "last_checked": "2026-06-22T14:58:32.537Z",
+    "last_checked": "2026-06-27T13:27:15.289Z",
     "race_id": "tsukuba-marathon-2026"
   },
   "https://www.tsukuba-marathon.com/page/page000276.html": {
     "hash": "0c04b04971c9a39c815751e532f23fa1da3c880bb68afacb334986acb779948a",
-    "last_checked": "2026-06-22T14:58:32.549Z",
+    "last_checked": "2026-06-27T13:27:15.305Z",
     "race_id": "tsukuba-marathon-2026"
   },
   "https://www.tsukuba-marathon.com/sitemap.php": {
     "hash": "5667045962b4905e807e5389ea5afb414b8a7a43085794a62dcf715c50f06bf0",
-    "last_checked": "2026-06-22T14:58:32.613Z",
+    "last_checked": "2026-06-27T13:27:15.376Z",
     "race_id": "tsukuba-marathon-2026"
   },
   "https://wakkanai-marathon.jp/outline/": {
     "hash": "059aa7367199eb98d28771738753fe9f367e2f3efe4fe6b6e0369890589b2638",
-    "last_checked": "2026-06-22T14:58:32.929Z",
+    "last_checked": "2026-06-27T13:27:15.693Z",
     "race_id": "wakkanai-peace-marathon-2026"
   },
   "https://wakkanai-marathon.jp/entry/": {
     "hash": "7472d8abd68e3a252d7a3b3c31170772b89a8a732958e4301fda629645e0891d",
-    "last_checked": "2026-06-22T14:58:33.182Z",
+    "last_checked": "2026-06-27T13:27:15.956Z",
     "race_id": "wakkanai-peace-marathon-2026"
   },
   "https://wakkanai-marathon.jp/course/": {
     "hash": "eb9901f04f6362ba9e0d34a7896c897581291ed27bde884605fc5a14af50b02a",
-    "last_checked": "2026-06-22T14:58:33.351Z",
+    "last_checked": "2026-06-27T13:27:16.142Z",
     "race_id": "wakkanai-peace-marathon-2026"
   },
   "https://yokohamamarathon.jp/outline/": {
-    "hash": "6c2f59b4043931893dc21a449d6650a495da591784417373c8cf44732a96772f",
-    "last_checked": "2026-06-22T14:58:35.058Z",
+    "hash": "f3ead4e8a56c144e1e25be08c37efa9f17d1d7c0bb8f2ab8f08b90bc2f200d34",
+    "last_checked": "2026-06-27T13:27:17.208Z",
     "race_id": "yokohama-marathon-2026"
   },
   "https://yokohamamarathon.jp/entrystart/": {
-    "hash": "07f3b6dac99ed3ddd90dbd22998d483517885c8472089094f619975ba353e32c",
-    "last_checked": "2026-06-22T14:58:35.899Z",
+    "hash": "ee832609e17c30c2deeb7595fc090b28ada8f6fc01be7e473a01a9ec5d66794c",
+    "last_checked": "2026-06-27T13:27:17.916Z",
     "race_id": "yokohama-marathon-2026"
   },
   "https://yokohamamarathon.jp/volunteerqa/": {
-    "hash": "efda23edbee60f211d790044ae3d1bbf50bc188cc0be0f2a807738a5a387a7f7",
-    "last_checked": "2026-06-22T14:58:36.802Z",
+    "hash": "a5ddea146b75664bcaeef281a37a028cab861528f7a854fa812ca96d2e3d04e1",
+    "last_checked": "2026-06-27T13:27:18.651Z",
     "race_id": "yokohama-marathon-2026"
   },
   "https://www.shining-foundation.org/izu-oshima-outline": {
     "hash": "fd0b7c193363c052a6cb54f16dee5df463d8cdc7a1f3f81ea257698ecef2a33a",
-    "last_checked": "2026-06-22T14:57:42.467Z",
+    "last_checked": "2026-06-27T13:26:24.151Z",
     "race_id": "izu-oshima-2026"
   },
   "https://www.shining-foundation.org/izu-oshima-entry": {
     "hash": "ff819e85fcbba14fed2915d5c1416a68ce9008a8dc23d7d2ad2b66bf1c67d539",
-    "last_checked": "2026-06-22T14:57:42.629Z",
+    "last_checked": "2026-06-27T13:26:24.374Z",
     "race_id": "izu-oshima-2026"
   },
   "https://www.shining-foundation.org/izu-oshima-special": {
     "hash": "a4ba7b6ce6723d6c58701cec26af76707e21362e4911535cc79ef8566da6db50",
-    "last_checked": "2026-06-22T14:57:43.233Z",
+    "last_checked": "2026-06-27T13:26:25.334Z",
     "race_id": "izu-oshima-2026"
   },
   "https://www.shining-foundation.org/izu-oshima-couse": {
     "hash": "6ba2beb1ac10dc8ba8178fccdb4035d98e8cbfed33fb7d79d87397193654566f",
-    "last_checked": "2026-06-22T14:57:43.473Z",
+    "last_checked": "2026-06-27T13:26:25.470Z",
     "race_id": "izu-oshima-2026"
   },
   "https://www.shining-foundation.org/izu-oshima-access": {
     "hash": "1625cbbc77d9ae2e7d788ee1694510973587207f351c91c53ce8f798892e9683",
-    "last_checked": "2026-06-22T14:57:43.640Z",
+    "last_checked": "2026-06-27T13:26:25.607Z",
     "race_id": "izu-oshima-2026"
   },
   "https://www.ohtawara-marathon.com/outline/": {
     "hash": "7ac11d799307551674f512302b40d959126ca8feff35f87a7a07f69ea5791e79",
-    "last_checked": "2026-06-22T14:58:08.219Z",
+    "last_checked": "2026-06-27T13:26:52.197Z",
     "race_id": "ohtawara-marathon-2026"
   },
   "https://www.ohtawara-marathon.com/feature/": {
     "hash": "4519ac97d89bae58c0b7ddf29651f2507ad75b164ba5a1ddb52ea2def0b084ba",
-    "last_checked": "2026-06-22T14:58:08.458Z",
+    "last_checked": "2026-06-27T13:26:52.458Z",
     "race_id": "ohtawara-marathon-2026"
   },
   "https://www.ohtawara-marathon.com/entry/": {
     "hash": "db9e2cc06e3c37de1e7891e71282f9224a68f5fd5062a0c8e7e8749bdc13f1e7",
-    "last_checked": "2026-06-22T14:58:08.620Z",
+    "last_checked": "2026-06-27T13:26:52.649Z",
     "race_id": "ohtawara-marathon-2026"
   },
   "https://www.ohtawara-marathon.com/course/": {
     "hash": "f8a2a1efe1556bd2fb5174fc341dacc609c1b736059e79cc2aaa1a40dbcab744",
-    "last_checked": "2026-06-22T14:58:08.763Z",
+    "last_checked": "2026-06-27T13:26:52.820Z",
     "race_id": "ohtawara-marathon-2026"
   },
   "https://www.ohtawara-marathon.com/contact/": {
     "hash": "dd29ce0f45d207e5b126e102f864b2a2a8278ad80c19434f0894667d3e7956e0",
-    "last_checked": "2026-06-22T14:58:08.940Z",
+    "last_checked": "2026-06-27T13:26:52.983Z",
     "race_id": "ohtawara-marathon-2026"
   },
   "https://hofu-yomiuri.jp/entry/": {
-    "hash": "54e7d56c65aa0f1db0b7270c6232e3fbbba00e2108525e275b763abcdfc3af14",
-    "last_checked": "2026-06-22T14:57:32.047Z",
+    "hash": "c986534021623e1256c701efcfa7b4bfd8c1c72c65443858da5efdae888354fa",
+    "last_checked": "2026-06-27T13:26:12.492Z",
     "race_id": "hofu-yomiuri-marathon-2026"
   }
 }

--- a/tools/crawl/extractor.js
+++ b/tools/crawl/extractor.js
@@ -196,6 +196,16 @@ async function extractFromPages(race, pageTexts) {
 const ALLOWED_KEYS = new Set(DIFF_FIELDS.map(f => f.key));
 
 function applyAndSave(race, extracted) {
+  // 年度不一致チェック: 抽出された開催日の年が現在のファイルの年と異なる場合は保存しない
+  if (extracted.date && race.date) {
+    const currentYear = race.date.slice(0, 4);
+    const extractedYear = extracted.date.slice(0, 4);
+    if (extractedYear !== currentYear) {
+      const suggestedFile = race.id.replace(/-\d{4}$/, `-${extractedYear}`) + '.json';
+      return { yearMismatch: true, currentYear, extractedYear, suggestedFile };
+    }
+  }
+
   const filePath = path.join(RACES_DIR, `${race.id}.json`);
   const updated = {
     ...race,

--- a/tools/crawl/extractor.js
+++ b/tools/crawl/extractor.js
@@ -226,6 +226,71 @@ function applyAndSave(race, extracted) {
   return updated;
 }
 
+/**
+ * 既存レースデータを元に次年度版のレースオブジェクトを構築する（純粋関数）
+ * @param {object} race - 現在の race JSON
+ * @param {object} extracted - 抽出済みデータ（extracted.date が次年度）
+ * @returns {object} 新しい年度用 race オブジェクト
+ */
+function buildNewEditionRace(race, extracted) {
+  const currentYear = race.date.slice(0, 4);
+  const extractedYear = extracted.date.slice(0, 4);
+
+  const newId = race.id.replace(/-\d{4}$/, `-${extractedYear}`);
+  const now = new Date().toISOString();
+  const today = now.slice(0, 10);
+
+  const extractedFiltered = Object.fromEntries(
+    Object.entries(extracted).filter(([k, v]) => v != null && ALLOWED_KEYS.has(k))
+  );
+
+  return {
+    ...race,
+    id: newId,
+    full_name_ja: race.full_name_ja?.replace(currentYear, extractedYear) ?? race.full_name_ja,
+    full_name_en: race.full_name_en?.replace(currentYear, extractedYear) ?? race.full_name_en,
+    // 前年のエントリー情報をリセット（extractedで上書きされる場合を除く）
+    entry_start_date: null,
+    entry_end_date: null,
+    entry_periods: [],
+    // 前年の実績データをリセット
+    result: null,
+    weather_history: [],
+    gallery: [],
+    voices: [],
+    time_buckets: [],
+    // 抽出フィールドを適用（entry_start_date 等もここで復元される）
+    ...extractedFiltered,
+    created_at: now,
+    updated_at: now,
+    _metadata: {
+      ...race._metadata,
+      last_verified: today,
+      data_accuracy_notes: [
+        `${today}: 自動クロールで ${race.id} を元に${extractedYear}年大会ファイルを新規作成`,
+      ],
+    },
+  };
+}
+
+/**
+ * 次年度版の race JSON ファイルを新規作成する
+ * @param {object} race
+ * @param {object} extracted
+ * @returns {{ created: boolean, skipped: boolean, newId: string, filePath: string }}
+ */
+function createNewEditionFile(race, extracted) {
+  const newRace = buildNewEditionRace(race, extracted);
+  const filePath = path.join(RACES_DIR, `${newRace.id}.json`);
+
+  if (fs.existsSync(filePath)) {
+    return { created: false, skipped: true, newId: newRace.id, filePath };
+  }
+
+  fs.writeFileSync(filePath, JSON.stringify(newRace, null, 2) + '\n', 'utf-8');
+  return { created: true, skipped: false, newId: newRace.id, filePath };
+}
+
 // ── エクスポート ──────────────────────────────────────────────────
 
 module.exports = {
@@ -234,4 +299,6 @@ module.exports = {
   buildDiff,
   extractFromPages,
   applyAndSave,
+  buildNewEditionRace,
+  createNewEditionFile,
 };

--- a/tools/crawl/extractor.test.js
+++ b/tools/crawl/extractor.test.js
@@ -2,7 +2,7 @@
 
 const { test, describe } = require('node:test');
 const assert = require('node:assert/strict');
-const { buildExtractionPrompt, parseClaudeResponse, buildDiff, applyAndSave } = require('./extractor');
+const { buildExtractionPrompt, parseClaudeResponse, buildDiff, applyAndSave, buildNewEditionRace } = require('./extractor');
 
 // ── buildExtractionPrompt ─────────────────────────────────────────
 
@@ -320,5 +320,111 @@ describe('applyAndSave - 年度不一致チェック', () => {
     } catch {
       // fs書き込みエラーは許容
     }
+  });
+});
+
+// ── buildNewEditionRace ───────────────────────────────────────────
+
+describe('buildNewEditionRace', () => {
+  const race = {
+    id: 'tokyo-marathon-2026',
+    name_ja: '東京マラソン',
+    name_en: 'Tokyo Marathon',
+    full_name_ja: '東京マラソン2026',
+    full_name_en: 'Tokyo Marathon 2026',
+    date: '2026-03-01',
+    entry_start_date: '2025-08-01',
+    entry_end_date: '2025-10-31',
+    entry_fee: 16200,
+    entry_capacity: 38000,
+    entry_periods: [{ label_ja: '一般', start_date: '2025-08-01', end_date: '2025-10-31', entry_fee: null, category_id: null, sort_order: 0 }],
+    result: { finishers: 30000 },
+    weather_history: [{ year: 2026, temp: 10 }],
+    gallery: ['img1.jpg'],
+    voices: ['voice1'],
+    time_buckets: [{ bucket: '3:30', count: 100 }],
+    _metadata: { data_accuracy_notes: ['old note'], last_verified: '2026-01-01' },
+  };
+  const extracted = {
+    date: '2027-03-07',
+    entry_start_date: '2026-06-24',
+    entry_end_date: '2026-08-28',
+    entry_periods: [{ label_ja: '一般エントリー', label_en: 'General Entry', start_date: '2026-06-24', end_date: '2026-08-28', entry_fee: null, category_id: null, sort_order: 0 }],
+  };
+
+  test('新しいidは年を置換したもの', () => {
+    const newRace = buildNewEditionRace(race, extracted);
+    assert.equal(newRace.id, 'tokyo-marathon-2027');
+  });
+
+  test('full_name_jaの年を更新する', () => {
+    const newRace = buildNewEditionRace(race, extracted);
+    assert.equal(newRace.full_name_ja, '東京マラソン2027');
+  });
+
+  test('full_name_enの年を更新する', () => {
+    const newRace = buildNewEditionRace(race, extracted);
+    assert.equal(newRace.full_name_en, 'Tokyo Marathon 2027');
+  });
+
+  test('resultをnullにリセット', () => {
+    const newRace = buildNewEditionRace(race, extracted);
+    assert.equal(newRace.result, null);
+  });
+
+  test('weather_historyを空配列にリセット', () => {
+    const newRace = buildNewEditionRace(race, extracted);
+    assert.deepEqual(newRace.weather_history, []);
+  });
+
+  test('galleryを空配列にリセット', () => {
+    const newRace = buildNewEditionRace(race, extracted);
+    assert.deepEqual(newRace.gallery, []);
+  });
+
+  test('voicesを空配列にリセット', () => {
+    const newRace = buildNewEditionRace(race, extracted);
+    assert.deepEqual(newRace.voices, []);
+  });
+
+  test('time_bucketsを空配列にリセット', () => {
+    const newRace = buildNewEditionRace(race, extracted);
+    assert.deepEqual(newRace.time_buckets, []);
+  });
+
+  test('extractedのdateが適用される', () => {
+    const newRace = buildNewEditionRace(race, extracted);
+    assert.equal(newRace.date, '2027-03-07');
+  });
+
+  test('extractedのentry_start_dateが適用される', () => {
+    const newRace = buildNewEditionRace(race, extracted);
+    assert.equal(newRace.entry_start_date, '2026-06-24');
+  });
+
+  test('extractedのentry_periodsが適用される', () => {
+    const newRace = buildNewEditionRace(race, extracted);
+    assert.equal(newRace.entry_periods.length, 1);
+    assert.equal(newRace.entry_periods[0].label_ja, '一般エントリー');
+  });
+
+  test('extractedにentry_periodsがない場合は空配列', () => {
+    const newRace = buildNewEditionRace(race, { date: '2027-03-07' });
+    assert.deepEqual(newRace.entry_periods, []);
+  });
+
+  test('extractedにentry_start_dateがない場合はnull', () => {
+    const newRace = buildNewEditionRace(race, { date: '2027-03-07' });
+    assert.equal(newRace.entry_start_date, null);
+  });
+
+  test('metadataに新規作成ノートが追加される', () => {
+    const newRace = buildNewEditionRace(race, extracted);
+    assert.ok(newRace._metadata.data_accuracy_notes.some(n => n.includes('2027')));
+  });
+
+  test('metadataの旧ノートは引き継がない（新規作成なのでリセット）', () => {
+    const newRace = buildNewEditionRace(race, extracted);
+    assert.ok(!newRace._metadata.data_accuracy_notes.includes('old note'));
   });
 });

--- a/tools/crawl/extractor.test.js
+++ b/tools/crawl/extractor.test.js
@@ -2,7 +2,7 @@
 
 const { test, describe } = require('node:test');
 const assert = require('node:assert/strict');
-const { buildExtractionPrompt, parseClaudeResponse, buildDiff } = require('./extractor');
+const { buildExtractionPrompt, parseClaudeResponse, buildDiff, applyAndSave } = require('./extractor');
 
 // ── buildExtractionPrompt ─────────────────────────────────────────
 
@@ -252,5 +252,73 @@ describe('buildDiff - 複合フィールド', () => {
     const entry = diff.find(d => d.key === 'nearby_spots');
     assert.ok(entry);
     assert.equal(entry.changed, true);
+  });
+});
+
+// ── applyAndSave - 年度不一致チェック ────────────────────────────────
+
+describe('applyAndSave - 年度不一致チェック', () => {
+  const race = {
+    id: 'tokyo-marathon-2026',
+    name_ja: '東京マラソン',
+    date: '2026-03-01',
+    entry_start_date: '2025-08-01',
+    entry_end_date: '2025-10-31',
+    entry_fee: 16200,
+    entry_capacity: 38000,
+    _metadata: { data_accuracy_notes: [], last_verified: '2026-01-01' },
+  };
+
+  test('extractedの年度がrace.dateの年度と異なる場合はyearMismatch=trueを返す', () => {
+    const extracted = { date: '2027-03-01' };
+    const result = applyAndSave(race, extracted);
+    assert.equal(result.yearMismatch, true);
+  });
+
+  test('年度不一致時はcurrentYearとextractedYearを返す', () => {
+    const extracted = { date: '2027-03-01' };
+    const result = applyAndSave(race, extracted);
+    assert.equal(result.currentYear, '2026');
+    assert.equal(result.extractedYear, '2027');
+  });
+
+  test('年度不一致時はsuggestedFileを返す（race.idの年を置換）', () => {
+    const extracted = { date: '2027-03-01' };
+    const result = applyAndSave(race, extracted);
+    assert.equal(result.suggestedFile, 'tokyo-marathon-2027.json');
+  });
+
+  test('extractedにdateがない場合はyearMismatchにならない', () => {
+    const extracted = { entry_fee: 17000 };
+    // ファイル書き込みが起きるため、実在しないidで呼ぶとエラーになる可能性あり
+    // → yearMismatch のパスに入らないことだけを確認
+    // (ファイル書き込みエラーは無視、yearMismatchプロパティがないことを確認)
+    try {
+      const result = applyAndSave(race, extracted);
+      assert.ok(!result.yearMismatch);
+    } catch {
+      // fs書き込みエラーは許容（年度チェックはパスした証拠）
+    }
+  });
+
+  test('extractedの年度がrace.dateと同じ場合はyearMismatchにならない', () => {
+    const extracted = { date: '2026-09-01' };
+    try {
+      const result = applyAndSave(race, extracted);
+      assert.ok(!result.yearMismatch);
+    } catch {
+      // fs書き込みエラーは許容
+    }
+  });
+
+  test('race.dateがnullの場合はyearMismatchにならない', () => {
+    const raceNoDate = { ...race, date: null };
+    const extracted = { date: '2027-03-01' };
+    try {
+      const result = applyAndSave(raceNoDate, extracted);
+      assert.ok(!result.yearMismatch);
+    } catch {
+      // fs書き込みエラーは許容
+    }
   });
 });

--- a/tools/crawl/index.js
+++ b/tools/crawl/index.js
@@ -114,7 +114,9 @@ function cleanHtml(html) {
 async function fetchPageText(url) {
   const res = await fetch(url, { ...FETCH_OPTS, signal: AbortSignal.timeout(15000) });
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  return cleanHtml(await res.text());
+  const text = cleanHtml(await res.text());
+  if (text.length < 100) throw new Error('ページコンテンツが空または短すぎます（スキップ）');
+  return text;
 }
 
 // ── クロール ─────────────────────────────────────────────────────

--- a/tools/crawl/index.js
+++ b/tools/crawl/index.js
@@ -154,12 +154,13 @@ async function run(options = {}) {
     .sort();
 
   const summary = {
-    changed: [],    // { race_id, url }
-    new: [],        // { race_id, url }
+    changed: [],         // { race_id, url }
+    new: [],             // { race_id, url }
     unchanged: 0,
-    skipped: 0,     // info_urls も official_url もない
-    errors: [],     // { race_id, url, error }
-    extracted: [],  // { race_id, diff } LLM抽出で変更が見つかったもの
+    skipped: 0,          // info_urls も official_url もない
+    errors: [],          // { race_id, url, error }
+    extracted: [],       // { race_id, diff } LLM抽出で変更が見つかったもの
+    year_mismatches: [], // { race_id, currentYear, extractedYear, suggestedFile }
   };
 
   // 変更が検出されたレースを収集（LLM抽出用）
@@ -234,7 +235,18 @@ async function run(options = {}) {
         }
 
         if (!dryRun) {
-          applyAndSave(race, extracted);
+          const saveResult = applyAndSave(race, extracted);
+          if (saveResult.yearMismatch) {
+            console.log(`  ⚠ 年度不一致: ${race.id} (現在:${saveResult.currentYear} → 抽出:${saveResult.extractedYear})`);
+            console.log(`    手動対応が必要: src/data/races/${saveResult.suggestedFile} を新規作成してください`);
+            summary.year_mismatches.push({
+              race_id: race.id,
+              currentYear: saveResult.currentYear,
+              extractedYear: saveResult.extractedYear,
+              suggestedFile: saveResult.suggestedFile,
+            });
+            continue;
+          }
           console.log(`  → ${race.id}.json を更新しました`);
         }
 
@@ -253,11 +265,20 @@ async function run(options = {}) {
   console.log(`LLM更新  : ${summary.extracted.length}件`);
   console.log(`エラー   : ${summary.errors.length}件`);
   console.log(`スキップ : ${summary.skipped}件（URL未設定）`);
+  console.log(`年度不一致: ${summary.year_mismatches.length}件（手動対応要）`);
 
   if (summary.extracted.length > 0) {
     console.log('\n--- 更新されたレース ---');
     for (const item of summary.extracted) {
       console.log(`  ${item.race_id}: ${item.diff.map(d => d.label).join(', ')}`);
+    }
+  }
+
+  if (summary.year_mismatches.length > 0) {
+    console.log('\n--- ⚠ 年度不一致（手動対応要） ---');
+    for (const item of summary.year_mismatches) {
+      console.log(`  ${item.race_id}: ${item.currentYear}年 → ${item.extractedYear}年`);
+      console.log(`    → src/data/races/${item.suggestedFile} を新規作成してください`);
     }
   }
 

--- a/tools/crawl/index.js
+++ b/tools/crawl/index.js
@@ -19,7 +19,7 @@ const ROOT = path.join(__dirname, '../..');
 const RACES_DIR = path.join(ROOT, 'src/data/races');
 const CHECKSUMS_FILE = path.join(__dirname, 'checksums.json');
 
-const { extractFromPages, applyAndSave, buildDiff } = require('./extractor');
+const { extractFromPages, applyAndSave, buildDiff, createNewEditionFile } = require('./extractor');
 
 const FETCH_OPTS = {
   headers: {
@@ -57,6 +57,26 @@ function buildUrlsToCheck(race) {
     return race.info_urls.map(u => u.url);
   }
   return race.official_url ? [race.official_url] : [];
+}
+
+/**
+ * ファイルリストからシリーズごとに最新年のファイルのみ返す
+ * 例: ['tokyo-marathon-2026.json', 'tokyo-marathon-2027.json'] → ['tokyo-marathon-2027.json']
+ * @param {string[]} files - JSONファイル名の配列（index.json は除外済み前提）
+ * @returns {string[]} ソート済みの最新ファイル一覧
+ */
+function getLatestFilesPerSeries(files) {
+  const map = new Map(); // series → { file, year }
+  for (const file of files) {
+    const match = file.match(/^(.+)-(\d{4})\.json$/);
+    if (!match) continue;
+    const [, series, year] = match;
+    const existing = map.get(series);
+    if (!existing || year > existing.year) {
+      map.set(series, { file, year });
+    }
+  }
+  return [...map.values()].map(v => v.file).sort();
 }
 
 // ── I/O ──────────────────────────────────────────────────────────
@@ -149,24 +169,26 @@ async function run(options = {}) {
   const dryRun = options.dryRun ?? false;
 
   const checksums = loadChecksums();
-  const files = fs.readdirSync(RACES_DIR)
+  const allFiles = fs.readdirSync(RACES_DIR)
     .filter(f => f.endsWith('.json') && f !== 'index.json')
     .sort();
+  const files = getLatestFilesPerSeries(allFiles);
+  const skippedBySeries = allFiles.length - files.length;
 
   const summary = {
-    changed: [],         // { race_id, url }
-    new: [],             // { race_id, url }
+    changed: [],       // { race_id, url }
+    new: [],           // { race_id, url }
     unchanged: 0,
-    skipped: 0,          // info_urls も official_url もない
-    errors: [],          // { race_id, url, error }
-    extracted: [],       // { race_id, diff } LLM抽出で変更が見つかったもの
-    year_mismatches: [], // { race_id, currentYear, extractedYear, suggestedFile }
+    skipped: 0,        // info_urls も official_url もない
+    errors: [],        // { race_id, url, error }
+    extracted: [],     // { race_id, diff } LLM抽出で変更が見つかったもの
+    new_editions: [],  // { race_id, new_race_id } 次年度ファイルを自動作成したもの
   };
 
   // 変更が検出されたレースを収集（LLM抽出用）
   const changedRaces = [];
 
-  console.log(`[crawl] ${files.length}件のレースをチェックします${dryRun ? ' (dry-run)' : ''}\n`);
+  console.log(`[crawl] ${files.length}件のレースをチェックします（${skippedBySeries}件は旧年度のためスキップ）${dryRun ? ' (dry-run)' : ''}\n`);
 
   for (const file of files) {
     const race = JSON.parse(fs.readFileSync(path.join(RACES_DIR, file), 'utf-8'));
@@ -237,14 +259,14 @@ async function run(options = {}) {
         if (!dryRun) {
           const saveResult = applyAndSave(race, extracted);
           if (saveResult.yearMismatch) {
-            console.log(`  ⚠ 年度不一致: ${race.id} (現在:${saveResult.currentYear} → 抽出:${saveResult.extractedYear})`);
-            console.log(`    手動対応が必要: src/data/races/${saveResult.suggestedFile} を新規作成してください`);
-            summary.year_mismatches.push({
-              race_id: race.id,
-              currentYear: saveResult.currentYear,
-              extractedYear: saveResult.extractedYear,
-              suggestedFile: saveResult.suggestedFile,
-            });
+            console.log(`  次年度大会を検出: ${race.id} (${saveResult.currentYear} → ${saveResult.extractedYear})`);
+            const createResult = createNewEditionFile(race, extracted);
+            if (createResult.created) {
+              console.log(`  → 新規ファイル作成: src/data/races/${createResult.newId}.json`);
+              summary.new_editions.push({ race_id: race.id, new_race_id: createResult.newId });
+            } else {
+              console.log(`  → ${createResult.newId}.json は既に存在するためスキップ`);
+            }
             continue;
           }
           console.log(`  → ${race.id}.json を更新しました`);
@@ -263,9 +285,9 @@ async function run(options = {}) {
   console.log(`新規     : ${summary.new.length}件`);
   console.log(`変更なし : ${summary.unchanged}件`);
   console.log(`LLM更新  : ${summary.extracted.length}件`);
+  console.log(`新年度作成: ${summary.new_editions.length}件`);
   console.log(`エラー   : ${summary.errors.length}件`);
   console.log(`スキップ : ${summary.skipped}件（URL未設定）`);
-  console.log(`年度不一致: ${summary.year_mismatches.length}件（手動対応要）`);
 
   if (summary.extracted.length > 0) {
     console.log('\n--- 更新されたレース ---');
@@ -274,11 +296,10 @@ async function run(options = {}) {
     }
   }
 
-  if (summary.year_mismatches.length > 0) {
-    console.log('\n--- ⚠ 年度不一致（手動対応要） ---');
-    for (const item of summary.year_mismatches) {
-      console.log(`  ${item.race_id}: ${item.currentYear}年 → ${item.extractedYear}年`);
-      console.log(`    → src/data/races/${item.suggestedFile} を新規作成してください`);
+  if (summary.new_editions.length > 0) {
+    console.log('\n--- 次年度ファイル作成 ---');
+    for (const item of summary.new_editions) {
+      console.log(`  ${item.race_id} → src/data/races/${item.new_race_id}.json`);
     }
   }
 
@@ -294,5 +315,5 @@ if (require.main === module) {
     process.exit(1);
   });
 } else {
-  module.exports = { computeHash, hasChanged, buildUrlsToCheck };
+  module.exports = { computeHash, hasChanged, buildUrlsToCheck, getLatestFilesPerSeries };
 }

--- a/tools/crawl/index.test.js
+++ b/tools/crawl/index.test.js
@@ -2,7 +2,7 @@
 
 const { test, describe } = require('node:test');
 const assert = require('node:assert/strict');
-const { computeHash, hasChanged, buildUrlsToCheck } = require('./index');
+const { computeHash, hasChanged, buildUrlsToCheck, getLatestFilesPerSeries } = require('./index');
 
 // ── computeHash ───────────────────────────────────────────────────
 
@@ -83,5 +83,57 @@ describe('buildUrlsToCheck', () => {
   test('official_url が空文字なら空配列を返す', () => {
     const race = { id: 'test-2026', official_url: '' };
     assert.deepEqual(buildUrlsToCheck(race), []);
+  });
+});
+
+// ── getLatestFilesPerSeries ───────────────────────────────────────
+
+describe('getLatestFilesPerSeries', () => {
+  test('同一シリーズに複数年がある場合は最新年のみ返す', () => {
+    const files = ['tokyo-marathon-2026.json', 'tokyo-marathon-2027.json'];
+    const result = getLatestFilesPerSeries(files);
+    assert.deepEqual(result, ['tokyo-marathon-2027.json']);
+  });
+
+  test('異なるシリーズはそれぞれ返す', () => {
+    const files = ['kyoto-marathon-2027.json', 'tokyo-marathon-2027.json'];
+    const result = getLatestFilesPerSeries(files);
+    assert.deepEqual(result, ['kyoto-marathon-2027.json', 'tokyo-marathon-2027.json']);
+  });
+
+  test('シリーズが混在する場合は各シリーズの最新のみ返す', () => {
+    const files = [
+      'ehime-marathon-2026.json',
+      'ehime-marathon-2027.json',
+      'tokyo-marathon-2026.json',
+      'tokyo-marathon-2027.json',
+      'kyoto-marathon-2027.json',
+    ];
+    const result = getLatestFilesPerSeries(files);
+    assert.deepEqual(result, [
+      'ehime-marathon-2027.json',
+      'kyoto-marathon-2027.json',
+      'tokyo-marathon-2027.json',
+    ]);
+  });
+
+  test('単独のファイルはそのまま返す', () => {
+    const files = ['saitama-marathon-2026.json'];
+    const result = getLatestFilesPerSeries(files);
+    assert.deepEqual(result, ['saitama-marathon-2026.json']);
+  });
+
+  test('結果はソートされている', () => {
+    const files = ['tokyo-marathon-2026.json', 'kyoto-marathon-2026.json', 'ehime-marathon-2026.json'];
+    const result = getLatestFilesPerSeries(files);
+    assert.deepEqual(result, [
+      'ehime-marathon-2026.json',
+      'kyoto-marathon-2026.json',
+      'tokyo-marathon-2026.json',
+    ]);
+  });
+
+  test('空配列を渡すと空配列を返す', () => {
+    assert.deepEqual(getLatestFilesPerSeries([]), []);
   });
 });


### PR DESCRIPTION
## Summary

### レースデータ 新規作成
- `saitama-marathon-2027`: 2027-02-14開催・定員14000人・参加費15000円。優先エントリー（市民/2026参加者）・一般エントリーの2区分
- `ehime-marathon-2027`: 2027年大会を前年ファイルから分離して新規作成

### レースデータ 更新
- `ehime-marathon-2026`: entry_periods を3区分に拡充（アスリート / ネットタイムアスリート / ランナーボランティア）
- `hokkaido-marathon-2026`: certification に WA・AIMS 追加、highlights を詳細化
- `kagawa-marathon-2026`: certification に JAAF 追加、参加賞（tshirt）・完走賞（medal+towel）を正しく分離して追加
- `kobe-marathon-2026` / `osaka-yodo-river-citizens-marathon-2026`: entry_periods の label 空文字を修正
- `tokyo-marathon-2027`: チャリティランナー・準エリートを含む4区分に拡充、entry_start_date を 2026-06-24 に更新、updated_at の時刻逆転を修正

### crawlコード改善 (`tools/crawl/`)

#### 年度不一致の自動検出・次年度ファイル自動作成
- `applyAndSave()` に年度チェックを追加: extracted.date の年が race.date の年と異なる場合はファイルを上書きせず `yearMismatch` を返す
- `buildNewEditionRace()` 追加: 旧年度ファイルを元に次年度レースオブジェクトを構築（純粋関数）
  - id・full_name の年を置換
  - entry_start/end_date・entry_periods をリセット（抽出データで上書き可）
  - result・weather_history・gallery・voices・time_buckets をリセット
- `createNewEditionFile()` 追加: 次年度ファイルを自動新規作成（既存ファイルがあればスキップ）

#### 最新年度のみクロール対象に絞り込み
- `getLatestFilesPerSeries()` 追加: 同一シリーズ（例: tokyo-marathon）の複数年ファイルから最新年のみを返す
- 旧年度ファイル（例: tokyo-marathon-2026 と 2027 が共存する場合は 2026）はクロールをスキップ

#### 空レスポンスのハッシュ保存を防止
- `fetchPageText()` でクリーン後テキストが100文字未満の場合にエラーをスロー
- 静岡・筑波で発生していた空コンテンツのSHA-256（`e3b0c44...`）保存を防止

## Test plan
- [ ] `pnpm run dev` でエラーなく起動
- [ ] さいたまマラソン2027の詳細ページが正常に表示される
- [ ] 東京マラソン2027のエントリー区分が4つ表示される
- [ ] `node --test tools/crawl/extractor.test.js` 全50件通過
- [ ] `node --test tools/crawl/index.test.js` 全19件通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)