### PR TITLE
feat: 会場・アクセスデータ基盤の整備（Issue #80）

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -428,3 +428,4 @@ ER図は `docs/er-diagram.drawio` で管理しています。[draw.io](https://a
 | `migrations/0009_shallow_captain_stacy.sql` | completion_gifts テーブルを追加（Issue #73）。medal 等の完走賞を participation_gifts から分離 |
 | `migrations/0010_loving_mister_fear.sql` | race_entry_periods.end_date の NOT NULL 制約を削除（終了日未定のエントリー期間を許容） |
 | `migrations/0011_parallel_winter_soldier.sql` | races に venue_name_ja/venue_name_en/venue_address/start_lat/start_lng を追加。access_points に walk_minutes/is_primary を追加（Issue #80） |
+| `migrations/0012_fearless_sleeper.sql` | access_points に partial unique index を追加（race_id + is_primary=1 の組み合わせを一意制約）（Issue #80） |

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -60,6 +60,11 @@ ER図は `docs/er-diagram.drawio` で管理しています。[draw.io](https://a
 | hero_image_url | text | YES | — | ヒーロー画像パス。例: `/images/races/nagano-marathon-2026-hero.jpg` |
 | hero_caption_ja | text | YES | — | ヒーロー画像キャプション（日本語） |
 | hero_caption_en | text | YES | — | ヒーロー画像キャプション（英語） |
+| venue_name_ja | text | YES | — | スタート地点名称（例: `"神戸市役所前"`）。Issue #80 |
+| venue_name_en | text | YES | — | |
+| venue_address | text | YES | — | ジオコーディング・経路検索の宛先。Issue #80 |
+| start_lat | real | YES | — | スタート地点緯度。Issue #80 |
+| start_lng | real | YES | — | スタート地点経度。Issue #80 |
 | created_at | text | NO | — | ISO 8601 |
 | updated_at | text | NO | — | ISO 8601 |
 
@@ -127,6 +132,8 @@ ER図は `docs/er-diagram.drawio` で管理しています。[draw.io](https://a
 | transport_to_venue_en | text | NO | `""` | |
 | latitude | real | NO | `0` | |
 | longitude | real | NO | `0` | |
+| walk_minutes | integer | YES | — | 駅から会場までの徒歩分数。Issue #80 |
+| is_primary | integer(bool) | NO | `false` | 代表最寄駅フラグ（前泊判定・旅程で使用）。Issue #80 |
 | sort_order | integer | NO | `0` | |
 
 ---
@@ -420,3 +427,4 @@ ER図は `docs/er-diagram.drawio` で管理しています。[draw.io](https://a
 | `migrations/0010_fix_course_highlights_fk.sql` | race_course_highlights.category_id FK を ON DELETE CASCADE に修正（schema.ts との整合） |
 | `migrations/0009_shallow_captain_stacy.sql` | completion_gifts テーブルを追加（Issue #73）。medal 等の完走賞を participation_gifts から分離 |
 | `migrations/0010_loving_mister_fear.sql` | race_entry_periods.end_date の NOT NULL 制約を削除（終了日未定のエントリー期間を許容） |
+| `migrations/0011_parallel_winter_soldier.sql` | races に venue_name_ja/venue_name_en/venue_address/start_lat/start_lng を追加。access_points に walk_minutes/is_primary を追加（Issue #80） |

--- a/docs/update-history.md
+++ b/docs/update-history.md
@@ -714,3 +714,18 @@
 - `migrations/0010_loving_mister_fear.sql`: テーブル再作成によるマイグレーション生成
 - `docs/schema.md`: マイグレーション履歴に追記
 - ローカル・リモートDBへのマイグレーション適用・シード再適用完了
+
+
+## 2026-07-05 会場・アクセスデータ基盤の整備（Issue #80）
+
+- `src/lib/db/schema.ts`: `races` に `venue_name_ja` / `venue_name_en` / `venue_address` / `start_lat` / `start_lng` を追加。`access_points` に `walk_minutes` / `is_primary` を追加
+- `migrations/0011_parallel_winter_soldier.sql`: Drizzle生成マイグレーション。ローカルD1に適用済み
+- `src/lib/types.ts`: `Race` / `AccessPoint` 型に新フィールドを追加
+- `src/lib/__tests__/fixtures.ts`: `makeRace` / `makeAccessPoint` に新フィールドを追加
+- `src/lib/data.ts`: `rowToRace` / `rowToAccessPoint` に新フィールドを追加
+- `scripts/add-venue-fields.js`: 全89 JSONに新フィールド（null）を一括追加するスクリプトを新規作成・実行済み
+- `scripts/generate-seed-races.js`: races INSERT と access_points INSERT に新カラムを追加
+- `migrations/seed-races-all.sql`: シード再生成済み。ローカルD1に適用済み
+- `tools/admin-server.js`: `getMissingFields` に venue_address / start_coords / access_point_primary のチェックを追加。新規レーステンプレートに venue フィールドを追加
+- `tools/admin-server.test.js`: 会場住所・座標・代表最寄駅チェックのテストを追加（53テスト全Pass）
+- `docs/schema.md`: races / access_points テーブル定義とマイグレーション履歴を更新

--- a/migrations/0011_parallel_winter_soldier.sql
+++ b/migrations/0011_parallel_winter_soldier.sql
@@ -1,0 +1,7 @@
+ALTER TABLE `access_points` ADD `walk_minutes` integer;--> statement-breakpoint
+ALTER TABLE `access_points` ADD `is_primary` integer DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE `races` ADD `venue_name_ja` text;--> statement-breakpoint
+ALTER TABLE `races` ADD `venue_name_en` text;--> statement-breakpoint
+ALTER TABLE `races` ADD `venue_address` text;--> statement-breakpoint
+ALTER TABLE `races` ADD `start_lat` real;--> statement-breakpoint
+ALTER TABLE `races` ADD `start_lng` real;

--- a/migrations/0012_fearless_sleeper.sql
+++ b/migrations/0012_fearless_sleeper.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX `access_points_primary_unique_idx` ON `access_points` (`race_id`,`is_primary`) WHERE "access_points"."is_primary" = 1;

--- a/migrations/meta/0011_snapshot.json
+++ b/migrations/meta/0011_snapshot.json
@@ -1,0 +1,2658 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "0a5d9a9e-4487-42e7-b7b5-ed8f22afecbd",
+  "prevId": "430df8f0-74bc-4db9-b2cc-a7f69fa3c5c7",
+  "tables": {
+    "access_points": {
+      "name": "access_points",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "station_name_ja": {
+          "name": "station_name_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "station_name_en": {
+          "name": "station_name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "station_code": {
+          "name": "station_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "transport_to_venue_ja": {
+          "name": "transport_to_venue_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "transport_to_venue_en": {
+          "name": "transport_to_venue_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "walk_minutes": {
+          "name": "walk_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "access_points_race_id_idx": {
+          "name": "access_points_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "access_points_race_id_races_id_fk": {
+          "name": "access_points_race_id_races_id_fk",
+          "tableFrom": "access_points",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "aid_stations": {
+      "name": "aid_stations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "distance_km": {
+          "name": "distance_km",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "offerings_ja": {
+          "name": "offerings_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "offerings_en": {
+          "name": "offerings_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "aid_stations_race_id_idx": {
+          "name": "aid_stations_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "aid_stations_race_id_races_id_fk": {
+          "name": "aid_stations_race_id_races_id_fk",
+          "tableFrom": "aid_stations",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "checkpoints": {
+      "name": "checkpoints",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "distance_km": {
+          "name": "distance_km",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "closing_time": {
+          "name": "closing_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "checkpoints_race_id_idx": {
+          "name": "checkpoints_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "checkpoints_race_id_races_id_fk": {
+          "name": "checkpoints_race_id_races_id_fk",
+          "tableFrom": "checkpoints",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "completion_gifts": {
+      "name": "completion_gifts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gift_categories": {
+          "name": "gift_categories",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "description_ja": {
+          "name": "description_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description_en": {
+          "name": "description_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "completion_gifts_race_id_idx": {
+          "name": "completion_gifts_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "completion_gifts_race_id_races_id_fk": {
+          "name": "completion_gifts_race_id_races_id_fk",
+          "tableFrom": "completion_gifts",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "contact_submissions": {
+      "name": "contact_submissions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "contact_submissions_status_idx": {
+          "name": "contact_submissions_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "contact_submissions_created_at_idx": {
+          "name": "contact_submissions_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "contact_submissions_user_id_user_id_fk": {
+          "name": "contact_submissions_user_id_user_id_fk",
+          "tableFrom": "contact_submissions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gift_categories": {
+      "name": "gift_categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_ja": {
+          "name": "name_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_en": {
+          "name": "name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "nearby_spots": {
+      "name": "nearby_spots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_ja": {
+          "name": "name_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_en": {
+          "name": "name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description_ja": {
+          "name": "description_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description_en": {
+          "name": "description_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "distance_from_venue": {
+          "name": "distance_from_venue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "nearby_spots_race_id_idx": {
+          "name": "nearby_spots_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "nearby_spots_race_id_races_id_fk": {
+          "name": "nearby_spots_race_id_races_id_fk",
+          "tableFrom": "nearby_spots",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "participation_gifts": {
+      "name": "participation_gifts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gift_categories": {
+          "name": "gift_categories",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "description_ja": {
+          "name": "description_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description_en": {
+          "name": "description_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "participation_gifts_race_id_idx": {
+          "name": "participation_gifts_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "participation_gifts_race_id_races_id_fk": {
+          "name": "participation_gifts_race_id_races_id_fk",
+          "tableFrom": "participation_gifts",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkey": {
+      "name": "passkey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "webAuthnUserID": {
+          "name": "webAuthnUserID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deviceType": {
+          "name": "deviceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backedUp": {
+          "name": "backedUp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "passkey_userId_user_id_fk": {
+          "name": "passkey_userId_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prefectures": {
+      "name": "prefectures",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_en": {
+          "name": "name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region_en": {
+          "name": "region_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lat": {
+          "name": "lat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lng": {
+          "name": "lng",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_categories": {
+      "name": "race_categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "distance_type": {
+          "name": "distance_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "distance_km": {
+          "name": "distance_km",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "time_limit_minutes": {
+          "name": "time_limit_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "entry_fee": {
+          "name": "entry_fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_fee_u25": {
+          "name": "entry_fee_u25",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name_ja": {
+          "name": "name_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name_en": {
+          "name": "name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description_ja": {
+          "name": "description_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description_en": {
+          "name": "description_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "eligibility_ja": {
+          "name": "eligibility_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "eligibility_en": {
+          "name": "eligibility_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "course_gpx_file": {
+          "name": "course_gpx_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "waves": {
+          "name": "waves",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "race_categories_race_id_idx": {
+          "name": "race_categories_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_categories_race_id_races_id_fk": {
+          "name": "race_categories_race_id_races_id_fk",
+          "tableFrom": "race_categories",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_course_highlights": {
+      "name": "race_course_highlights",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "km": {
+          "name": "km",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name_ja": {
+          "name": "name_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_en": {
+          "name": "name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note_ja": {
+          "name": "note_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note_en": {
+          "name": "note_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "race_course_highlights_race_id_idx": {
+          "name": "race_course_highlights_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_course_highlights_race_id_races_id_fk": {
+          "name": "race_course_highlights_race_id_races_id_fk",
+          "tableFrom": "race_course_highlights",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "race_course_highlights_category_id_race_categories_id_fk": {
+          "name": "race_course_highlights_category_id_race_categories_id_fk",
+          "tableFrom": "race_course_highlights",
+          "tableTo": "race_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_entry_links": {
+      "name": "race_entry_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "race_entry_links_race_id_idx": {
+          "name": "race_entry_links_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_entry_links_race_id_races_id_fk": {
+          "name": "race_entry_links_race_id_races_id_fk",
+          "tableFrom": "race_entry_links",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_entry_periods": {
+      "name": "race_entry_periods",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "label_ja": {
+          "name": "label_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'一般エントリー'"
+        },
+        "label_en": {
+          "name": "label_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'General Entry'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_fee": {
+          "name": "entry_fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "race_entry_periods_race_id_idx": {
+          "name": "race_entry_periods_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_entry_periods_race_id_races_id_fk": {
+          "name": "race_entry_periods_race_id_races_id_fk",
+          "tableFrom": "race_entry_periods",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "race_entry_periods_category_id_race_categories_id_fk": {
+          "name": "race_entry_periods_category_id_race_categories_id_fk",
+          "tableFrom": "race_entry_periods",
+          "tableTo": "race_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_gallery": {
+      "name": "race_gallery",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "src": {
+          "name": "src",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caption_ja": {
+          "name": "caption_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "caption_en": {
+          "name": "caption_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "race_gallery_race_id_idx": {
+          "name": "race_gallery_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_gallery_race_id_races_id_fk": {
+          "name": "race_gallery_race_id_races_id_fk",
+          "tableFrom": "race_gallery",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_results": {
+      "name": "race_results",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "participants_count": {
+          "name": "participants_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finishers_count": {
+          "name": "finishers_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finisher_rate_pct": {
+          "name": "finisher_rate_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "weather_condition_ja": {
+          "name": "weather_condition_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "weather_condition_en": {
+          "name": "weather_condition_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "temperature_c": {
+          "name": "temperature_c",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_temp_c": {
+          "name": "max_temp_c",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "min_temp_c": {
+          "name": "min_temp_c",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "wind_speed_ms": {
+          "name": "wind_speed_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "humidity_pct": {
+          "name": "humidity_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes_ja": {
+          "name": "notes_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes_en": {
+          "name": "notes_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avg_time": {
+          "name": "avg_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "race_results_race_id_idx": {
+          "name": "race_results_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_results_race_id_races_id_fk": {
+          "name": "race_results_race_id_races_id_fk",
+          "tableFrom": "race_results",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_series": {
+      "name": "race_series",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_ja": {
+          "name": "name_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_en": {
+          "name": "name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_held_year": {
+          "name": "first_held_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_time_buckets": {
+      "name": "race_time_buckets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pct": {
+          "name": "pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "race_time_buckets_race_id_idx": {
+          "name": "race_time_buckets_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_time_buckets_race_id_races_id_fk": {
+          "name": "race_time_buckets_race_id_races_id_fk",
+          "tableFrom": "race_time_buckets",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_voices": {
+      "name": "race_voices",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quote_ja": {
+          "name": "quote_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quote_en": {
+          "name": "quote_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "race_voices_race_id_idx": {
+          "name": "race_voices_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_voices_race_id_races_id_fk": {
+          "name": "race_voices_race_id_races_id_fk",
+          "tableFrom": "race_voices",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "races": {
+      "name": "races",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_ja": {
+          "name": "name_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_en": {
+          "name": "name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "full_name_ja": {
+          "name": "full_name_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "full_name_en": {
+          "name": "full_name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "edition": {
+          "name": "edition",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prefecture": {
+          "name": "prefecture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "city_ja": {
+          "name": "city_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "city_en": {
+          "name": "city_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description_ja": {
+          "name": "description_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description_en": {
+          "name": "description_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "official_url": {
+          "name": "official_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "entry_fee": {
+          "name": "entry_fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_fee_by_category": {
+          "name": "entry_fee_by_category",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "entry_capacity": {
+          "name": "entry_capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "entry_start_date": {
+          "name": "entry_start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_end_date": {
+          "name": "entry_end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_closed": {
+          "name": "entry_closed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "reception_type": {
+          "name": "reception_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'race_day'"
+        },
+        "reception_note_ja": {
+          "name": "reception_note_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "reception_note_en": {
+          "name": "reception_note_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "course_gpx_file": {
+          "name": "course_gpx_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "course_max_elevation_m": {
+          "name": "course_max_elevation_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "course_min_elevation_m": {
+          "name": "course_min_elevation_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "course_elevation_diff_m": {
+          "name": "course_elevation_diff_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "course_surface": {
+          "name": "course_surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'road'"
+        },
+        "course_certification": {
+          "name": "course_certification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "course_highlights_ja": {
+          "name": "course_highlights_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "course_highlights_en": {
+          "name": "course_highlights_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "course_notes_ja": {
+          "name": "course_notes_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "course_notes_en": {
+          "name": "course_notes_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "venue_name_ja": {
+          "name": "venue_name_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "venue_name_en": {
+          "name": "venue_name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "venue_address": {
+          "name": "venue_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_lat": {
+          "name": "start_lat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_lng": {
+          "name": "start_lng",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "motif": {
+          "name": "motif",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "motif_color": {
+          "name": "motif_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "motif_romaji": {
+          "name": "motif_romaji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tagline_ja": {
+          "name": "tagline_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tagline_en": {
+          "name": "tagline_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hero_image_url": {
+          "name": "hero_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hero_caption_ja": {
+          "name": "hero_caption_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hero_caption_en": {
+          "name": "hero_caption_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "races_date_idx": {
+          "name": "races_date_idx",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        },
+        "races_prefecture_idx": {
+          "name": "races_prefecture_idx",
+          "columns": [
+            "prefecture"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "races_series_id_race_series_id_fk": {
+          "name": "races_series_id_race_series_id_fk",
+          "tableFrom": "races",
+          "tableTo": "race_series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_races": {
+      "name": "user_races",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_planning": {
+          "name": "is_planning",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "planning_category_id": {
+          "name": "planning_category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_reminder_period_ids": {
+          "name": "entry_reminder_period_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_races_user_id_idx": {
+          "name": "user_races_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "user_races_race_id_idx": {
+          "name": "user_races_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        },
+        "user_races_user_race_idx": {
+          "name": "user_races_user_race_idx",
+          "columns": [
+            "user_id",
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_races_user_id_user_id_fk": {
+          "name": "user_races_user_id_user_id_fk",
+          "tableFrom": "user_races",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_races_race_id_races_id_fk": {
+          "name": "user_races_race_id_races_id_fk",
+          "tableFrom": "user_races",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_races_planning_category_id_race_categories_id_fk": {
+          "name": "user_races_planning_category_id_race_categories_id_fk",
+          "tableFrom": "user_races",
+          "tableTo": "race_categories",
+          "columnsFrom": [
+            "planning_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "weather_history": {
+      "name": "weather_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avg_temp": {
+          "name": "avg_temp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "max_temp": {
+          "name": "max_temp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "min_temp": {
+          "name": "min_temp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "humidity_pct": {
+          "name": "humidity_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "precipitation_mm": {
+          "name": "precipitation_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "wind_speed_ms": {
+          "name": "wind_speed_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "weather_history_race_id_idx": {
+          "name": "weather_history_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "weather_history_race_id_races_id_fk": {
+          "name": "weather_history_race_id_races_id_fk",
+          "tableFrom": "weather_history",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/0012_snapshot.json
+++ b/migrations/meta/0012_snapshot.json
@@ -1,0 +1,2667 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "201b0359-90e9-427f-80b2-0a1999c82225",
+  "prevId": "0a5d9a9e-4487-42e7-b7b5-ed8f22afecbd",
+  "tables": {
+    "access_points": {
+      "name": "access_points",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "station_name_ja": {
+          "name": "station_name_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "station_name_en": {
+          "name": "station_name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "station_code": {
+          "name": "station_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "transport_to_venue_ja": {
+          "name": "transport_to_venue_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "transport_to_venue_en": {
+          "name": "transport_to_venue_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "walk_minutes": {
+          "name": "walk_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "access_points_race_id_idx": {
+          "name": "access_points_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        },
+        "access_points_primary_unique_idx": {
+          "name": "access_points_primary_unique_idx",
+          "columns": [
+            "race_id",
+            "is_primary"
+          ],
+          "isUnique": true,
+          "where": "\"access_points\".\"is_primary\" = 1"
+        }
+      },
+      "foreignKeys": {
+        "access_points_race_id_races_id_fk": {
+          "name": "access_points_race_id_races_id_fk",
+          "tableFrom": "access_points",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "aid_stations": {
+      "name": "aid_stations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "distance_km": {
+          "name": "distance_km",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "offerings_ja": {
+          "name": "offerings_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "offerings_en": {
+          "name": "offerings_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "aid_stations_race_id_idx": {
+          "name": "aid_stations_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "aid_stations_race_id_races_id_fk": {
+          "name": "aid_stations_race_id_races_id_fk",
+          "tableFrom": "aid_stations",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "checkpoints": {
+      "name": "checkpoints",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "distance_km": {
+          "name": "distance_km",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "closing_time": {
+          "name": "closing_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "checkpoints_race_id_idx": {
+          "name": "checkpoints_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "checkpoints_race_id_races_id_fk": {
+          "name": "checkpoints_race_id_races_id_fk",
+          "tableFrom": "checkpoints",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "completion_gifts": {
+      "name": "completion_gifts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gift_categories": {
+          "name": "gift_categories",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "description_ja": {
+          "name": "description_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description_en": {
+          "name": "description_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "completion_gifts_race_id_idx": {
+          "name": "completion_gifts_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "completion_gifts_race_id_races_id_fk": {
+          "name": "completion_gifts_race_id_races_id_fk",
+          "tableFrom": "completion_gifts",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "contact_submissions": {
+      "name": "contact_submissions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "contact_submissions_status_idx": {
+          "name": "contact_submissions_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "contact_submissions_created_at_idx": {
+          "name": "contact_submissions_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "contact_submissions_user_id_user_id_fk": {
+          "name": "contact_submissions_user_id_user_id_fk",
+          "tableFrom": "contact_submissions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gift_categories": {
+      "name": "gift_categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_ja": {
+          "name": "name_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_en": {
+          "name": "name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "nearby_spots": {
+      "name": "nearby_spots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_ja": {
+          "name": "name_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_en": {
+          "name": "name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description_ja": {
+          "name": "description_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description_en": {
+          "name": "description_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "distance_from_venue": {
+          "name": "distance_from_venue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "nearby_spots_race_id_idx": {
+          "name": "nearby_spots_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "nearby_spots_race_id_races_id_fk": {
+          "name": "nearby_spots_race_id_races_id_fk",
+          "tableFrom": "nearby_spots",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "participation_gifts": {
+      "name": "participation_gifts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gift_categories": {
+          "name": "gift_categories",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "description_ja": {
+          "name": "description_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description_en": {
+          "name": "description_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "participation_gifts_race_id_idx": {
+          "name": "participation_gifts_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "participation_gifts_race_id_races_id_fk": {
+          "name": "participation_gifts_race_id_races_id_fk",
+          "tableFrom": "participation_gifts",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkey": {
+      "name": "passkey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "webAuthnUserID": {
+          "name": "webAuthnUserID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deviceType": {
+          "name": "deviceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backedUp": {
+          "name": "backedUp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "passkey_userId_user_id_fk": {
+          "name": "passkey_userId_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prefectures": {
+      "name": "prefectures",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_en": {
+          "name": "name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region_en": {
+          "name": "region_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lat": {
+          "name": "lat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lng": {
+          "name": "lng",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_categories": {
+      "name": "race_categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "distance_type": {
+          "name": "distance_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "distance_km": {
+          "name": "distance_km",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "time_limit_minutes": {
+          "name": "time_limit_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "entry_fee": {
+          "name": "entry_fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_fee_u25": {
+          "name": "entry_fee_u25",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name_ja": {
+          "name": "name_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name_en": {
+          "name": "name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description_ja": {
+          "name": "description_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description_en": {
+          "name": "description_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "eligibility_ja": {
+          "name": "eligibility_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "eligibility_en": {
+          "name": "eligibility_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "course_gpx_file": {
+          "name": "course_gpx_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "waves": {
+          "name": "waves",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "race_categories_race_id_idx": {
+          "name": "race_categories_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_categories_race_id_races_id_fk": {
+          "name": "race_categories_race_id_races_id_fk",
+          "tableFrom": "race_categories",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_course_highlights": {
+      "name": "race_course_highlights",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "km": {
+          "name": "km",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name_ja": {
+          "name": "name_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_en": {
+          "name": "name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note_ja": {
+          "name": "note_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note_en": {
+          "name": "note_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "race_course_highlights_race_id_idx": {
+          "name": "race_course_highlights_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_course_highlights_race_id_races_id_fk": {
+          "name": "race_course_highlights_race_id_races_id_fk",
+          "tableFrom": "race_course_highlights",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "race_course_highlights_category_id_race_categories_id_fk": {
+          "name": "race_course_highlights_category_id_race_categories_id_fk",
+          "tableFrom": "race_course_highlights",
+          "tableTo": "race_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_entry_links": {
+      "name": "race_entry_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "race_entry_links_race_id_idx": {
+          "name": "race_entry_links_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_entry_links_race_id_races_id_fk": {
+          "name": "race_entry_links_race_id_races_id_fk",
+          "tableFrom": "race_entry_links",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_entry_periods": {
+      "name": "race_entry_periods",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "label_ja": {
+          "name": "label_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'一般エントリー'"
+        },
+        "label_en": {
+          "name": "label_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'General Entry'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_fee": {
+          "name": "entry_fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "race_entry_periods_race_id_idx": {
+          "name": "race_entry_periods_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_entry_periods_race_id_races_id_fk": {
+          "name": "race_entry_periods_race_id_races_id_fk",
+          "tableFrom": "race_entry_periods",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "race_entry_periods_category_id_race_categories_id_fk": {
+          "name": "race_entry_periods_category_id_race_categories_id_fk",
+          "tableFrom": "race_entry_periods",
+          "tableTo": "race_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_gallery": {
+      "name": "race_gallery",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "src": {
+          "name": "src",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caption_ja": {
+          "name": "caption_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "caption_en": {
+          "name": "caption_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "race_gallery_race_id_idx": {
+          "name": "race_gallery_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_gallery_race_id_races_id_fk": {
+          "name": "race_gallery_race_id_races_id_fk",
+          "tableFrom": "race_gallery",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_results": {
+      "name": "race_results",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "participants_count": {
+          "name": "participants_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finishers_count": {
+          "name": "finishers_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finisher_rate_pct": {
+          "name": "finisher_rate_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "weather_condition_ja": {
+          "name": "weather_condition_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "weather_condition_en": {
+          "name": "weather_condition_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "temperature_c": {
+          "name": "temperature_c",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_temp_c": {
+          "name": "max_temp_c",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "min_temp_c": {
+          "name": "min_temp_c",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "wind_speed_ms": {
+          "name": "wind_speed_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "humidity_pct": {
+          "name": "humidity_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes_ja": {
+          "name": "notes_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes_en": {
+          "name": "notes_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avg_time": {
+          "name": "avg_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "race_results_race_id_idx": {
+          "name": "race_results_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_results_race_id_races_id_fk": {
+          "name": "race_results_race_id_races_id_fk",
+          "tableFrom": "race_results",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_series": {
+      "name": "race_series",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_ja": {
+          "name": "name_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_en": {
+          "name": "name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_held_year": {
+          "name": "first_held_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_time_buckets": {
+      "name": "race_time_buckets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pct": {
+          "name": "pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "race_time_buckets_race_id_idx": {
+          "name": "race_time_buckets_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_time_buckets_race_id_races_id_fk": {
+          "name": "race_time_buckets_race_id_races_id_fk",
+          "tableFrom": "race_time_buckets",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_voices": {
+      "name": "race_voices",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quote_ja": {
+          "name": "quote_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quote_en": {
+          "name": "quote_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "race_voices_race_id_idx": {
+          "name": "race_voices_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_voices_race_id_races_id_fk": {
+          "name": "race_voices_race_id_races_id_fk",
+          "tableFrom": "race_voices",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "races": {
+      "name": "races",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_ja": {
+          "name": "name_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_en": {
+          "name": "name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "full_name_ja": {
+          "name": "full_name_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "full_name_en": {
+          "name": "full_name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "edition": {
+          "name": "edition",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prefecture": {
+          "name": "prefecture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "city_ja": {
+          "name": "city_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "city_en": {
+          "name": "city_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description_ja": {
+          "name": "description_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description_en": {
+          "name": "description_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "official_url": {
+          "name": "official_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "entry_fee": {
+          "name": "entry_fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_fee_by_category": {
+          "name": "entry_fee_by_category",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "entry_capacity": {
+          "name": "entry_capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "entry_start_date": {
+          "name": "entry_start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_end_date": {
+          "name": "entry_end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_closed": {
+          "name": "entry_closed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "reception_type": {
+          "name": "reception_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'race_day'"
+        },
+        "reception_note_ja": {
+          "name": "reception_note_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "reception_note_en": {
+          "name": "reception_note_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "course_gpx_file": {
+          "name": "course_gpx_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "course_max_elevation_m": {
+          "name": "course_max_elevation_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "course_min_elevation_m": {
+          "name": "course_min_elevation_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "course_elevation_diff_m": {
+          "name": "course_elevation_diff_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "course_surface": {
+          "name": "course_surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'road'"
+        },
+        "course_certification": {
+          "name": "course_certification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "course_highlights_ja": {
+          "name": "course_highlights_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "course_highlights_en": {
+          "name": "course_highlights_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "course_notes_ja": {
+          "name": "course_notes_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "course_notes_en": {
+          "name": "course_notes_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "venue_name_ja": {
+          "name": "venue_name_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "venue_name_en": {
+          "name": "venue_name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "venue_address": {
+          "name": "venue_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_lat": {
+          "name": "start_lat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_lng": {
+          "name": "start_lng",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "motif": {
+          "name": "motif",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "motif_color": {
+          "name": "motif_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "motif_romaji": {
+          "name": "motif_romaji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tagline_ja": {
+          "name": "tagline_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tagline_en": {
+          "name": "tagline_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hero_image_url": {
+          "name": "hero_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hero_caption_ja": {
+          "name": "hero_caption_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hero_caption_en": {
+          "name": "hero_caption_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "races_date_idx": {
+          "name": "races_date_idx",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        },
+        "races_prefecture_idx": {
+          "name": "races_prefecture_idx",
+          "columns": [
+            "prefecture"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "races_series_id_race_series_id_fk": {
+          "name": "races_series_id_race_series_id_fk",
+          "tableFrom": "races",
+          "tableTo": "race_series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_races": {
+      "name": "user_races",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_planning": {
+          "name": "is_planning",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "planning_category_id": {
+          "name": "planning_category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_reminder_period_ids": {
+          "name": "entry_reminder_period_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_races_user_id_idx": {
+          "name": "user_races_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "user_races_race_id_idx": {
+          "name": "user_races_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        },
+        "user_races_user_race_idx": {
+          "name": "user_races_user_race_idx",
+          "columns": [
+            "user_id",
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_races_user_id_user_id_fk": {
+          "name": "user_races_user_id_user_id_fk",
+          "tableFrom": "user_races",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_races_race_id_races_id_fk": {
+          "name": "user_races_race_id_races_id_fk",
+          "tableFrom": "user_races",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_races_planning_category_id_race_categories_id_fk": {
+          "name": "user_races_planning_category_id_race_categories_id_fk",
+          "tableFrom": "user_races",
+          "tableTo": "race_categories",
+          "columnsFrom": [
+            "planning_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "weather_history": {
+      "name": "weather_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avg_temp": {
+          "name": "avg_temp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "max_temp": {
+          "name": "max_temp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "min_temp": {
+          "name": "min_temp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "humidity_pct": {
+          "name": "humidity_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "precipitation_mm": {
+          "name": "precipitation_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "wind_speed_ms": {
+          "name": "wind_speed_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "weather_history_race_id_idx": {
+          "name": "weather_history_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "weather_history_race_id_races_id_fk": {
+          "name": "weather_history_race_id_races_id_fk",
+          "tableFrom": "weather_history",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1781274009633,
       "tag": "0010_loving_mister_fear",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1783261279345,
+      "tag": "0011_parallel_winter_soldier",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1783261279345,
       "tag": "0011_parallel_winter_soldier",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "6",
+      "when": 1783310438507,
+      "tag": "0012_fearless_sleeper",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/seed-races-all.sql
+++ b/migrations/seed-races-all.sql
@@ -1,5 +1,5 @@
 -- 自動生成: generate-seed-races.js
--- 生成日時: 2026-07-05T14:07:44.461Z
+-- 生成日時: 2026-07-05T14:23:29.257Z
 -- 対象ファイル数: 87 件（既存 2 件はskip）
 
 -- ==================
@@ -34,6 +34,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'abashiri-marathon-2026',
@@ -71,6 +72,11 @@ INSERT INTO races (
   'Ryuhyo',
   '流氷の大地を駆け抜ける春の42km',
   'Run through the land of drift ice in spring',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -114,6 +120,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('abashiri-marathon-2026', 'full', 42.195, 390, '08:45', 2600, 12000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -156,6 +167,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'akita-nairiku-ultra-2026',
@@ -193,6 +205,11 @@ INSERT INTO races (
   'Koyo',
   '秋田内陸の紅葉の回廊を走る100km',
   'A 100km journey through autumn foliage corridors',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -236,6 +253,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('akita-nairiku-ultra-2026', 'ultra', 100, 780, '05:00', 650, 22000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -284,6 +306,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'aomori-sakura-marathon-2026',
@@ -321,6 +344,11 @@ INSERT INTO races (
   'Sakura',
   '桜前線に乗って、青森を走る',
   'Run through Aomori on the cherry blossom front',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -364,6 +392,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('aomori-sakura-marathon-2026', 'full', 42.195, 330, '08:50', 2400, 7000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -418,6 +451,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'aoshima-taiheyo-marathon-2026',
@@ -450,6 +484,11 @@ INSERT INTO races (
   '',
   '',
   '',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -498,6 +537,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 
 -- ==================
@@ -532,6 +576,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'asahikawa-half-marathon-2026',
@@ -569,6 +614,11 @@ INSERT INTO races (
   'Taisetsuzan',
   '大雪山を仰ぎながら旭川の街を駆ける',
   'Run through Asahikawa with Mt. Taisetsu in view',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -612,6 +662,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('asahikawa-half-marathon-2026', 'half', 21.0975, 180, '08:30', 2500, 6500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -654,6 +709,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'beppu-oita-marathon-2026',
@@ -691,6 +747,11 @@ INSERT INTO races (
   'Onsen',
   '湯けむりの街から、大分へ。歴史ある42.195km',
   'From the city of hot springs to Oita — a storied 42.195km',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -734,6 +795,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('beppu-oita-marathon-2026', 'full', 42.195, 0, '12:00', 4000, 15000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -782,6 +848,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'biwako-marathon-2026',
@@ -819,6 +886,11 @@ INSERT INTO races (
   'Biwako',
   '日本最大の湖を舞台に、水の都を走る',
   'Run along Japan''s largest lake',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -862,6 +934,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('biwako-marathon-2026', 'full', 42.195, 360, '08:20', 7000, 15000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -908,6 +985,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'chiba-aqualine-marathon-2026',
@@ -945,6 +1023,11 @@ INSERT INTO races (
   'Umi',
   '東京湾アクアラインを渡る、世界唯一のコース',
   'The world-unique course crossing Tokyo Bay Aqua-Line',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -988,6 +1071,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('chiba-aqualine-marathon-2026', 'full', 42.195, 375, '09:45', 12000, 16500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -1040,6 +1128,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'ehime-marathon-2026',
@@ -1077,6 +1166,11 @@ INSERT INTO races (
   'Mikan',
   '蜜柑の香り漂う、瀬戸内の道を走る',
   'Run through the Seto Inland citrus country',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -1120,6 +1214,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('ehime-marathon-2026', 'full', 42.195, 360, '10:00', 10000, 12900, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -1170,6 +1269,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'ehime-marathon-2027',
@@ -1207,6 +1307,11 @@ INSERT INTO races (
   'Mikan',
   '蜜柑の香り漂う、瀬戸内の道を走る',
   'Run through the Seto Inland citrus country',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -1250,6 +1355,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('ehime-marathon-2027', 'full', 42.195, 360, '10:00', 10000, 12900, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -1304,6 +1414,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'fuji-mountain-race-2026',
@@ -1350,6 +1461,11 @@ Please note that if you forget your race number or timing chip on the day of the
   NULL,
   NULL,
   NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   '2026-04-28T16:44:56.479Z',
   '2026-04-28T16:44:56.479Z'
 ) ON CONFLICT(id) DO UPDATE SET
@@ -1390,6 +1506,11 @@ Please note that if you forget your race number or timing chip on the day of the
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('fuji-mountain-race-2026', 'other', 21, 260, '07:00', 1770, 18000, NULL, '山頂コース', NULL, NULL, NULL, '第76回大会、第77回大会、第78回大会のいずれかにおいて五合目関門（五合目ゴール）通過時間が2時間20分以内の実績のある者。又は、第2回富士山クライムランにおいて五合目ゴール時間が2時間以内の実績がある者とする。 過去(第76回、第77回、第78回)の大会の記録についてはこちらからご確認ください。 第2回富士山クライムランの記録についてはこちらからご確認ください。', 'Participants must have completed the 5th Station checkpoint (5th Station finish) in 2 hours and 20 minutes or less in either the 76th, 77th, or 78th edition of the race. Alternatively, participants must have completed the 5th Station finish in 2 hours or less in the 2nd Mount Fuji Climb Run. Please click here to view records from past editions (76th, 77th, and 78th). Please click here to view records from the 2nd Mt. Fuji Climb Run.  Translated with DeepL.com (free version)', 'fuji-mountain-race-2026.gpx', '[]', 0);
@@ -1432,6 +1553,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'fujisan-marathon-2026',
@@ -1469,6 +1591,11 @@ INSERT INTO races (
   'Fujisan',
   '霊峰富士を望みながら駆ける、絶景のコース',
   'Run with Japan''s sacred peak as your guide',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -1512,6 +1639,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('fujisan-marathon-2026', 'full', 42.195, 360, '09:00', 0, 12900, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 'fujisan-marathon-2026.kml', '[]', 0);
@@ -1566,6 +1698,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'fukuchiyama-marathon-2026',
@@ -1603,6 +1736,11 @@ INSERT INTO races (
   'Fukuchiyama-jo',
   '城下町・福知山の歴史街道を駆け抜ける',
   'Run through the historic castle town of Fukuchiyama',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -1646,6 +1784,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('fukuchiyama-marathon-2026', 'full', 42.195, 360, '', 5400, 11000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -1696,6 +1839,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'fukui-sakura-marathon-2026',
@@ -1733,6 +1877,11 @@ INSERT INTO races (
   'Sakura',
   '福井の桜回廊を巡る、春の42km',
   'A spring 42km through Fukui''s cherry blossom corridors',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -1776,6 +1925,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('fukui-sakura-marathon-2026', 'full', 42.195, 420, '08:30', 13200, 14000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -1830,6 +1984,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'fukuoka-international-marathon-2026',
@@ -1867,6 +2022,11 @@ INSERT INTO races (
   'Hakata',
   '国際都市・福岡が誇る、世界へ続く道',
   'A world-class course in the international city of Fukuoka',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -1910,6 +2070,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('fukuoka-international-marathon-2026', 'full', 42.195, 155, '12:10', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -1956,6 +2121,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'fukuoka-marathon-2026',
@@ -1993,6 +2159,11 @@ INSERT INTO races (
   'Hakata-wan',
   '博多の海沿いを走る、秋の風物詩',
   'Run along Hakata Bay in autumn',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -2036,6 +2207,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('fukuoka-marathon-2026', 'full', 42.195, 420, '08:20', 13000, 16000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -2094,6 +2270,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'gunma-marathon-2026',
@@ -2144,6 +2321,11 @@ If you are unable to participate after registering, you do not need to contact u
   NULL,
   NULL,
   NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   '2026-03-15T00:00:00Z',
   '2026-06-22T15:01:11.589Z'
 ) ON CONFLICT(id) DO UPDATE SET
@@ -2184,6 +2366,11 @@ If you are unable to participate after registering, you do not need to contact u
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('gunma-marathon-2026', 'full', 42.195, 360, '08:55', 5500, 13500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -2242,6 +2429,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'higashine-sakuranbo-marathon-2026',
@@ -2279,6 +2467,11 @@ INSERT INTO races (
   'Sakuranbo',
   'さくらんぼの里・東根で走る、甘い42km',
   'Run 42km in Japan''s cherry capital',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -2322,6 +2515,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('higashine-sakuranbo-marathon-2026', 'half', 21.0975, 170, '08:40', 5500, 6000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -2370,6 +2568,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'higashinipon-half-marathon-2026',
@@ -2407,6 +2606,11 @@ INSERT INTO races (
   'Sakura',
   '立川の春を駆け抜ける東日本ハーフ',
   'East Japan Half Marathon through spring Tachikawa',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -2450,6 +2654,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('higashinipon-half-marathon-2026', 'half', 21.0975, 180, '09:00', 4000, 5500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -2494,6 +2703,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'himeji-castle-marathon-2026',
@@ -2531,6 +2741,11 @@ INSERT INTO races (
   'Himeji-jo',
   '世界遺産・白鷺城を眺めながら走る42.195km',
   'Run beneath the White Heron Castle, a World Heritage Site',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -2574,6 +2789,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('himeji-castle-marathon-2026', 'full', 42.195, 360, '', 9000, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -2620,6 +2840,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'hitachi-seaside-marathon-2026',
@@ -2664,6 +2885,11 @@ With the scenery and the sea breeze pushing you forward, you can fully savor the
   NULL,
   NULL,
   NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   '2026-04-11T14:28:19.021Z',
   '2026-04-11T14:28:19.021Z'
 ) ON CONFLICT(id) DO UPDATE SET
@@ -2704,6 +2930,11 @@ With the scenery and the sea breeze pushing you forward, you can fully savor the
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('hitachi-seaside-marathon-2026', 'full', 42.195, 360, '10:00', 6000, 10000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -2754,6 +2985,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'hofu-yomiuri-marathon-2026',
@@ -2791,6 +3023,11 @@ INSERT INTO races (
   'Hofu-Tenmangu',
   '日本最古の天満宮の参道を巡る歴史ある大会',
   'Race through the grounds of Japan''s oldest Tenmangu shrine',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -2834,6 +3071,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('hofu-yomiuri-marathon-2026', 'full', 42.195, 240, '12:03', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -2884,6 +3126,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'hokkaido-marathon-2026',
@@ -2921,6 +3164,11 @@ INSERT INTO races (
   'Rairakku',
   'ライラック香る大通公園から、北の大地を走る',
   'From the lilac-scented Odori Park across Hokkaido',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -2964,6 +3212,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('hokkaido-marathon-2026', 'full', 42.195, 360, '08:30', 20000, 16500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -3018,6 +3271,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'ibusuki-nanohana-2026',
@@ -3055,6 +3309,11 @@ INSERT INTO races (
   'Nanohana',
   '黄金色の菜の花畑と薩摩の海を巡る42km',
   'Run through golden rapeseed fields along the Satsuma sea',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -3098,6 +3357,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('ibusuki-nanohana-2026', 'full', 42.195, 480, '09:00', 10000, 10000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -3111,8 +3375,8 @@ INSERT OR REPLACE INTO aid_stations (race_id, distance_km, offerings_ja, offerin
   ('ibusuki-nanohana-2026', 28, '水、スポーツドリンク、茶ぶし', 'Water, sports drink, tea-steamed rice cake', 1);
 INSERT OR REPLACE INTO aid_stations (race_id, distance_km, offerings_ja, offerings_en, is_featured) VALUES
   ('ibusuki-nanohana-2026', 35, '水、スポーツドリンク', 'Water, sports drink', 0);
-INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, sort_order) VALUES
-  ('ibusuki-nanohana-2026', '指宿駅', 'Ibusuki Station', 'ibusuki', 'JR指宿駅から徒歩約15分', 'About 15 min walk from JR Ibusuki Station', 31.2544, 130.6556, 0);
+INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, walk_minutes, is_primary, sort_order) VALUES
+  ('ibusuki-nanohana-2026', '指宿駅', 'Ibusuki Station', 'ibusuki', 'JR指宿駅から徒歩約15分', 'About 15 min walk from JR Ibusuki Station', 31.2544, 130.6556, NULL, 0, 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('ibusuki-nanohana-2026', '温泉', '砂むし温泉', 'Sand Steam Bath (Sunamushi Onsen)', '指宿名物の砂蒸し温泉。海岸の天然砂の中に埋まって温まる独特の体験。レース後のリカバリーに最適。', 'Ibusuki''s famous sand steam bath. A unique experience of being buried in naturally heated sand on the beach. Perfect for post-race recovery.', '指宿市内', NULL, 31.2283, 130.6367);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
@@ -3150,6 +3414,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'ichinoseki-half-marathon-2026',
@@ -3187,6 +3452,11 @@ INSERT INTO races (
   'Genbikei',
   '厳美渓の渓谷美を感じながら走る一関ハーフ',
   'Run through the scenic Genbikei gorge in Ichinoseki',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -3230,6 +3500,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('ichinoseki-half-marathon-2026', 'half', 21.0975, 170, '09:00', 2000, 6000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -3272,6 +3547,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'iki-ultra-marathon-2026',
@@ -3309,6 +3585,11 @@ INSERT INTO races (
   'Iki-no-Umi',
   '玄界灘に浮かぶ神秘の島・壱岐を一周する',
   'Circle the mystical island of Iki in the Genkai Sea',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -3352,6 +3633,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('iki-ultra-marathon-2026', 'ultra', 100, 840, '05:00', 1000, 20000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -3394,6 +3680,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'itabashi-city-marathon-2026',
@@ -3431,6 +3718,11 @@ INSERT INTO races (
   'Arakawa',
   '荒川河川敷を駆ける、春の板橋シティマラソン',
   'Run the Arakawa riverside in spring',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -3474,6 +3766,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('itabashi-city-marathon-2026', 'full', 42.195, 420, '09:00', 10000, 11550, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -3522,6 +3819,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'iwaki-sunshine-marathon-2026',
@@ -3559,6 +3857,11 @@ INSERT INTO races (
   'Taiheiyo',
   '太平洋の輝きとともに、いわきの海岸を走る',
   'Run along Iwaki''s Pacific coast in sunshine',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -3602,6 +3905,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('iwaki-sunshine-marathon-2026', 'full', 42.195, 360, '', 5000, 9000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -3654,6 +3962,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'iwaki-sunshine-marathon-2027',
@@ -3691,6 +4000,11 @@ INSERT INTO races (
   'Taiheiyo',
   '太平洋の輝きとともに、いわきの海岸を走る',
   'Run along Iwaki''s Pacific coast in sunshine',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -3734,6 +4048,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('iwaki-sunshine-marathon-2027', 'full', 42.195, 360, '', 5000, 9000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -3786,6 +4105,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'iwate-morioka-city-marathon-2026',
@@ -3856,6 +4176,11 @@ Translated with DeepL.com (free version)',
   NULL,
   NULL,
   NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   '2026-04-16T15:23:52.019Z',
   '2026-06-08T14:33:03.724Z'
 ) ON CONFLICT(id) DO UPDATE SET
@@ -3896,6 +4221,11 @@ Translated with DeepL.com (free version)',
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('iwate-morioka-city-marathon-2026', 'full', 42.195, 360, '09:00', 6000, 12000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -3936,6 +4266,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'iwate-oshu-kirameki-marathon-2026',
@@ -3973,6 +4304,11 @@ INSERT INTO races (
   'Hiraizumi',
   '世界遺産・平泉の黄金文化を感じながら走る',
   'Run through Hiraizumi, the Golden City of World Heritage',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -4016,6 +4352,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('iwate-oshu-kirameki-marathon-2026', 'full', 42.195, 360, '08:30', 3000, 10000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -4062,6 +4403,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'izu-oshima-2026',
@@ -4127,6 +4469,11 @@ Translated with DeepL.com (free version)',
   NULL,
   NULL,
   NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   '2026-06-06T08:43:10.814Z',
   '2026-06-06T00:00:00.000Z'
 ) ON CONFLICT(id) DO UPDATE SET
@@ -4167,6 +4514,11 @@ Translated with DeepL.com (free version)',
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('izu-oshima-2026', 'full', 42.195, 420, '08:00', 750, 9400, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 'izu-oshima-2026.gpx', '[]', 0);
@@ -4217,6 +4569,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'kagawa-marathon-2026',
@@ -4254,6 +4607,11 @@ INSERT INTO races (
   'Setonaikai',
   '瀬戸内の穏やかな海を見渡しながら走る42km',
   'Run along the serene shores of the Seto Inland Sea',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -4297,6 +4655,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kagawa-marathon-2026', 'full', 42.195, 360, '10:00', 10000, 14000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -4345,6 +4708,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'kagoshima-marathon-2026',
@@ -4382,6 +4746,11 @@ INSERT INTO races (
   'Sakura-jima',
   '活火山・桜島を望む、薩摩の海岸を走る',
   'Run along Kagoshima Bay with the volcanic Sakurajima in view',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -4425,6 +4794,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kagoshima-marathon-2026', 'full', 42.195, 420, '08:30', 10000, 14000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -4475,6 +4849,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'kaikyo-marathon-2026',
@@ -4512,6 +4887,11 @@ INSERT INTO races (
   'Kanmon-Kaikyo',
   '本州と九州をつなぐ、関門海峡を渡る',
   'Cross the Kanmon Strait connecting Honshu and Kyushu',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -4555,6 +4935,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kaikyo-marathon-2026', 'full', 42.195, 360, '', 10000, 12000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -4609,6 +4994,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'kanazawa-marathon-2026',
@@ -4646,6 +5032,11 @@ INSERT INTO races (
   'Kenroku-en',
   '加賀百万石の城下町・金沢を駆ける',
   'Run through Kanazawa, the castle town of one million koku',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -4689,6 +5080,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kanazawa-marathon-2026', 'full', 42.195, 420, '08:30', 15000, 14000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -4737,6 +5133,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'kasama-togeinosato-half-2025-2025',
@@ -4774,6 +5171,11 @@ INSERT INTO races (
   'KASAMA-YAKI',
   'アップダウンが自慢の大会となります。日本全国の「ガチランナー」の皆さん、エントリーお待ちしております',
   'This race is known for its challenging terrain. We look forward to your entries, serious runners from all over Japan!',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -4817,6 +5219,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kasama-togeinosato-half-2025-2025', 'half', 21.0975, 150, '10:00', 2000, 5000, NULL, NULL, NULL, NULL, NULL, '18歳以上（高校生を除く）で健康に異常がなく２時間30分以内で完走できる方。なお、安全管理運営上、車いすやベビーカーを使用しての参加はできません。
@@ -4879,6 +5286,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'kasumigaura-marathon-2026',
@@ -4916,6 +5324,11 @@ INSERT INTO races (
   'Kasumigaura',
   '日本第2位の湖・霞ヶ浦のほとりを走る',
   'Run along the shores of Lake Kasumigaura, Japan''s 2nd largest lake',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -4959,6 +5372,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kasumigaura-marathon-2026', 'full', 42.195, 360, '09:45', 14000, 12000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -5009,6 +5427,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'katsuta-marathon-2026',
@@ -5046,6 +5465,11 @@ INSERT INTO races (
   'Hyakuri',
   '常陸の大地を駆け抜ける、勝田全国マラソン',
   'Run across the Hitachi plains at Katsuta',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -5089,13 +5513,18 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('katsuta-marathon-2026', 'full', 42.195, 360, '10:30', 0, 8000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('katsuta-marathon-2026', '10k', 10, 0, '', 0, 5000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 1);
-INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, sort_order) VALUES
-  ('katsuta-marathon-2026', '勝田駅', 'Katsuta Station', 'katsuta', 'JR勝田駅東口から徒歩約10分。無料シャトルバスあり。', 'About 10 min walk from JR Katsuta Station East Exit. Free shuttle bus available.', 36.3933, 140.4756, 0);
+INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, walk_minutes, is_primary, sort_order) VALUES
+  ('katsuta-marathon-2026', '勝田駅', 'Katsuta Station', 'katsuta', 'JR勝田駅東口から徒歩約10分。無料シャトルバスあり。', 'About 10 min walk from JR Katsuta Station East Exit. Free shuttle bus available.', 36.3933, 140.4756, NULL, 0, 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('katsuta-marathon-2026', '観光地', '国営ひたち海浜公園', 'Hitachi Seaside Park', 'ネモフィラやコキアで有名な広大な公園。ひたちなか市のシンボル。', 'A vast park famous for nemophila and kochia. Symbol of Hitachinaka City.', 'ひたちなか市内', NULL, 36.3958, 140.5917);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
@@ -5135,6 +5564,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'kitakyushu-marathon-2026',
@@ -5172,6 +5602,11 @@ INSERT INTO races (
   'Dokai-wan',
   '北九州の海と工場夜景の街を走る',
   'Run through Kitakyushu''s industrial waterfront',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -5215,6 +5650,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kitakyushu-marathon-2026', 'full', 42.195, 360, '09:00', 10800, 14500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -5265,6 +5705,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'kix-senshu-marathon-2026',
@@ -5302,6 +5743,11 @@ INSERT INTO races (
   'Osaka-wan',
   '関西国際空港を望む、泉州の海岸を駆ける',
   'Run the Senshu coast with Kansai International Airport in view',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -5345,6 +5791,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kix-senshu-marathon-2026', 'full', 42.195, 420, '10:30', 700, 5000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -5389,6 +5840,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'kobe-marathon-2026',
@@ -5447,6 +5899,11 @@ For relay runs, both runners must register together. Registration by one person,
   NULL,
   NULL,
   NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   '2026-03-15T00:00:00Z',
   '2026-06-27T13:30:41.348Z'
 ) ON CONFLICT(id) DO UPDATE SET
@@ -5487,6 +5944,11 @@ For relay runs, both runners must register together. Registration by one person,
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kobe-marathon-2026', 'full', 42.195, 420, '09:00', 20000, 18000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -5541,6 +6003,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'kochi-ryoma-marathon-2026',
@@ -5578,6 +6041,11 @@ INSERT INTO races (
   'Ryoma',
   '龍馬の志を胸に、土佐の大地を駆け抜ける',
   'Run the Tosa plains with the spirit of Ryoma',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -5621,6 +6089,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kochi-ryoma-marathon-2026', 'full', 42.195, 420, '09:00', 10000, 13000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -5673,6 +6146,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'kochi-ryoma-marathon-2027',
@@ -5710,6 +6184,11 @@ INSERT INTO races (
   'Ryoma',
   '龍馬の志を胸に、土佐の大地を駆け抜ける',
   'Run the Tosa plains with the spirit of Ryoma',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -5753,6 +6232,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kochi-ryoma-marathon-2027', 'full', 42.195, 420, '09:00', 10000, 13000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -5805,6 +6289,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'kumamoto-castle-marathon-2026',
@@ -5842,6 +6327,11 @@ INSERT INTO races (
   'Kumamoto-jo',
   '不落の名城・熊本城をめぐる感動の42km',
   '42km around the legendary Kumamoto Castle',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -5885,6 +6375,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kumamoto-castle-marathon-2026', 'full', 42.195, 420, '09:00', 13000, 13750, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -5933,6 +6428,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'kyoto-marathon-2026',
@@ -5970,6 +6466,11 @@ INSERT INTO races (
   'Daimonji-yama',
   '千年の古都・京都の世界遺産をめぐる',
   'Run through Kyoto''s thousand years of world heritage',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -6013,6 +6514,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kyoto-marathon-2026', 'full', 42.195, 360, '08:55', 16000, 18500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -6071,6 +6577,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'kyoto-marathon-2027',
@@ -6108,6 +6615,11 @@ INSERT INTO races (
   'Daimonji-yama',
   '千年の古都・京都の世界遺産をめぐる',
   'Run through Kyoto''s thousand years of world heritage',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -6151,6 +6663,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kyoto-marathon-2027', 'full', 42.195, 360, '08:55', 16000, 18500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -6209,6 +6726,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'mie-matsusaka-marathon-2026',
@@ -6246,6 +6764,11 @@ INSERT INTO races (
   'Matsusaka-gyu',
   '松阪牛の里・松阪を走る、美食ランナーの聖地',
   'Run through Matsusaka, home of Japan''s finest beef',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -6289,6 +6812,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('mie-matsusaka-marathon-2026', 'full', 42.195, 0, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -6341,6 +6869,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'mito-komon-manyu-marathon-2026',
@@ -6378,6 +6907,11 @@ INSERT INTO races (
   'Mito-Komon',
   '助さん格さんも驚く、水戸を駆ける42km',
   'Run through Mito as legends of the Komon await',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -6421,6 +6955,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('mito-komon-manyu-marathon-2026', 'full', 42.195, 360, '', 10000, 10000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 'mito-komon-manyu-marathon-2026', '[]', 0);
@@ -6469,6 +7008,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'mtfuji-climb-run-2026',
@@ -6527,6 +7067,11 @@ Sunday, September 13, 6:30 AM – 30 minutes before the start time of each wave'
   NULL,
   NULL,
   NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   '2026-04-28T13:53:53.451Z',
   '2026-05-30T06:38:26.366Z'
 ) ON CONFLICT(id) DO UPDATE SET
@@ -6567,6 +7112,11 @@ Sunday, September 13, 6:30 AM – 30 minutes before the start time of each wave'
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('mtfuji-climb-run-2026', 'other', 12, 180, '09:00', 2000, 15000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -6607,6 +7157,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'nagai-marathon-2026',
@@ -6642,6 +7193,11 @@ INSERT INTO races (
   '芋煮',
   NULL,
   'IMONI',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -6687,6 +7243,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('nagai-marathon-2026', 'full', 42.195, 330, '09:25', 0, 10000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -6735,6 +7296,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'nagoya-womens-marathon-2026',
@@ -6772,6 +7334,11 @@ INSERT INTO races (
   'Nagoya-jo',
   '女性ランナーの憧れ、名古屋の街を駆ける42km',
   'The women''s marathon destination — run through Nagoya',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -6815,6 +7382,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('nagoya-womens-marathon-2026', 'full', 42.195, 420, '09:10', 20000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -6863,6 +7435,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'naha-marathon-2026',
@@ -6900,6 +7473,11 @@ INSERT INTO races (
   'Haibisukasu',
   '南国の陽光と笑顔溢れる、那覇の42km',
   'Run through tropical Naha with sunshine and smiles',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -6943,6 +7521,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('naha-marathon-2026', 'full', 42.195, 375, '09:00', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -6987,6 +7570,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'nara-marathon-2026',
@@ -7024,6 +7608,11 @@ INSERT INTO races (
   'Nara-no-Shika',
   '奈良の鹿と世界遺産が待つ、古都の42km',
   'Run through the ancient capital of Nara alongside sacred deer',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -7067,6 +7656,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('nara-marathon-2026', 'full', 42.195, 360, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -7123,6 +7717,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'niigata-city-marathon-2026',
@@ -7160,6 +7755,11 @@ INSERT INTO races (
   'Shinano-gawa',
   '日本一の大河・信濃川が流れる、米どころを走る',
   'Run along the Shinano River, Japan''s longest',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -7203,6 +7803,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('niigata-city-marathon-2026', 'full', 42.195, 420, '08:30', 9000, 12500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -7247,6 +7852,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'nishio-marathon-2026',
@@ -7284,6 +7890,11 @@ INSERT INTO races (
   'Matcha',
   '日本有数の抹茶の産地・西尾を巡る42km',
   'Run through Nishio, one of Japan''s top matcha-producing cities',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -7327,6 +7938,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('nishio-marathon-2026', 'full', 42.195, 390, '09:00', 6000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -7367,6 +7983,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'ohtawara-marathon-2026',
@@ -7400,6 +8017,11 @@ INSERT INTO races (
   '',
   '',
   '',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -7448,6 +8070,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 
 -- ==================
@@ -7482,6 +8109,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'okayama-marathon-2026',
@@ -7520,6 +8148,11 @@ Loppi端末(ローソン・ミニストップ店頭)',
   'Momo',
   '桃太郎の里・岡山を、晴れの国で走る',
   'Run through Okayama, the sunny land of Momotaro',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -7563,6 +8196,11 @@ Loppi端末(ローソン・ミニストップ店頭)',
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('okayama-marathon-2026', 'full', 42.195, 360, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -7611,6 +8249,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'okushinano100-2026',
@@ -7648,6 +8287,11 @@ INSERT INTO races (
   'Kita-Arupusu',
   '北アルプスの麓・奥信濃を走る100km',
   '100km through the foothills of the Northern Alps',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -7691,6 +8335,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('okushinano100-2026', 'ultra', 100, 1260, '05:00', 700, 31000, NULL, NULL, NULL, NULL, NULL, '・各種目の規定年齢に達している方（100km／50km…18歳以上、25km…高校生以上、8km…中学生以上）※未成年者は保護者の承認が必要
@@ -7760,6 +8409,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'osaka-marathon-2026',
@@ -7797,6 +8447,11 @@ INSERT INTO races (
   'Osaka-jo',
   '笑いと活気溢れる、天下の台所・大阪を走る',
   'Run through Osaka, the nation''s kitchen of energy',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -7840,6 +8495,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('osaka-marathon-2026', 'full', 42.195, 420, '09:15', 31970, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -7894,6 +8554,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'osaka-yodo-river-citizens-marathon-2026',
@@ -7942,6 +8603,11 @@ Based on themes such as “people,” “environment,” and “the Yodogawa Riv
   NULL,
   NULL,
   NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   '2026-04-11T14:42:59.225Z',
   '2026-06-27T13:32:25.650Z'
 ) ON CONFLICT(id) DO UPDATE SET
@@ -7982,6 +8648,11 @@ Based on themes such as “people,” “environment,” and “the Yodogawa Riv
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('osaka-yodo-river-citizens-marathon-2026', 'full', 42.195, 480, '09:00', 4000, 9800, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -8030,6 +8701,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'osj-ontake100-2026',
@@ -8067,6 +8739,11 @@ INSERT INTO races (
   'Ontake-san',
   '霊峰・御嶽山の麓を巡る、100kmの山岳路',
   '100km through the sacred slopes of Mt. Ontake',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -8110,6 +8787,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('osj-ontake100-2026', 'ultra', 163, 1440, '20:00', 200, 21000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -8162,6 +8844,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'sado-toki-marathon-2026',
@@ -8199,6 +8882,11 @@ INSERT INTO races (
   'Toki',
   '朱鷺舞う離島・佐渡で走る、自然豊かな42km',
   'Run the island of Sado where the endangered crested ibis soars',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -8242,6 +8930,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('sado-toki-marathon-2026', 'full', 42.195, 0, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -8288,6 +8981,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'saga-sakura-marathon-2026',
@@ -8325,6 +9019,11 @@ INSERT INTO races (
   'Sakura',
   '佐賀城址の桜を愛でながら走る、春の42km',
   'Run beneath cherry blossoms at Saga Castle in spring',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -8368,6 +9067,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('saga-sakura-marathon-2026', 'full', 42.195, 0, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -8414,6 +9118,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'saitama-marathon-2026',
@@ -8451,6 +9156,11 @@ INSERT INTO races (
   'Arakawa',
   '荒川の雄大な流れとともに走る、さいたまの42km',
   'Run along the vast Arakawa River through Saitama',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -8494,6 +9204,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('saitama-marathon-2026', 'full', 42.195, 360, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -8532,6 +9247,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'saitama-marathon-2027',
@@ -8569,6 +9285,11 @@ INSERT INTO races (
   'Arakawa',
   '荒川の雄大な流れとともに走る、さいたまの42km',
   'Run along the vast Arakawa River through Saitama',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -8612,6 +9333,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('saitama-marathon-2027', 'full', 42.195, 360, '', 14000, 15000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -8654,6 +9380,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'sapporo-marathon-2026',
@@ -8691,6 +9418,11 @@ INSERT INTO races (
   'NEW CLASSIC',
   'その一歩から、また始まる。',
   'It all starts with that first step.',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -8734,6 +9466,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('sapporo-marathon-2026', 'half', 21.0975, 0, '09:20', 8000, 8000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -8787,6 +9524,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'shiga-kogen100-2026',
@@ -8918,6 +9656,11 @@ EQUIPMENT
   NULL,
   NULL,
   NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   '2026-04-05T06:01:54.559Z',
   '2026-06-22T15:06:42.561Z'
 ) ON CONFLICT(id) DO UPDATE SET
@@ -8958,6 +9701,11 @@ EQUIPMENT
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('shiga-kogen100-2026', 'ultra', 100, 1560, '04:30', 700, 28000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -9002,6 +9750,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'shimada-oigawa-marathon-2026',
@@ -9048,6 +9797,11 @@ Translated with DeepL.com (free version)',
   NULL,
   NULL,
   NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   '2026-04-25T04:12:54.667Z',
   '2026-04-25T04:12:54.667Z'
 ) ON CONFLICT(id) DO UPDATE SET
@@ -9088,6 +9842,11 @@ Translated with DeepL.com (free version)',
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('shimada-oigawa-marathon-2026', 'full', 42.195, 420, '09:00', 6000, 10000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -9130,6 +9889,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'shinetsu5mountains-trail-100-2026',
@@ -9168,6 +9928,11 @@ INSERT INTO races (
   'Shin-etsu-Gogaku',
   '信越の五つの山を巡る、100マイルの挑戦',
   'A 100-mile challenge through five peaks of the Shin-Etsu mountains',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -9211,6 +9976,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('shinetsu5mountains-trail-100-2026', 'ultra', 163, 1980, '18:30', 600, 47000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -9261,6 +10031,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'shizuoka-marathon-2026',
@@ -9298,6 +10069,11 @@ INSERT INTO races (
   'Fujisan',
   '富士山を正面に望む、海岸線の42km',
   'Run the coastline with Mt. Fuji straight ahead',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -9341,6 +10117,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('shizuoka-marathon-2026', 'full', 42.195, 0, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -9383,6 +10164,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'shonan-international-marathon-2026',
@@ -9420,6 +10202,11 @@ INSERT INTO races (
   'Shonan-no-Umi',
   '湘南の海風を感じながら走る、江ノ島から湘南へ',
   'Run the Shonan coast from Enoshima with ocean breezes',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -9463,6 +10250,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('shonan-international-marathon-2026', 'full', 42.195, 345, '', 19500, 16000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -9511,6 +10303,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'soja-kibiji-marathon-2026',
@@ -9554,6 +10347,11 @@ Therefore, there is no registration required.',
   NULL,
   NULL,
   NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   '2026-03-15T00:00:00Z',
   '2026-05-30T06:42:39.583Z'
 ) ON CONFLICT(id) DO UPDATE SET
@@ -9594,6 +10392,11 @@ Therefore, there is no registration required.',
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('soja-kibiji-marathon-2026', 'full', 42.195, 360, '09:20', 2000, 9100, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -9644,6 +10447,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'tamba-sasayama-abc-marathon-2026',
@@ -9681,6 +10485,11 @@ INSERT INTO races (
   'Jokamachi',
   '丹波篠山・城下町の風情漂う黒豆の里を走る',
   'Run through the castle town of Tamba Sasayama, home of black soybeans',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -9724,6 +10533,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('tamba-sasayama-abc-marathon-2026', 'full', 42.195, 330, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -9768,6 +10582,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'tateyama-wakashio-2026',
@@ -9805,6 +10620,11 @@ INSERT INTO races (
   'Wakashio',
   '太平洋に面した館山の若潮を感じながら走る',
   'Run Tateyama''s Pacific coast on the fresh tides of spring',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -9848,6 +10668,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('tateyama-wakashio-2026', 'full', 42.195, 360, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -9894,6 +10719,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'tazawako-marathon-2026',
@@ -9932,6 +10758,11 @@ INSERT INTO races (
   'Tazawako',
   '日本最深の湖・田沢湖を一望しながら走る',
   'Run overlooking Lake Tazawa, Japan''s deepest lake',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -9975,6 +10806,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('tazawako-marathon-2026', 'full', 42.195, 360, '08:30', 1600, 10000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -10019,6 +10855,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'tokushima-marathon-2026',
@@ -10056,6 +10893,11 @@ INSERT INTO races (
   'Awa-Odori',
   '踊る阿呆に走る阿呆！阿波の国を駆け抜ける',
   'Run the land of Awa dance — the spirit of Tokushima',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -10099,6 +10941,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('tokushima-marathon-2026', 'full', 42.195, 0, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -10143,6 +10990,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'tokyo-legacy-half-2026',
@@ -10195,6 +11043,11 @@ MUFG Stadium (National Stadium): 10-1 Kasumigaoka-cho, Shinjuku-ku, Tokyo',
   NULL,
   NULL,
   NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   '2026-05-14T14:47:07.523Z',
   '2026-05-14T14:47:07.523Z'
 ) ON CONFLICT(id) DO UPDATE SET
@@ -10235,6 +11088,11 @@ MUFG Stadium (National Stadium): 10-1 Kasumigaoka-cho, Shinjuku-ku, Tokyo',
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('tokyo-legacy-half-2026', 'half', 21.0975, 180, '08:05', 18000, 13200, NULL, NULL, NULL, NULL, NULL, '大会当日満18歳以上で以下の条件にあてはまる者で、主催者が出場を認めた者。
@@ -10338,6 +11196,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'tokyo-marathon-2026',
@@ -10375,6 +11234,11 @@ INSERT INTO races (
   'Tokyo-no-Machi',
   '世界6大メジャーの一つ、東京の街を駆け抜ける',
   'Race through Tokyo — one of the six World Marathon Majors',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -10418,13 +11282,18 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('tokyo-marathon-2026', 'full', 42.195, 420, '09:10', 38500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
-INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, sort_order) VALUES
-  ('tokyo-marathon-2026', '新宿駅', 'Shinjuku Station', 'shinjuku', '新宿駅西口から徒歩約10分でスタート会場（東京都庁前）', '10 min walk from Shinjuku Station West Exit to the start (Tokyo Metropolitan Government)', 35.6896, 139.6999, 0);
-INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, sort_order) VALUES
-  ('tokyo-marathon-2026', '都庁前駅', 'Tochomae Station', 'tochomae', '都営大江戸線都庁前駅直結', 'Direct access from Toei Oedo Line Tochomae Station', 35.6915, 139.6917, 1);
+INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, walk_minutes, is_primary, sort_order) VALUES
+  ('tokyo-marathon-2026', '新宿駅', 'Shinjuku Station', 'shinjuku', '新宿駅西口から徒歩約10分でスタート会場（東京都庁前）', '10 min walk from Shinjuku Station West Exit to the start (Tokyo Metropolitan Government)', 35.6896, 139.6999, NULL, 0, 0);
+INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, walk_minutes, is_primary, sort_order) VALUES
+  ('tokyo-marathon-2026', '都庁前駅', 'Tochomae Station', 'tochomae', '都営大江戸線都庁前駅直結', 'Direct access from Toei Oedo Line Tochomae Station', 35.6915, 139.6917, NULL, 0, 1);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('tokyo-marathon-2026', '観光地', '浅草寺・雷門', 'Sensoji Temple & Kaminarimon', 'コース上を通過する東京を代表する観光名所。外国人ランナーにも人気のスポット。', 'An iconic Tokyo landmark on the course. Popular with international runners.', 'コース上（約15km地点）', NULL, 35.7148, 139.7967);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -10482,6 +11351,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'tokyo-marathon-2027',
@@ -10519,6 +11389,11 @@ INSERT INTO races (
   'Tokyo-no-Machi',
   '世界6大メジャーの一つ、東京の街を駆け抜ける',
   'Race through Tokyo — one of the six World Marathon Majors',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -10562,13 +11437,18 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('tokyo-marathon-2027', 'full', 42.195, 420, '09:10', 38500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
-INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, sort_order) VALUES
-  ('tokyo-marathon-2027', '新宿駅', 'Shinjuku Station', 'shinjuku', '新宿駅西口から徒歩約10分でスタート会場（東京都庁前）', '10 min walk from Shinjuku Station West Exit to the start (Tokyo Metropolitan Government)', 35.6896, 139.6999, 0);
-INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, sort_order) VALUES
-  ('tokyo-marathon-2027', '都庁前駅', 'Tochomae Station', 'tochomae', '都営大江戸線都庁前駅直結', 'Direct access from Toei Oedo Line Tochomae Station', 35.6915, 139.6917, 1);
+INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, walk_minutes, is_primary, sort_order) VALUES
+  ('tokyo-marathon-2027', '新宿駅', 'Shinjuku Station', 'shinjuku', '新宿駅西口から徒歩約10分でスタート会場（東京都庁前）', '10 min walk from Shinjuku Station West Exit to the start (Tokyo Metropolitan Government)', 35.6896, 139.6999, NULL, 0, 0);
+INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, walk_minutes, is_primary, sort_order) VALUES
+  ('tokyo-marathon-2027', '都庁前駅', 'Tochomae Station', 'tochomae', '都営大江戸線都庁前駅直結', 'Direct access from Toei Oedo Line Tochomae Station', 35.6915, 139.6917, NULL, 0, 1);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('tokyo-marathon-2027', '観光地', '浅草寺・雷門', 'Sensoji Temple & Kaminarimon', 'コース上を通過する東京を代表する観光名所。外国人ランナーにも人気のスポット。', 'An iconic Tokyo landmark on the course. Popular with international runners.', 'コース上（約15km地点）', NULL, 35.7148, 139.7967);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -10632,6 +11512,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'tomisato-suikaroad-2026',
@@ -10669,6 +11550,11 @@ INSERT INTO races (
   'KyuSuika',
   '日本一のスイカの産地・富里を走る、夏の風物詩',
   'Run Japan''s watermelon capital — a midsummer tradition',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -10712,6 +11598,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('tomisato-suikaroad-2026', '10k', 10, 70, '09:15', 1500, 6500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -10756,6 +11647,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'tottori-marathon-2026',
@@ -10793,6 +11685,11 @@ INSERT INTO races (
   'Sakyu',
   '日本最大の砂丘を望む、山陰の大地を走る',
   'Run the San-in coast with Japan''s great sand dunes in view',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -10836,6 +11733,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('tottori-marathon-2026', 'full', 42.195, 0, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -10898,6 +11800,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'toyako-marathon-2026',
@@ -10935,6 +11838,11 @@ INSERT INTO races (
   'Toyako',
   '洞爺湖の湖畔を巡る、北海道の爽快42km',
   'Circle the shores of Lake Toya in refreshing Hokkaido',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -10978,6 +11886,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('toyako-marathon-2026', 'full', 42.195, 0, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -11028,6 +11941,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'toyama-marathon-2026',
@@ -11065,6 +11979,11 @@ INSERT INTO races (
   'Tateyama-Rempo',
   '立山連峰と富山湾を望む、360度の絶景コース',
   'Run with panoramic views of the Tateyama Range and Toyama Bay',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -11108,6 +12027,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('toyama-marathon-2026', 'full', 42.195, 420, '09:30', 13000, 14000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -11160,6 +12084,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'tsukuba-marathon-2026',
@@ -11197,6 +12122,11 @@ INSERT INTO races (
   'Tsukuba-san',
   '西の富士、東の筑波。科学の街を快走する',
   'Run through the science city with Mt. Tsukuba as your landmark',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -11240,6 +12170,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('tsukuba-marathon-2026', 'full', 42.195, 0, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -11282,6 +12217,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'wakkanai-peace-marathon-2026',
@@ -11319,6 +12255,11 @@ INSERT INTO races (
   'Soya-Misaki',
   '日本最北端・宗谷岬を目指す平和の42km',
   'Run toward Cape Soya, Japan''s northernmost point',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -11362,6 +12303,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('wakkanai-peace-marathon-2026', 'full', 42.195, 390, '', 1000, 10000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
@@ -11414,6 +12360,7 @@ INSERT INTO races (
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   'yokohama-marathon-2026',
@@ -11451,6 +12398,11 @@ INSERT INTO races (
   'Minato',
   '開港の街・横浜の海と丘を駆け抜ける',
   'Run through Yokohama''s historic port city of sea and hills',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -11494,6 +12446,11 @@ INSERT INTO races (
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('yokohama-marathon-2026', 'full', 42.195, 390, '08:30', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);

--- a/migrations/seed-races-all.sql
+++ b/migrations/seed-races-all.sql
@@ -1,5 +1,5 @@
 -- 自動生成: generate-seed-races.js
--- 生成日時: 2026-07-05T14:23:29.257Z
+-- 生成日時: 2026-07-06T04:04:31.966Z
 -- 対象ファイル数: 87 件（既存 2 件はskip）
 
 -- ==================
@@ -3376,7 +3376,7 @@ INSERT OR REPLACE INTO aid_stations (race_id, distance_km, offerings_ja, offerin
 INSERT OR REPLACE INTO aid_stations (race_id, distance_km, offerings_ja, offerings_en, is_featured) VALUES
   ('ibusuki-nanohana-2026', 35, '水、スポーツドリンク', 'Water, sports drink', 0);
 INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, walk_minutes, is_primary, sort_order) VALUES
-  ('ibusuki-nanohana-2026', '指宿駅', 'Ibusuki Station', 'ibusuki', 'JR指宿駅から徒歩約15分', 'About 15 min walk from JR Ibusuki Station', 31.2544, 130.6556, NULL, 0, 0);
+  ('ibusuki-nanohana-2026', '指宿駅', 'Ibusuki Station', 'ibusuki', 'JR指宿駅から徒歩約15分', 'About 15 min walk from JR Ibusuki Station', 31.2544, 130.6556, NULL, 1, 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('ibusuki-nanohana-2026', '温泉', '砂むし温泉', 'Sand Steam Bath (Sunamushi Onsen)', '指宿名物の砂蒸し温泉。海岸の天然砂の中に埋まって温まる独特の体験。レース後のリカバリーに最適。', 'Ibusuki''s famous sand steam bath. A unique experience of being buried in naturally heated sand on the beach. Perfect for post-race recovery.', '指宿市内', NULL, 31.2283, 130.6367);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
@@ -5524,7 +5524,7 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('katsuta-marathon-2026', '10k', 10, 0, '', 0, 5000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 1);
 INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, walk_minutes, is_primary, sort_order) VALUES
-  ('katsuta-marathon-2026', '勝田駅', 'Katsuta Station', 'katsuta', 'JR勝田駅東口から徒歩約10分。無料シャトルバスあり。', 'About 10 min walk from JR Katsuta Station East Exit. Free shuttle bus available.', 36.3933, 140.4756, NULL, 0, 0);
+  ('katsuta-marathon-2026', '勝田駅', 'Katsuta Station', 'katsuta', 'JR勝田駅東口から徒歩約10分。無料シャトルバスあり。', 'About 10 min walk from JR Katsuta Station East Exit. Free shuttle bus available.', 36.3933, 140.4756, NULL, 1, 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('katsuta-marathon-2026', '観光地', '国営ひたち海浜公園', 'Hitachi Seaside Park', 'ネモフィラやコキアで有名な広大な公園。ひたちなか市のシンボル。', 'A vast park famous for nemophila and kochia. Symbol of Hitachinaka City.', 'ひたちなか市内', NULL, 36.3958, 140.5917);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES

--- a/scripts/add-venue-fields.js
+++ b/scripts/add-venue-fields.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+/**
+ * 全レースJSONに venue_name_ja / venue_name_en / venue_address / start_lat / start_lng を追加する
+ * access_points 各エントリーに walk_minutes / is_primary を追加する
+ * 既にフィールドが存在する場合はスキップ
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const RACES_DIR = path.join(__dirname, '../src/data/races');
+
+const files = fs.readdirSync(RACES_DIR).filter(f => f.endsWith('.json') && f !== 'index.json');
+let updated = 0;
+
+for (const file of files) {
+  const filePath = path.join(RACES_DIR, file);
+  const race = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  let changed = false;
+
+  // races テーブルの新フィールド
+  if (!('venue_name_ja' in race)) { race.venue_name_ja = null; changed = true; }
+  if (!('venue_name_en' in race)) { race.venue_name_en = null; changed = true; }
+  if (!('venue_address' in race)) { race.venue_address = null; changed = true; }
+  if (!('start_lat' in race)) { race.start_lat = null; changed = true; }
+  if (!('start_lng' in race)) { race.start_lng = null; changed = true; }
+
+  // access_points の新フィールド
+  if (Array.isArray(race.access_points)) {
+    for (const ap of race.access_points) {
+      if (!('walk_minutes' in ap)) { ap.walk_minutes = null; changed = true; }
+      if (!('is_primary' in ap)) { ap.is_primary = false; changed = true; }
+    }
+  }
+
+  if (changed) {
+    fs.writeFileSync(filePath, JSON.stringify(race, null, 2) + '\n', 'utf8');
+    updated++;
+    console.log(`  updated: ${file}`);
+  }
+}
+
+console.log(`\n完了: ${updated} / ${files.length} ファイルを更新しました`);

--- a/scripts/add-venue-fields.js
+++ b/scripts/add-venue-fields.js
@@ -26,10 +26,16 @@ for (const file of files) {
   if (!('start_lng' in race)) { race.start_lng = null; changed = true; }
 
   // access_points の新フィールド
-  if (Array.isArray(race.access_points)) {
+  if (Array.isArray(race.access_points) && race.access_points.length > 0) {
     for (const ap of race.access_points) {
       if (!('walk_minutes' in ap)) { ap.walk_minutes = null; changed = true; }
       if (!('is_primary' in ap)) { ap.is_primary = false; changed = true; }
+    }
+    // access_points が1件のみで全て is_primary=false の場合は先頭を primary にする
+    const hasPrimary = race.access_points.some(ap => ap.is_primary);
+    if (!hasPrimary && race.access_points.length === 1) {
+      race.access_points[0].is_primary = true;
+      changed = true;
     }
   }
 

--- a/scripts/generate-seed-races.js
+++ b/scripts/generate-seed-races.js
@@ -193,7 +193,7 @@ function generateRaceSQL(r) {
   if (r.access_points && r.access_points.length > 0) {
     r.access_points.forEach((ap, idx) => {
       lines.push(`INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, walk_minutes, is_primary, sort_order) VALUES
-  (${esc(r.id)}, ${esc(ap.station_name_ja)}, ${esc(ap.station_name_en || '')}, ${esc(ap.station_code || '')}, ${esc(ap.transport_to_venue_ja || '')}, ${esc(ap.transport_to_venue_en || '')}, ${esc(ap.latitude || 0)}, ${esc(ap.longitude || 0)}, ${esc(ap.walk_minutes ?? null)}, ${ap.is_primary ? '1' : '0'}, ${idx});`);
+  (${esc(r.id)}, ${esc(ap.station_name_ja)}, ${esc(ap.station_name_en || '')}, ${esc(ap.station_code || '')}, ${esc(ap.transport_to_venue_ja || '')}, ${esc(ap.transport_to_venue_en || '')}, ${esc(ap.latitude ?? 0)}, ${esc(ap.longitude ?? 0)}, ${esc(ap.walk_minutes ?? null)}, ${ap.is_primary ? '1' : '0'}, ${idx});`);
     });
   }
 

--- a/scripts/generate-seed-races.js
+++ b/scripts/generate-seed-races.js
@@ -64,6 +64,7 @@ function generateRaceSQL(r) {
   motif, motif_color, motif_romaji,
   tagline_ja, tagline_en,
   hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
   created_at, updated_at
 ) VALUES (
   ${esc(r.id)},
@@ -104,6 +105,11 @@ function generateRaceSQL(r) {
   ${esc(r.hero_image_url)},
   ${esc(r.hero_caption_ja)},
   ${esc(r.hero_caption_en)},
+  ${esc(r.venue_name_ja ?? null)},
+  ${esc(r.venue_name_en ?? null)},
+  ${esc(r.venue_address ?? null)},
+  ${esc(r.start_lat ?? null)},
+  ${esc(r.start_lng ?? null)},
   ${esc(r.created_at)},
   ${esc(r.updated_at)}
 ) ON CONFLICT(id) DO UPDATE SET
@@ -144,6 +150,11 @@ function generateRaceSQL(r) {
   hero_image_url = excluded.hero_image_url,
   hero_caption_ja = excluded.hero_caption_ja,
   hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
   updated_at = excluded.updated_at;`);
 
   // race_categories（+ カテゴリに付随する course_highlights）
@@ -181,8 +192,8 @@ function generateRaceSQL(r) {
   // access_points
   if (r.access_points && r.access_points.length > 0) {
     r.access_points.forEach((ap, idx) => {
-      lines.push(`INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, sort_order) VALUES
-  (${esc(r.id)}, ${esc(ap.station_name_ja)}, ${esc(ap.station_name_en || '')}, ${esc(ap.station_code || '')}, ${esc(ap.transport_to_venue_ja || '')}, ${esc(ap.transport_to_venue_en || '')}, ${esc(ap.latitude || 0)}, ${esc(ap.longitude || 0)}, ${idx});`);
+      lines.push(`INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, walk_minutes, is_primary, sort_order) VALUES
+  (${esc(r.id)}, ${esc(ap.station_name_ja)}, ${esc(ap.station_name_en || '')}, ${esc(ap.station_code || '')}, ${esc(ap.transport_to_venue_ja || '')}, ${esc(ap.transport_to_venue_en || '')}, ${esc(ap.latitude || 0)}, ${esc(ap.longitude || 0)}, ${esc(ap.walk_minutes ?? null)}, ${ap.is_primary ? '1' : '0'}, ${idx});`);
     });
   }
 

--- a/src/data/races/abashiri-marathon-2026.json
+++ b/src/data/races/abashiri-marathon-2026.json
@@ -114,5 +114,10 @@
       "description_en": "",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/akita-nairiku-ultra-2026.json
+++ b/src/data/races/akita-nairiku-ultra-2026.json
@@ -144,5 +144,10 @@
       "url": "https://www.kumagera.ne.jp/a100km/question.html",
       "label": "FAQ"
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/aomori-sakura-marathon-2026.json
+++ b/src/data/races/aomori-sakura-marathon-2026.json
@@ -175,5 +175,10 @@
       "description_en": "Finisher's towel",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/aoshima-taiheyo-marathon-2026.json
+++ b/src/data/races/aoshima-taiheyo-marathon-2026.json
@@ -78,5 +78,10 @@
   "hero_caption_en": null,
   "gallery": [],
   "voices": [],
-  "time_buckets": []
+  "time_buckets": [],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/asahikawa-half-marathon-2026.json
+++ b/src/data/races/asahikawa-half-marathon-2026.json
@@ -114,5 +114,10 @@
       "url": "https://www.asahikawa-half-marathon.jp/entry/",
       "label": "エントリー"
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/beppu-oita-marathon-2026.json
+++ b/src/data/races/beppu-oita-marathon-2026.json
@@ -156,5 +156,10 @@
       "url": "https://www.betsudai.com/wp-content/themes/betsudai/pdf/74/kou.pdf",
       "label": "アクセス"
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/biwako-marathon-2026.json
+++ b/src/data/races/biwako-marathon-2026.json
@@ -140,5 +140,10 @@
       "url": "https://biwako-marathon.com/traffic_regulation/",
       "label": "アクセス"
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/challenge-fuji5lakes-2026.json
+++ b/src/data/races/challenge-fuji5lakes-2026.json
@@ -140,7 +140,9 @@
       "transport_to_venue_ja": "富士山駅から富士北麓公園までシャトルバス運行（大会当日早朝）。または徒歩約30分。",
       "transport_to_venue_en": "Shuttle bus from Fujisan Station to Fuji Hokuroku Park (early morning on race day). Or approx. 30 min walk.",
       "latitude": 35.4879,
-      "longitude": 138.7948
+      "longitude": 138.7948,
+      "walk_minutes": null,
+      "is_primary": false
     },
     {
       "station_name_ja": "河口湖駅",
@@ -149,7 +151,9 @@
       "transport_to_venue_ja": "河口湖駅からタクシーで約15分。大会当日のシャトルバスは富士山駅発。",
       "transport_to_venue_en": "Approx. 15 min by taxi from Kawaguchiko Station. Race day shuttle buses depart from Fujisan Station.",
       "latitude": 35.4997,
-      "longitude": 138.7656
+      "longitude": 138.7656,
+      "walk_minutes": null,
+      "is_primary": false
     }
   ],
   "nearby_spots": [
@@ -383,5 +387,10 @@
       "description_en": "Official race T-shirt by THE NORTH FACE (first 2,800 entries; changes to original towel after limit reached), Finisher medal (finishers), Web finisher certificate (finishers)",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/chiba-aqualine-marathon-2026.json
+++ b/src/data/races/chiba-aqualine-marathon-2026.json
@@ -160,5 +160,10 @@
       "description_en": "",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/ehime-marathon-2026.json
+++ b/src/data/races/ehime-marathon-2026.json
@@ -171,5 +171,10 @@
       "description_en": "Official race T-shirt, Finisher medal, Imabari towel (finishers)",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/ehime-marathon-2027.json
+++ b/src/data/races/ehime-marathon-2027.json
@@ -195,5 +195,10 @@
       "description_en": "Finisher medal, Imabari towel (finishers)",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/fuji-mountain-race-2026.json
+++ b/src/data/races/fuji-mountain-race-2026.json
@@ -117,5 +117,10 @@
       "url": "https://fujimountainrace.city.fujiyoshida.yamanashi.jp/2026/wp-content/uploads/2026/04/info-sponsors.pdf",
       "label": "開催概要"
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/fujisan-marathon-2026.json
+++ b/src/data/races/fujisan-marathon-2026.json
@@ -195,5 +195,10 @@
       "description_en": "Finisher medal, Finisher towel",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/fukuchiyama-marathon-2026.json
+++ b/src/data/races/fukuchiyama-marathon-2026.json
@@ -176,5 +176,10 @@
       "description_en": "Finisher medal, Official race T-shirt (excluding late/last-minute entries)",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/fukui-sakura-marathon-2026.json
+++ b/src/data/races/fukui-sakura-marathon-2026.json
@@ -178,5 +178,10 @@
       "description_en": "Race T-shirt, Finisher medal, Finisher towel",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/fukuoka-international-marathon-2026.json
+++ b/src/data/races/fukuoka-international-marathon-2026.json
@@ -119,5 +119,10 @@
       "description_ja": null,
       "description_en": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/fukuoka-marathon-2026.json
+++ b/src/data/races/fukuoka-marathon-2026.json
@@ -213,5 +213,10 @@
       "description_en": "Finisher medal, sports towel (marathon only)",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/gunma-marathon-2026.json
+++ b/src/data/races/gunma-marathon-2026.json
@@ -186,5 +186,10 @@
       "description_en": "Full marathon finisher towel (sports towel, mint blue design)",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/higashine-sakuranbo-marathon-2026.json
+++ b/src/data/races/higashine-sakuranbo-marathon-2026.json
@@ -147,5 +147,10 @@
       "url": "https://www.sakuranbo-m.jp/qa/",
       "label": "FAQ"
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/higashinipon-half-marathon-2026.json
+++ b/src/data/races/higashinipon-half-marathon-2026.json
@@ -115,5 +115,10 @@
       "url": "https://www.runningkanagawa.com/legal/",
       "label": "開催概要"
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/himeji-castle-marathon-2026.json
+++ b/src/data/races/himeji-castle-marathon-2026.json
@@ -145,5 +145,10 @@
       "description_en": "Race T-shirt, Finisher medal, Finisher towel",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/hitachi-seaside-marathon-2026.json
+++ b/src/data/races/hitachi-seaside-marathon-2026.json
@@ -108,5 +108,10 @@
       "description_en": "",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/hofu-yomiuri-marathon-2026.json
+++ b/src/data/races/hofu-yomiuri-marathon-2026.json
@@ -162,5 +162,10 @@
       "description_en": "Finisher medal",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/hokkaido-marathon-2026.json
+++ b/src/data/races/hokkaido-marathon-2026.json
@@ -191,5 +191,10 @@
       "description_en": "Official race T-shirt, Finisher medal",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/ibusuki-nanohana-2026.json
+++ b/src/data/races/ibusuki-nanohana-2026.json
@@ -103,7 +103,9 @@
       "transport_to_venue_ja": "JR指宿駅から徒歩約15分",
       "transport_to_venue_en": "About 15 min walk from JR Ibusuki Station",
       "latitude": 31.2544,
-      "longitude": 130.6556
+      "longitude": 130.6556,
+      "walk_minutes": null,
+      "is_primary": false
     }
   ],
   "nearby_spots": [
@@ -177,5 +179,10 @@
     }
   ],
   "entry_closed": false,
-  "entry_links": []
+  "entry_links": [],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/ibusuki-nanohana-2026.json
+++ b/src/data/races/ibusuki-nanohana-2026.json
@@ -105,7 +105,7 @@
       "latitude": 31.2544,
       "longitude": 130.6556,
       "walk_minutes": null,
-      "is_primary": false
+      "is_primary": true
     }
   ],
   "nearby_spots": [

--- a/src/data/races/ichinoseki-half-marathon-2026.json
+++ b/src/data/races/ichinoseki-half-marathon-2026.json
@@ -116,5 +116,10 @@
       "url": "https://ichinoseki-half.jp/course/",
       "label": "コース情報"
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/iki-ultra-marathon-2026.json
+++ b/src/data/races/iki-ultra-marathon-2026.json
@@ -118,5 +118,10 @@
     "data_accuracy_notes": [
       "2026-05-30: 自動クロールで更新"
     ]
-  }
+  },
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/itabashi-city-marathon-2026.json
+++ b/src/data/races/itabashi-city-marathon-2026.json
@@ -155,5 +155,10 @@
       "description_en": "Race T-shirt, Finisher medal",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/iwaki-sunshine-marathon-2026.json
+++ b/src/data/races/iwaki-sunshine-marathon-2026.json
@@ -173,5 +173,10 @@
       "description_en": "Race T-shirt, Finisher medal",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/iwaki-sunshine-marathon-2027.json
+++ b/src/data/races/iwaki-sunshine-marathon-2027.json
@@ -173,5 +173,10 @@
       "description_en": "Finisher medal",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/iwate-morioka-city-marathon-2026.json
+++ b/src/data/races/iwate-morioka-city-marathon-2026.json
@@ -113,5 +113,10 @@
       "description_en": "Finisher towel, Nanbu ironware finisher medal",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/iwate-oshu-kirameki-marathon-2026.json
+++ b/src/data/races/iwate-oshu-kirameki-marathon-2026.json
@@ -148,5 +148,10 @@
       "description_en": "Race T-shirt, Finisher medal",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/izu-oshima-2026.json
+++ b/src/data/races/izu-oshima-2026.json
@@ -171,5 +171,10 @@
       "description_en": "",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/kagawa-marathon-2026.json
+++ b/src/data/races/kagawa-marathon-2026.json
@@ -166,5 +166,10 @@
       "description_en": "Finisher medal and finisher towel",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/kagoshima-marathon-2026.json
+++ b/src/data/races/kagoshima-marathon-2026.json
@@ -167,5 +167,10 @@
       "description_en": "Race T-shirt, Finisher medal",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/kaikyo-marathon-2026.json
+++ b/src/data/races/kaikyo-marathon-2026.json
@@ -187,5 +187,10 @@
       "description_en": "Finisher medal, Official race T-shirt",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/kanazawa-marathon-2026.json
+++ b/src/data/races/kanazawa-marathon-2026.json
@@ -174,5 +174,10 @@
       "description_en": "Official race T-shirt, Finisher medal, Local specialty products",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/kasama-togeinosato-half-2025-2025.json
+++ b/src/data/races/kasama-togeinosato-half-2025-2025.json
@@ -153,5 +153,10 @@
     "data_accuracy_notes": [
       "2026-05-30: 自動クロールで更新"
     ]
-  }
+  },
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/kasumigaura-marathon-2026.json
+++ b/src/data/races/kasumigaura-marathon-2026.json
@@ -169,5 +169,10 @@
       "description_en": "Race T-shirt, Finisher medal",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/katsuta-marathon-2026.json
+++ b/src/data/races/katsuta-marathon-2026.json
@@ -76,7 +76,7 @@
       "latitude": 36.3933,
       "longitude": 140.4756,
       "walk_minutes": null,
-      "is_primary": false
+      "is_primary": true
     }
   ],
   "nearby_spots": [

--- a/src/data/races/katsuta-marathon-2026.json
+++ b/src/data/races/katsuta-marathon-2026.json
@@ -74,7 +74,9 @@
       "transport_to_venue_ja": "JR勝田駅東口から徒歩約10分。無料シャトルバスあり。",
       "transport_to_venue_en": "About 10 min walk from JR Katsuta Station East Exit. Free shuttle bus available.",
       "latitude": 36.3933,
-      "longitude": 140.4756
+      "longitude": 140.4756,
+      "walk_minutes": null,
+      "is_primary": false
     }
   ],
   "nearby_spots": [
@@ -151,5 +153,10 @@
       "url": "https://katsutamarathon.jp/course/",
       "label": "コース情報"
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/kitakyushu-marathon-2026.json
+++ b/src/data/races/kitakyushu-marathon-2026.json
@@ -164,5 +164,10 @@
       "description_en": "Race T-shirt, Finisher medal, Finisher towel",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/kix-senshu-marathon-2026.json
+++ b/src/data/races/kix-senshu-marathon-2026.json
@@ -138,5 +138,10 @@
       "url": "http://www.senshu-marathon.jp/entry/",
       "label": "エントリー"
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/kobe-marathon-2026.json
+++ b/src/data/races/kobe-marathon-2026.json
@@ -196,5 +196,10 @@
       "description_en": "Official race T-shirt, Finisher medal, Finisher towel",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/kochi-ryoma-marathon-2026.json
+++ b/src/data/races/kochi-ryoma-marathon-2026.json
@@ -176,5 +176,10 @@
       "description_en": "Race T-shirt, Finisher medal",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/kochi-ryoma-marathon-2027.json
+++ b/src/data/races/kochi-ryoma-marathon-2027.json
@@ -178,5 +178,10 @@
       "description_en": "Finisher medal",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/kumamoto-castle-marathon-2026.json
+++ b/src/data/races/kumamoto-castle-marathon-2026.json
@@ -163,5 +163,10 @@
       "description_en": "Race T-shirt, Finisher medal",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/kyoto-marathon-2026.json
+++ b/src/data/races/kyoto-marathon-2026.json
@@ -199,5 +199,10 @@
       "description_en": "Official race T-shirt, Finisher medal",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/kyoto-marathon-2027.json
+++ b/src/data/races/kyoto-marathon-2027.json
@@ -202,5 +202,10 @@
       "description_en": "Finisher medal",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/mie-matsusaka-marathon-2026.json
+++ b/src/data/races/mie-matsusaka-marathon-2026.json
@@ -183,5 +183,10 @@
       "description_en": "Finisher medal",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/mito-komon-manyu-marathon-2026.json
+++ b/src/data/races/mito-komon-manyu-marathon-2026.json
@@ -170,5 +170,10 @@
       "description_en": "Finisher medal (Mito Komon inro design with plum blossom and seigaiha wave pattern)",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/mtfuji-climb-run-2026.json
+++ b/src/data/races/mtfuji-climb-run-2026.json
@@ -108,5 +108,10 @@
     "data_accuracy_notes": [
       "2026-05-30: 自動クロールで更新"
     ]
-  }
+  },
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/nagai-marathon-2026.json
+++ b/src/data/races/nagai-marathon-2026.json
@@ -119,5 +119,10 @@
       "url": "https://nagai-marathon.jp/wp/wp-content/themes/source_tcd045-child/pdf/nagaimararhon2026_yoko.pdf",
       "label": "大会要項"
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/nagano-marathon-2026.json
+++ b/src/data/races/nagano-marathon-2026.json
@@ -155,7 +155,9 @@
       "transport_to_venue_ja": "長野駅東口からスタート会場（長野運動公園）までシャトルバスで約15分。または北長野駅から徒歩約15分。",
       "transport_to_venue_en": "Shuttle bus from Nagano Station East Exit to the start venue (Nagano Athletic Park), approx. 15 min. Or 15 min walk from Kita-Nagano Station.",
       "latitude": 36.6433,
-      "longitude": 138.1889
+      "longitude": 138.1889,
+      "walk_minutes": null,
+      "is_primary": false
     },
     {
       "station_name_ja": "北長野駅",
@@ -164,7 +166,9 @@
       "transport_to_venue_ja": "徒歩約15分でスタート会場（長野運動公園）に到着",
       "transport_to_venue_en": "Approx. 15 min walk to the start venue (Nagano Athletic Park)",
       "latitude": 36.6586,
-      "longitude": 138.1932
+      "longitude": 138.1932,
+      "walk_minutes": null,
+      "is_primary": false
     }
   ],
   "nearby_spots": [
@@ -387,5 +391,10 @@
       "description_en": "Official race T-shirt (all participants), Finisher medal (finishers), Finisher towel (finishers)",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/nagoya-womens-marathon-2026.json
+++ b/src/data/races/nagoya-womens-marathon-2026.json
@@ -162,5 +162,10 @@
       "description_en": "Tiffany original pendant (all finishers)",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/naha-marathon-2026.json
+++ b/src/data/races/naha-marathon-2026.json
@@ -152,5 +152,10 @@
       "description_en": "Finisher medal, Finisher certificate",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/nara-marathon-2026.json
+++ b/src/data/races/nara-marathon-2026.json
@@ -199,5 +199,10 @@
       "description_en": "Finisher medal",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/niigata-city-marathon-2026.json
+++ b/src/data/races/niigata-city-marathon-2026.json
@@ -109,5 +109,10 @@
       "2026-06-22: 自動クロールで更新",
       "2026-06-29: 自動クロールで更新"
     ]
-  }
+  },
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/nishio-marathon-2026.json
+++ b/src/data/races/nishio-marathon-2026.json
@@ -101,5 +101,10 @@
   "voices": [],
   "time_buckets": [],
   "course_highlights": [],
-  "info_urls": []
+  "info_urls": [],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/ohtawara-marathon-2026.json
+++ b/src/data/races/ohtawara-marathon-2026.json
@@ -78,5 +78,10 @@
   "hero_caption_en": null,
   "gallery": [],
   "voices": [],
-  "time_buckets": []
+  "time_buckets": [],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/okayama-marathon-2026.json
+++ b/src/data/races/okayama-marathon-2026.json
@@ -157,5 +157,10 @@
       "description_en": "Race T-shirt, Finisher medal",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/okushinano100-2026.json
+++ b/src/data/races/okushinano100-2026.json
@@ -197,5 +197,10 @@
       "url": "https://okushinano100.com/entry/",
       "label": "エントリー"
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/osaka-marathon-2026.json
+++ b/src/data/races/osaka-marathon-2026.json
@@ -187,5 +187,10 @@
       "description_en": "Commemorative T-shirt, Finisher medal, Finisher towel",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/osaka-yodo-river-citizens-marathon-2026.json
+++ b/src/data/races/osaka-yodo-river-citizens-marathon-2026.json
@@ -126,5 +126,10 @@
       "2026-06-08: 自動クロールで更新",
       "2026-06-27: 自動クロールで更新"
     ]
-  }
+  },
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/osj-ontake100-2026.json
+++ b/src/data/races/osj-ontake100-2026.json
@@ -164,5 +164,10 @@
       "url": "https://www.outdoorsportsjapan.com/trail/ontake100/entry-list-ontake100/",
       "label": "エントリー"
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/sado-toki-marathon-2026.json
+++ b/src/data/races/sado-toki-marathon-2026.json
@@ -155,5 +155,10 @@
       "description_en": "Race T-shirt, Finisher medal, Sado Island local products",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/saga-sakura-marathon-2026.json
+++ b/src/data/races/saga-sakura-marathon-2026.json
@@ -147,5 +147,10 @@
       "description_en": "Race T-shirt, Finisher medal",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/saitama-marathon-2026.json
+++ b/src/data/races/saitama-marathon-2026.json
@@ -110,5 +110,10 @@
       "url": "https://saitama-marathon.jp/entry/",
       "label": "エントリー"
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/saitama-marathon-2027.json
+++ b/src/data/races/saitama-marathon-2027.json
@@ -131,5 +131,10 @@
       "label": "エントリー"
     }
   ],
-  "completion_gifts": []
+  "completion_gifts": [],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/sapporo-marathon-2026.json
+++ b/src/data/races/sapporo-marathon-2026.json
@@ -164,5 +164,10 @@
       "2026-05-30: 自動クロールで更新",
       "2026-06-08: 自動クロールで更新"
     ]
-  }
+  },
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/shiga-kogen100-2026.json
+++ b/src/data/races/shiga-kogen100-2026.json
@@ -121,5 +121,10 @@
       "2026-05-30: 自動クロールで更新",
       "2026-06-22: 自動クロールで更新"
     ]
-  }
+  },
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/shimada-oigawa-marathon-2026.json
+++ b/src/data/races/shimada-oigawa-marathon-2026.json
@@ -107,5 +107,10 @@
       "url": "https://www.shimada-marathon.jp/faq.html",
       "label": "FAQ"
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/shinetsu5mountains-trail-100-2026.json
+++ b/src/data/races/shinetsu5mountains-trail-100-2026.json
@@ -120,5 +120,10 @@
     "data_accuracy_notes": [
       "2026-05-30: 自動クロールで更新"
     ]
-  }
+  },
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/shizuoka-marathon-2026.json
+++ b/src/data/races/shizuoka-marathon-2026.json
@@ -140,5 +140,10 @@
       "description_en": "Race T-shirt, Finisher medal",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/shonan-international-marathon-2026.json
+++ b/src/data/races/shonan-international-marathon-2026.json
@@ -170,5 +170,10 @@
       "description_en": "Finisher medal",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/soja-kibiji-marathon-2026.json
+++ b/src/data/races/soja-kibiji-marathon-2026.json
@@ -163,5 +163,10 @@
       "description_en": "Race T-shirt, Finisher medal",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/tamba-sasayama-abc-marathon-2026.json
+++ b/src/data/races/tamba-sasayama-abc-marathon-2026.json
@@ -137,5 +137,10 @@
       "url": "https://tambasasayama-abc-marathon.jp/faq/",
       "label": "FAQ"
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/tateyama-wakashio-2026.json
+++ b/src/data/races/tateyama-wakashio-2026.json
@@ -150,5 +150,10 @@
       "description_en": "Race T-shirt, Finisher medal",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/tazawako-marathon-2026.json
+++ b/src/data/races/tazawako-marathon-2026.json
@@ -136,5 +136,10 @@
     "data_accuracy_notes": [
       "2026-05-30: 自動クロールで更新"
     ]
-  }
+  },
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/tokushima-marathon-2026.json
+++ b/src/data/races/tokushima-marathon-2026.json
@@ -139,5 +139,10 @@
       "description_en": "Race T-shirt, Finisher medal",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/tokyo-legacy-half-2026.json
+++ b/src/data/races/tokyo-legacy-half-2026.json
@@ -117,5 +117,10 @@
       "description_en": "",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/tokyo-marathon-2026.json
+++ b/src/data/races/tokyo-marathon-2026.json
@@ -70,7 +70,9 @@
       "transport_to_venue_ja": "新宿駅西口から徒歩約10分でスタート会場（東京都庁前）",
       "transport_to_venue_en": "10 min walk from Shinjuku Station West Exit to the start (Tokyo Metropolitan Government)",
       "latitude": 35.6896,
-      "longitude": 139.6999
+      "longitude": 139.6999,
+      "walk_minutes": null,
+      "is_primary": false
     },
     {
       "station_name_ja": "都庁前駅",
@@ -79,7 +81,9 @@
       "transport_to_venue_ja": "都営大江戸線都庁前駅直結",
       "transport_to_venue_en": "Direct access from Toei Oedo Line Tochomae Station",
       "latitude": 35.6915,
-      "longitude": 139.6917
+      "longitude": 139.6917,
+      "walk_minutes": null,
+      "is_primary": false
     }
   ],
   "nearby_spots": [
@@ -229,5 +233,10 @@
       "description_en": "Commemorative T-shirt (all participants), Finisher medal (finishers), Finisher towel (finishers)",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/tokyo-marathon-2027.json
+++ b/src/data/races/tokyo-marathon-2027.json
@@ -20,14 +20,25 @@
   "reception_type": "pre_day",
   "reception_note_ja": "EXPO会場（東京ビッグサイト）にて前日受付。大会当日の受付なし。",
   "reception_note_en": "Pre-race registration at EXPO venue (Tokyo Big Sight). No registration on race day.",
-  "tags": ["フラット","ワールドメジャーズ","初心者おすすめ","大規模","日本陸連公認","観光"],
+  "tags": [
+    "フラット",
+    "ワールドメジャーズ",
+    "初心者おすすめ",
+    "大規模",
+    "日本陸連公認",
+    "観光"
+  ],
   "course_gpx_file": null,
   "course_info": {
     "max_elevation_m": 40,
     "min_elevation_m": 3,
     "elevation_diff_m": 37,
     "surface": "road",
-    "certification": ["JAAF","AIMS","WMM"],
+    "certification": [
+      "JAAF",
+      "AIMS",
+      "WMM"
+    ],
     "highlights_ja": "東京都庁、皇居、浅草雷門、銀座、東京タワー、東京駅丸の内",
     "highlights_en": "Tokyo Metropolitan Government, Imperial Palace, Asakusa Kaminarimon, Ginza, Tokyo Tower, Tokyo Station Marunouchi",
     "notes_ja": null,
@@ -59,7 +70,9 @@
       "transport_to_venue_ja": "新宿駅西口から徒歩約10分でスタート会場（東京都庁前）",
       "transport_to_venue_en": "10 min walk from Shinjuku Station West Exit to the start (Tokyo Metropolitan Government)",
       "latitude": 35.6896,
-      "longitude": 139.6999
+      "longitude": 139.6999,
+      "walk_minutes": null,
+      "is_primary": false
     },
     {
       "station_name_ja": "都庁前駅",
@@ -68,7 +81,9 @@
       "transport_to_venue_ja": "都営大江戸線都庁前駅直結",
       "transport_to_venue_en": "Direct access from Toei Oedo Line Tochomae Station",
       "latitude": 35.6915,
-      "longitude": 139.6917
+      "longitude": 139.6917,
+      "walk_minutes": null,
+      "is_primary": false
     }
   ],
   "nearby_spots": [
@@ -109,7 +124,9 @@
   "weather_history": [],
   "participation_gifts": [
     {
-      "gift_categories": ["tshirt"],
+      "gift_categories": [
+        "tshirt"
+      ],
       "description_ja": "参加記念Tシャツ（参加者全員）",
       "description_en": "Commemorative T-shirt (all participants)",
       "image": null
@@ -178,26 +195,79 @@
   "voices": [],
   "time_buckets": [],
   "course_highlights": [
-    {"name_ja": "東京都庁","name_en": "Tokyo Metropolitan Government","description_ja": null,"description_en": null},
-    {"name_ja": "皇居","name_en": "Imperial Palace","description_ja": null,"description_en": null},
-    {"name_ja": "浅草雷門","name_en": "Asakusa Kaminarimon","description_ja": null,"description_en": null},
-    {"name_ja": "銀座","name_en": "Ginza","description_ja": null,"description_en": null},
-    {"name_ja": "東京タワー","name_en": "Tokyo Tower","description_ja": null,"description_en": null},
-    {"name_ja": "東京駅丸の内","name_en": "Tokyo Station Marunouchi","description_ja": null,"description_en": null}
+    {
+      "name_ja": "東京都庁",
+      "name_en": "Tokyo Metropolitan Government",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "皇居",
+      "name_en": "Imperial Palace",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "浅草雷門",
+      "name_en": "Asakusa Kaminarimon",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "銀座",
+      "name_en": "Ginza",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "東京タワー",
+      "name_en": "Tokyo Tower",
+      "description_ja": null,
+      "description_en": null
+    },
+    {
+      "name_ja": "東京駅丸の内",
+      "name_en": "Tokyo Station Marunouchi",
+      "description_ja": null,
+      "description_en": null
+    }
   ],
   "info_urls": [
-    {"url": "https://www.marathon.tokyo/volunteer/about/","label": "大会の特色"},
-    {"url": "https://www.marathon.tokyo/faq/","label": "FAQ"},
-    {"url": "https://www.marathon.tokyo/about/outline/","label": "大会要項"},
-    {"url": "https://www.marathon.tokyo/about/course/","label": "コース情報"},
-    {"url": "https://www.marathon.tokyo/participants/","label": "エントリー"}
+    {
+      "url": "https://www.marathon.tokyo/volunteer/about/",
+      "label": "大会の特色"
+    },
+    {
+      "url": "https://www.marathon.tokyo/faq/",
+      "label": "FAQ"
+    },
+    {
+      "url": "https://www.marathon.tokyo/about/outline/",
+      "label": "大会要項"
+    },
+    {
+      "url": "https://www.marathon.tokyo/about/course/",
+      "label": "コース情報"
+    },
+    {
+      "url": "https://www.marathon.tokyo/participants/",
+      "label": "エントリー"
+    }
   ],
   "completion_gifts": [
     {
-      "gift_categories": ["medal","towel"],
+      "gift_categories": [
+        "medal",
+        "towel"
+      ],
       "description_ja": "完走メダル、完走タオル（完走者）",
       "description_en": "Finisher medal, Finisher towel (finishers)",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/tomisato-suikaroad-2026.json
+++ b/src/data/races/tomisato-suikaroad-2026.json
@@ -141,5 +141,10 @@
       "url": "https://tomisato-suikaroad.jp/archives/770/",
       "label": "アクセス"
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/tottori-marathon-2026.json
+++ b/src/data/races/tottori-marathon-2026.json
@@ -153,5 +153,10 @@
       "description_en": "Race T-shirt",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/toyako-marathon-2026.json
+++ b/src/data/races/toyako-marathon-2026.json
@@ -160,5 +160,10 @@
       "description_en": "Race T-shirt, Finisher medal",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/toyama-marathon-2026.json
+++ b/src/data/races/toyama-marathon-2026.json
@@ -178,5 +178,10 @@
       "description_en": "Race T-shirt, Finisher medal",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/tsukuba-marathon-2026.json
+++ b/src/data/races/tsukuba-marathon-2026.json
@@ -140,5 +140,10 @@
       "url": "https://www.tsukuba-marathon.com/sitemap.php",
       "label": "コース情報"
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/wakkanai-peace-marathon-2026.json
+++ b/src/data/races/wakkanai-peace-marathon-2026.json
@@ -167,5 +167,10 @@
       "description_en": "Finisher medal, Official race T-shirt",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/data/races/yokohama-marathon-2026.json
+++ b/src/data/races/yokohama-marathon-2026.json
@@ -174,5 +174,10 @@
       "description_en": "Race T-shirt, Finisher medal, Finisher towel",
       "image": null
     }
-  ]
+  ],
+  "venue_name_ja": null,
+  "venue_name_en": null,
+  "venue_address": null,
+  "start_lat": null,
+  "start_lng": null
 }

--- a/src/lib/__tests__/fixtures.ts
+++ b/src/lib/__tests__/fixtures.ts
@@ -1,4 +1,4 @@
-import type { Race, RaceCategory, EntryPeriod, EntryLink, RaceGallery, RaceVoice, RaceTimeBucket, RaceCourseHighlight, ParticipationGift, CompletionGift } from '../types';
+import type { Race, RaceCategory, EntryPeriod, EntryLink, RaceGallery, RaceVoice, RaceTimeBucket, RaceCourseHighlight, ParticipationGift, CompletionGift, AccessPoint } from '../types';
 
 /** テスト用の最小限 Race オブジェクトを生成するファクトリ */
 export function makeRace(overrides: Partial<Race> = {}): Race {
@@ -60,6 +60,11 @@ export function makeRace(overrides: Partial<Race> = {}): Race {
     hero_image_url: null,
     hero_caption_ja: null,
     hero_caption_en: null,
+    venue_name_ja: null,
+    venue_name_en: null,
+    venue_address: null,
+    start_lat: null,
+    start_lng: null,
     created_at: '2025-01-01T00:00:00Z',
     updated_at: '2025-01-01T00:00:00Z',
     ...overrides,
@@ -181,6 +186,21 @@ export function makeCompletionGift(overrides: Partial<CompletionGift> = {}): Com
     description_ja: 'テスト完走賞',
     description_en: 'Test completion gift',
     image: null,
+    ...overrides,
+  };
+}
+
+export function makeAccessPoint(overrides: Partial<AccessPoint> = {}): AccessPoint {
+  return {
+    station_name_ja: 'テスト駅',
+    station_name_en: 'Test Station',
+    station_code: 'test',
+    transport_to_venue_ja: '徒歩10分',
+    transport_to_venue_en: '10 min walk',
+    latitude: 35.0,
+    longitude: 135.0,
+    walk_minutes: 10,
+    is_primary: true,
     ...overrides,
   };
 }

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -78,6 +78,8 @@ function rowToAccessPoint(row: AccessPointRow): AccessPoint {
     transport_to_venue_en: row.transport_to_venue_en,
     latitude: row.latitude,
     longitude: row.longitude,
+    walk_minutes: row.walk_minutes ?? null,
+    is_primary: row.is_primary,
   };
 }
 
@@ -303,6 +305,11 @@ function assembleRace(
     hero_image_url:  row.hero_image_url ?? null,
     hero_caption_ja: row.hero_caption_ja ?? null,
     hero_caption_en: row.hero_caption_en ?? null,
+    venue_name_ja:   row.venue_name_ja ?? null,
+    venue_name_en:   row.venue_name_en ?? null,
+    venue_address:   row.venue_address ?? null,
+    start_lat:       row.start_lat ?? null,
+    start_lng:       row.start_lng ?? null,
     created_at: row.created_at,
     updated_at: row.updated_at,
   };

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1,4 +1,5 @@
-import { sqliteTable, text, integer, real, index } from "drizzle-orm/sqlite-core";
+import { sqliteTable, text, integer, real, index, uniqueIndex } from "drizzle-orm/sqlite-core";
+import { sql } from "drizzle-orm";
 import { relations } from "drizzle-orm";
 
 // ==================
@@ -151,6 +152,8 @@ export const access_points = sqliteTable("access_points", {
   sort_order:            integer("sort_order").notNull().default(0),
 }, (t) => [
   index("access_points_race_id_idx").on(t.race_id),
+  // 1レースにつき is_primary=true の行は1件のみ許可する partial unique index
+  uniqueIndex("access_points_primary_unique_idx").on(t.race_id, t.is_primary).where(sql`${t.is_primary} = 1`),
 ]);
 
 // ==================

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -41,6 +41,12 @@ export const races = sqliteTable("races", {
   course_highlights_en:    text("course_highlights_en").notNull().default(""),
   course_notes_ja:         text("course_notes_ja"),
   course_notes_en:         text("course_notes_en"),
+  // Issue #80: 会場・スタート地点
+  venue_name_ja:         text("venue_name_ja"),            // スタート地点名称（例: 神戸市役所前）
+  venue_name_en:         text("venue_name_en"),
+  venue_address:         text("venue_address"),            // ジオコーディング・経路検索の宛先
+  start_lat:             real("start_lat"),                // スタート地点緯度
+  start_lng:             real("start_lng"),                // スタート地点経度
   // Phase 2: ビジュアル拡張フィールド
   motif:                 text("motif"),                    // 漢字モチーフ（例: 都、霊峰）
   motif_color:           text("motif_color"),              // モチーフカラー（例: #1d4373）
@@ -140,6 +146,8 @@ export const access_points = sqliteTable("access_points", {
   transport_to_venue_en: text("transport_to_venue_en").notNull().default(""),
   latitude:              real("latitude").notNull().default(0),
   longitude:             real("longitude").notNull().default(0),
+  walk_minutes:          integer("walk_minutes"),          // 駅から会場までの徒歩分数（不明なら NULL）
+  is_primary:            integer("is_primary", { mode: "boolean" }).notNull().default(false), // 代表最寄駅フラグ
   sort_order:            integer("sort_order").notNull().default(0),
 }, (t) => [
   index("access_points_race_id_idx").on(t.race_id),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -62,6 +62,12 @@ export interface Race {
   hero_image_url: string | null;
   hero_caption_ja: string | null;
   hero_caption_en: string | null;
+  // Issue #80: 会場・スタート地点
+  venue_name_ja: string | null;
+  venue_name_en: string | null;
+  venue_address: string | null;
+  start_lat: number | null;
+  start_lng: number | null;
   created_at: string; // ISO datetime string
   updated_at: string; // ISO datetime string
 }
@@ -179,6 +185,9 @@ export interface AccessPoint {
   transport_to_venue_en: string;
   latitude: number;
   longitude: number;
+  // Issue #80: 追加フィールド
+  walk_minutes: number | null;
+  is_primary: boolean;
 }
 
 // ==================

--- a/tools/admin-server.js
+++ b/tools/admin-server.js
@@ -303,6 +303,18 @@ function getMissingFields(r) {
     medium.push({ field: 'description', label: '説明文' });
   }
 
+  // 会場・スタート地点（Issue #80）
+  if (!r.venue_address) {
+    high.push({ field: 'venue_address', label: '会場住所' });
+  }
+  if (r.start_lat == null || r.start_lng == null) {
+    high.push({ field: 'start_coords', label: 'スタート地点座標' });
+  }
+  const hasPrimaryAccessPoint = (r.access_points ?? []).some(ap => ap.is_primary);
+  if ((r.access_points ?? []).length > 0 && !hasPrimaryAccessPoint) {
+    medium.push({ field: 'access_point_primary', label: '代表最寄駅（is_primary）' });
+  }
+
   // 周辺スポット
   if (!r.nearby_spots || r.nearby_spots.length === 0) {
     medium.push({ field: 'nearby_spots', label: '周辺スポット' });
@@ -572,6 +584,11 @@ const server = http.createServer(async (req, res) => {
           checkpoints: [],
           access_points: [],
           nearby_spots: [],
+          venue_name_ja: null,
+          venue_name_en: null,
+          venue_address: null,
+          start_lat: null,
+          start_lng: null,
           result: null,
           created_at: now,
           updated_at: now,

--- a/tools/admin-server.test.js
+++ b/tools/admin-server.test.js
@@ -223,6 +223,60 @@ describe('getMissingFields', () => {
     });
   });
 
+  describe('会場住所（high）', () => {
+    test('venue_address が null → high に追加', () => {
+      const r = { entry_periods: [{ start_date: '2026-01-01' }], entry_start_date: null, entry_fee_by_category: true, categories: [{ entry_fee: 5000, time_limit_minutes: 360 }], official_url: 'https://example.com', entry_capacity: 100, description_ja: '説明', nearby_spots: [{}], venue_address: null, start_lat: 35.0, start_lng: 135.0 };
+      const { high } = getMissingFields(r);
+      assert.ok(high.some(f => f.field === 'venue_address'));
+    });
+
+    test('venue_address に値あり → 追加しない', () => {
+      const r = { entry_periods: [{ start_date: '2026-01-01' }], entry_start_date: null, entry_fee_by_category: true, categories: [{ entry_fee: 5000, time_limit_minutes: 360 }], official_url: 'https://example.com', entry_capacity: 100, description_ja: '説明', nearby_spots: [{}], venue_address: '東京都新宿区1-1-1', start_lat: 35.0, start_lng: 135.0 };
+      const { high } = getMissingFields(r);
+      assert.ok(!high.some(f => f.field === 'venue_address'));
+    });
+  });
+
+  describe('スタート地点座標（high）', () => {
+    test('start_lat が null → high に追加', () => {
+      const r = { entry_periods: [{ start_date: '2026-01-01' }], entry_start_date: null, entry_fee_by_category: true, categories: [{ entry_fee: 5000, time_limit_minutes: 360 }], official_url: 'https://example.com', entry_capacity: 100, description_ja: '説明', nearby_spots: [{}], venue_address: '住所', start_lat: null, start_lng: 135.0 };
+      const { high } = getMissingFields(r);
+      assert.ok(high.some(f => f.field === 'start_coords'));
+    });
+
+    test('start_lng が null → high に追加', () => {
+      const r = { entry_periods: [{ start_date: '2026-01-01' }], entry_start_date: null, entry_fee_by_category: true, categories: [{ entry_fee: 5000, time_limit_minutes: 360 }], official_url: 'https://example.com', entry_capacity: 100, description_ja: '説明', nearby_spots: [{}], venue_address: '住所', start_lat: 35.0, start_lng: null };
+      const { high } = getMissingFields(r);
+      assert.ok(high.some(f => f.field === 'start_coords'));
+    });
+
+    test('座標両方あり → 追加しない', () => {
+      const r = { entry_periods: [{ start_date: '2026-01-01' }], entry_start_date: null, entry_fee_by_category: true, categories: [{ entry_fee: 5000, time_limit_minutes: 360 }], official_url: 'https://example.com', entry_capacity: 100, description_ja: '説明', nearby_spots: [{}], venue_address: '住所', start_lat: 35.0, start_lng: 135.0 };
+      const { high } = getMissingFields(r);
+      assert.ok(!high.some(f => f.field === 'start_coords'));
+    });
+  });
+
+  describe('代表最寄駅（medium）', () => {
+    test('access_points が1件以上あり is_primary=false のみ → medium に追加', () => {
+      const r = { entry_periods: [{ start_date: '2026-01-01' }], entry_start_date: null, entry_fee_by_category: true, categories: [{ entry_fee: 5000, time_limit_minutes: 360 }], official_url: 'https://example.com', entry_capacity: 100, description_ja: '説明', nearby_spots: [{}], venue_address: '住所', start_lat: 35.0, start_lng: 135.0, access_points: [{ is_primary: false }] };
+      const { medium } = getMissingFields(r);
+      assert.ok(medium.some(f => f.field === 'access_point_primary'));
+    });
+
+    test('access_points に is_primary=true あり → 追加しない', () => {
+      const r = { entry_periods: [{ start_date: '2026-01-01' }], entry_start_date: null, entry_fee_by_category: true, categories: [{ entry_fee: 5000, time_limit_minutes: 360 }], official_url: 'https://example.com', entry_capacity: 100, description_ja: '説明', nearby_spots: [{}], venue_address: '住所', start_lat: 35.0, start_lng: 135.0, access_points: [{ is_primary: true }] };
+      const { medium } = getMissingFields(r);
+      assert.ok(!medium.some(f => f.field === 'access_point_primary'));
+    });
+
+    test('access_points が空配列 → 追加しない（駅データ自体が未入力）', () => {
+      const r = { entry_periods: [{ start_date: '2026-01-01' }], entry_start_date: null, entry_fee_by_category: true, categories: [{ entry_fee: 5000, time_limit_minutes: 360 }], official_url: 'https://example.com', entry_capacity: 100, description_ja: '説明', nearby_spots: [{}], venue_address: '住所', start_lat: 35.0, start_lng: 135.0, access_points: [] };
+      const { medium } = getMissingFields(r);
+      assert.ok(!medium.some(f => f.field === 'access_point_primary'));
+    });
+  });
+
   describe('すべて整備済み', () => {
     test('全フィールド揃っている場合は high/medium ともに空配列', () => {
       const r = {
@@ -234,6 +288,10 @@ describe('getMissingFields', () => {
         entry_capacity: 38000,
         description_ja: '世界的に有名な都市型マラソン大会',
         nearby_spots: [{ type: '観光地', name_ja: 'テスト神社' }],
+        venue_address: '東京都新宿区1-1-1',
+        start_lat: 35.6895,
+        start_lng: 139.6917,
+        access_points: [{ is_primary: true }],
       };
       const { high, medium } = getMissingFields(r);
       assert.deepEqual(high, []);

--- a/tools/admin/app.js
+++ b/tools/admin/app.js
@@ -804,6 +804,10 @@ const NEARBY_SPOT_TYPES = [
 ];
 
 // ── アクセスポイント ──────────────────────────────────────────────
+function escAttr(val) {
+  return String(val ?? '').replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
 function renderAccessPoints(points) {
   const container = document.getElementById('access-points-container');
   container.innerHTML = '';
@@ -823,31 +827,35 @@ function addAccessPointRow(ap = {}) {
     <div class="nearby-spot-fields">
       <div class="field">
         <label>駅名（日本語）</label>
-        <input type="text" class="ap-name-ja" value="${ap.station_name_ja ?? ''}">
+        <input type="text" class="ap-name-ja" value="${escAttr(ap.station_name_ja)}">
       </div>
       <div class="field">
         <label>駅名（English）</label>
-        <input type="text" class="ap-name-en" value="${ap.station_name_en ?? ''}">
+        <input type="text" class="ap-name-en" value="${escAttr(ap.station_name_en)}">
+      </div>
+      <div class="field">
+        <label>駅コード</label>
+        <input type="text" class="ap-station-code" placeholder="例: shinjuku" value="${escAttr(ap.station_code)}">
       </div>
       <div class="field full">
         <label>アクセス方法（日本語）</label>
-        <input type="text" class="ap-transport-ja" placeholder="例: 徒歩10分" value="${ap.transport_to_venue_ja ?? ''}">
+        <input type="text" class="ap-transport-ja" placeholder="例: 徒歩10分" value="${escAttr(ap.transport_to_venue_ja)}">
       </div>
       <div class="field full">
         <label>アクセス方法（English）</label>
-        <input type="text" class="ap-transport-en" placeholder="例: 10 min walk" value="${ap.transport_to_venue_en ?? ''}">
+        <input type="text" class="ap-transport-en" placeholder="例: 10 min walk" value="${escAttr(ap.transport_to_venue_en)}">
       </div>
       <div class="field">
         <label>徒歩分数</label>
-        <input type="number" class="ap-walk-minutes" min="0" placeholder="例: 10" value="${ap.walk_minutes ?? ''}">
+        <input type="number" class="ap-walk-minutes" min="0" placeholder="例: 10" value="${escAttr(ap.walk_minutes ?? '')}">
       </div>
       <div class="field">
         <label>緯度</label>
-        <input type="number" class="ap-lat" step="0.000001" value="${ap.latitude ?? ''}">
+        <input type="number" class="ap-lat" step="0.000001" value="${escAttr(ap.latitude != null && ap.latitude !== 0 ? ap.latitude : '')}">
       </div>
       <div class="field">
         <label>経度</label>
-        <input type="number" class="ap-lng" step="0.000001" value="${ap.longitude ?? ''}">
+        <input type="number" class="ap-lng" step="0.000001" value="${escAttr(ap.longitude != null && ap.longitude !== 0 ? ap.longitude : '')}">
       </div>
       <div class="field">
         <label><input type="checkbox" class="ap-is-primary" ${ap.is_primary ? 'checked' : ''}> 代表最寄駅</label>
@@ -860,17 +868,22 @@ function addAccessPointRow(ap = {}) {
 }
 
 function collectAccessPoints() {
-  return Array.from(document.querySelectorAll('#access-points-container .nearby-spot-row')).map(row => ({
-    station_name_ja: row.querySelector('.ap-name-ja').value,
-    station_name_en: row.querySelector('.ap-name-en').value,
-    station_code: '',
-    transport_to_venue_ja: row.querySelector('.ap-transport-ja').value,
-    transport_to_venue_en: row.querySelector('.ap-transport-en').value,
-    walk_minutes: row.querySelector('.ap-walk-minutes').value ? Number(row.querySelector('.ap-walk-minutes').value) : null,
-    latitude: Number(row.querySelector('.ap-lat').value) || 0,
-    longitude: Number(row.querySelector('.ap-lng').value) || 0,
-    is_primary: row.querySelector('.ap-is-primary').checked,
-  }));
+  return Array.from(document.querySelectorAll('#access-points-container .nearby-spot-row')).map((row, idx) => {
+    const latVal = row.querySelector('.ap-lat').value;
+    const lngVal = row.querySelector('.ap-lng').value;
+    return {
+      station_name_ja: row.querySelector('.ap-name-ja').value,
+      station_name_en: row.querySelector('.ap-name-en').value,
+      station_code: row.querySelector('.ap-station-code').value,
+      transport_to_venue_ja: row.querySelector('.ap-transport-ja').value,
+      transport_to_venue_en: row.querySelector('.ap-transport-en').value,
+      walk_minutes: row.querySelector('.ap-walk-minutes').value ? Number(row.querySelector('.ap-walk-minutes').value) : null,
+      latitude: latVal ? Number(latVal) : null,
+      longitude: lngVal ? Number(lngVal) : null,
+      is_primary: row.querySelector('.ap-is-primary').checked,
+      sort_order: idx,
+    };
+  });
 }
 
 document.getElementById('btn-add-access-point').addEventListener('click', () => addAccessPointRow());

--- a/tools/admin/app.js
+++ b/tools/admin/app.js
@@ -199,6 +199,14 @@ function populateForm(r) {
   // 完走賞
   renderCompletionGifts(r.completion_gifts ?? []);
 
+  // 会場・アクセス（Issue #80）
+  setVal('f-venue_name_ja', r.venue_name_ja ?? '');
+  setVal('f-venue_name_en', r.venue_name_en ?? '');
+  setVal('f-venue_address', r.venue_address ?? '');
+  setVal('f-start_lat', r.start_lat ?? '');
+  setVal('f-start_lng', r.start_lng ?? '');
+  renderAccessPoints(r.access_points ?? []);
+
   // 周辺スポット
   renderNearbySpots(r.nearby_spots ?? []);
 
@@ -795,6 +803,78 @@ const NEARBY_SPOT_TYPES = [
   { value: '宿泊',   icon: '🏨' },
 ];
 
+// ── アクセスポイント ──────────────────────────────────────────────
+function renderAccessPoints(points) {
+  const container = document.getElementById('access-points-container');
+  container.innerHTML = '';
+  points.forEach(ap => addAccessPointRow(ap));
+}
+
+function addAccessPointRow(ap = {}) {
+  const container = document.getElementById('access-points-container');
+  const row = document.createElement('div');
+  row.className = 'nearby-spot-row';
+
+  row.innerHTML = `
+    <div class="gift-row-header">
+      <span class="gift-row-label">駅 ${container.children.length + 1}</span>
+      <button class="btn btn-danger btn-remove-ap">削除</button>
+    </div>
+    <div class="nearby-spot-fields">
+      <div class="field">
+        <label>駅名（日本語）</label>
+        <input type="text" class="ap-name-ja" value="${ap.station_name_ja ?? ''}">
+      </div>
+      <div class="field">
+        <label>駅名（English）</label>
+        <input type="text" class="ap-name-en" value="${ap.station_name_en ?? ''}">
+      </div>
+      <div class="field full">
+        <label>アクセス方法（日本語）</label>
+        <input type="text" class="ap-transport-ja" placeholder="例: 徒歩10分" value="${ap.transport_to_venue_ja ?? ''}">
+      </div>
+      <div class="field full">
+        <label>アクセス方法（English）</label>
+        <input type="text" class="ap-transport-en" placeholder="例: 10 min walk" value="${ap.transport_to_venue_en ?? ''}">
+      </div>
+      <div class="field">
+        <label>徒歩分数</label>
+        <input type="number" class="ap-walk-minutes" min="0" placeholder="例: 10" value="${ap.walk_minutes ?? ''}">
+      </div>
+      <div class="field">
+        <label>緯度</label>
+        <input type="number" class="ap-lat" step="0.000001" value="${ap.latitude ?? ''}">
+      </div>
+      <div class="field">
+        <label>経度</label>
+        <input type="number" class="ap-lng" step="0.000001" value="${ap.longitude ?? ''}">
+      </div>
+      <div class="field">
+        <label><input type="checkbox" class="ap-is-primary" ${ap.is_primary ? 'checked' : ''}> 代表最寄駅</label>
+      </div>
+    </div>
+  `;
+
+  row.querySelector('.btn-remove-ap').addEventListener('click', () => row.remove());
+  container.appendChild(row);
+}
+
+function collectAccessPoints() {
+  return Array.from(document.querySelectorAll('#access-points-container .nearby-spot-row')).map(row => ({
+    station_name_ja: row.querySelector('.ap-name-ja').value,
+    station_name_en: row.querySelector('.ap-name-en').value,
+    station_code: '',
+    transport_to_venue_ja: row.querySelector('.ap-transport-ja').value,
+    transport_to_venue_en: row.querySelector('.ap-transport-en').value,
+    walk_minutes: row.querySelector('.ap-walk-minutes').value ? Number(row.querySelector('.ap-walk-minutes').value) : null,
+    latitude: Number(row.querySelector('.ap-lat').value) || 0,
+    longitude: Number(row.querySelector('.ap-lng').value) || 0,
+    is_primary: row.querySelector('.ap-is-primary').checked,
+  }));
+}
+
+document.getElementById('btn-add-access-point').addEventListener('click', () => addAccessPointRow());
+
 function renderNearbySpots(spots) {
   const container = document.getElementById('nearby-spots-container');
   container.innerHTML = '';
@@ -1077,6 +1157,13 @@ function buildRaceData() {
     course_gpx_file: currentRace?.course_gpx_file ?? null,
     participation_gifts: collectGifts(),
     completion_gifts: collectCompletionGifts(),
+    // 会場・アクセス（Issue #80）
+    venue_name_ja: getVal('f-venue_name_ja') || null,
+    venue_name_en: getVal('f-venue_name_en') || null,
+    venue_address: getVal('f-venue_address') || null,
+    start_lat: getVal('f-start_lat') ? Number(getVal('f-start_lat')) : null,
+    start_lng: getVal('f-start_lng') ? Number(getVal('f-start_lng')) : null,
+    access_points: collectAccessPoints(),
     nearby_spots: collectNearbySpots(),
     // Phase 2: ビジュアル拡張フィールド
     motif: getVal('f-motif') || null,

--- a/tools/admin/app.js
+++ b/tools/admin/app.js
@@ -1043,6 +1043,14 @@ async function saveRace() {
   if (!currentRace) return;
 
   const updated = buildRaceData();
+
+  // 代表最寄駅（is_primary=true）は1件のみ許可
+  const primaryCount = (updated.access_points ?? []).filter(ap => ap.is_primary).length;
+  if (primaryCount > 1) {
+    alert(`代表最寄駅（is_primary）は1件のみ設定できます。現在 ${primaryCount} 件が選択されています。`);
+    return;
+  }
+
   const btn = document.getElementById('btn-save');
   const status = document.getElementById('save-status');
   btn.disabled = true;

--- a/tools/admin/index.html
+++ b/tools/admin/index.html
@@ -224,6 +224,40 @@
             <button class="btn btn-secondary" id="btn-add-completion-gift">＋ 完走賞を追加</button>
           </section>
 
+          <!-- 会場・アクセス -->
+          <section class="form-section">
+            <h2 class="section-title">会場・アクセス</h2>
+            <div class="form-grid">
+              <div class="field">
+                <label>会場名（日本語）</label>
+                <input type="text" id="f-venue_name_ja" placeholder="例: 神戸市役所前" />
+              </div>
+              <div class="field">
+                <label>会場名（English）</label>
+                <input type="text" id="f-venue_name_en" placeholder="例: Kobe City Hall" />
+              </div>
+              <div class="field full">
+                <label>会場住所 <span class="required-badge">必須</span></label>
+                <input type="text" id="f-venue_address" placeholder="例: 兵庫県神戸市中央区加納町6丁目5-1" />
+              </div>
+              <div class="field">
+                <label>スタート地点 緯度 <span class="required-badge">必須</span></label>
+                <input type="number" id="f-start_lat" step="0.000001" placeholder="例: 34.6901" />
+              </div>
+              <div class="field">
+                <label>スタート地点 経度 <span class="required-badge">必須</span></label>
+                <input type="number" id="f-start_lng" step="0.000001" placeholder="例: 135.1956" />
+              </div>
+            </div>
+            <div style="margin-top:16px;">
+              <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:8px;">
+                <label style="font-size:13px;font-weight:600;color:var(--mid);">最寄駅・アクセス</label>
+                <button class="btn btn-secondary" id="btn-add-access-point">＋ 駅を追加</button>
+              </div>
+              <div id="access-points-container"></div>
+            </div>
+          </section>
+
           <!-- 周辺スポット -->
           <section class="form-section">
             <h2 class="section-title">周辺スポット</h2>


### PR DESCRIPTION
Closes #80

## 概要

前泊判定・旅程提案（エピック #4）の前提となるスタート地点・最寄駅データの受け皿を整備。

## スキーマ変更

### races テーブルへ追加
| カラム | 型 | 備考 |
|---|---|---|
| venue_name_ja | text | スタート地点名称 |
| venue_name_en | text | |
| venue_address | text | ジオコーディング・経路検索の宛先 |
| start_lat | real | スタート地点緯度 |
| start_lng | real | スタート地点経度 |

### access_points テーブルへ追加
| カラム | 型 | 備考 |
|---|---|---|
| walk_minutes | integer | 駅から会場までの徒歩分数 |
| is_primary | boolean | 代表最寄駅フラグ |

## 変更内容

- **マイグレーション**: `0011_parallel_winter_soldier.sql`（ローカルD1適用済み）
- **型定義**: `Race` / `AccessPoint` インターフェースに新フィールドを追加
- **JSONデータ**: `scripts/add-venue-fields.js` で全89ファイルに null フィールドを一括追加
- **シードスクリプト**: 新カラム対応・seed-races-all.sql 再生成済み
- **管理ツール**: venue_address / 座標 / is_primary の欠損チェックを追加

## Test plan

- [x] vitest: 332テスト全Pass
- [x] admin-server.test.js: 53テスト全Pass（venue関連11テスト追加）
- [ ] `pnpm run db:migrate:remote` でリモートD1に適用
- [ ] `pnpm run dev` でエラーなし確認
- [ ] 主要5大会に手動で会場データを投入し表示確認（後続タスク）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 大会編集画面に「会場・アクセス」セクションを追加し、会場名/住所、スタート地点（緯度/経度）、徒歩分数、代表最寄駅を入力・保存できるようになりました。
  * 新規/既存の大会データでも会場・アクセス情報が反映されます。
* **Bug Fixes**
  * 完備度チェックで、会場住所・スタート地点座標・代表最寄駅の未整備をより正確に検出します。
  * 代表最寄駅の重複を防ぐ整合性確認を追加しました。
* **Documentation**
  * 会場・アクセス関連のスキーマ/更新履歴を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->