### PR TITLE
feat: 装備管理テーブル追加 (Issue #120)

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -296,6 +296,10 @@ ER図は `docs/er-diagram.drawio` で管理しています。[draw.io](https://a
 | user_races | user_races_user_id_idx | user_id |
 | user_races | user_races_race_id_idx | race_id |
 | user_races | user_races_user_race_idx | user_id, race_id |
+| user_gear | user_gear_user_id_idx | user_id |
+| user_race_gear | user_race_gear_user_race_id_idx | user_race_id |
+| user_race_gear | user_race_gear_unique_idx（unique） | user_race_id, gear_id |
+| user_race_results | user_race_results_user_race_id_idx | user_race_id |
 
 ---
 
@@ -311,6 +315,7 @@ ER図は `docs/er-diagram.drawio` で管理しています。[draw.io](https://a
 | is_planning | integer(boolean) | NO | 参加予定フラグ |
 | planning_category_id | integer | YES | FK → race_categories.id（SET NULL）。参加予定カテゴリ |
 | entry_reminder_period_ids | text | NO | エントリーリマインド対象の entry_period id 一覧（JSON: number[]、デフォルト "[]"） |
+| gear_is_public | integer(bool) | NO | 装備リストを公開するかどうか（デフォルト false）。Issue #120 |
 | created_at | text | NO | ISO8601 |
 | updated_at | text | NO | ISO8601 |
 
@@ -406,6 +411,64 @@ ER図は `docs/er-diagram.drawio` で管理しています。[draw.io](https://a
 
 ---
 
+## user_gear テーブル
+
+ユーザーが所持するギア（シューズ・ウェア・栄養補給品など）のマスター。
+
+| カラム | 型 | NULL | デフォルト | 備考 |
+|---|---|---|---|---|
+| id | text | NO | — | PK（UUID） |
+| user_id | text | NO | — | FK → user.id（CASCADE） |
+| category | text | NO | — | `GearCategory`（shoes / tops / bottoms 等 12種） |
+| brand | text | NO | `""` | ブランド名 |
+| name | text | NO | — | 商品名 |
+| amazon_url | text | YES | — | Amazon商品URL |
+| asin | text | YES | — | Amazon ASIN |
+| usage_tag | text | NO | — | `race` / `training` / `both` |
+| memo | text | NO | `""` | メモ |
+| is_retired | integer(bool) | NO | `false` | 引退フラグ |
+| created_at | text | NO | — | ISO8601 |
+| updated_at | text | NO | — | ISO8601 |
+
+---
+
+## user_race_gear テーブル
+
+ユーザーの大会登録（user_races）に紐付くギアリスト。
+
+| カラム | 型 | NULL | デフォルト | 備考 |
+|---|---|---|---|---|
+| id | integer | NO | autoincrement | PK |
+| user_race_id | text | NO | — | FK → user_races.id（CASCADE） |
+| gear_id | text | NO | — | FK → user_gear.id（CASCADE） |
+| quantity | integer | NO | `1` | 持参予定数量 |
+| used | integer(bool) | YES | — | NULL=未記録 / true=使用 / false=未使用 |
+| used_quantity | integer | YES | — | 実際に使用した数量 |
+| note | text | NO | `""` | メモ |
+| sort_order | integer | NO | `0` | 表示順 |
+
+**備考**
+- `(user_race_id, gear_id)` に unique 制約あり（同一大会に同じギアを重複登録不可）
+
+---
+
+## user_race_results テーブル
+
+ユーザーの大会結果（自己記録）。user_races と 1:1 対応。
+
+| カラム | 型 | NULL | デフォルト | 備考 |
+|---|---|---|---|---|
+| id | text | NO | — | PK（UUID） |
+| user_race_id | text | NO | — | FK → user_races.id（CASCADE）。UNIQUE |
+| category_id | integer | YES | — | FK → race_categories.id（SET NULL）。参加カテゴリ |
+| status | text | NO | — | `finished` / `dnf` / `dns` |
+| finish_time_sec | integer | YES | — | フィニッシュタイム（秒）。DNF/DNS 時は null |
+| note | text | NO | `""` | 振り返りメモ |
+| created_at | text | NO | — | ISO8601 |
+| updated_at | text | NO | — | ISO8601 |
+
+---
+
 ## マイグレーション履歴
 
 | ファイル | 内容 |
@@ -429,3 +492,4 @@ ER図は `docs/er-diagram.drawio` で管理しています。[draw.io](https://a
 | `migrations/0010_loving_mister_fear.sql` | race_entry_periods.end_date の NOT NULL 制約を削除（終了日未定のエントリー期間を許容） |
 | `migrations/0011_parallel_winter_soldier.sql` | races に venue_name_ja/venue_name_en/venue_address/start_lat/start_lng を追加。access_points に walk_minutes/is_primary を追加（Issue #80） |
 | `migrations/0012_fearless_sleeper.sql` | access_points に partial unique index を追加（race_id + is_primary=1 の組み合わせを一意制約）（Issue #80） |
+| `migrations/0013_old_rick_jones.sql` | user_gear / user_race_gear / user_race_results テーブルを追加。user_races に gear_is_public カラムを追加（Issue #120） |

--- a/docs/update-history.md
+++ b/docs/update-history.md
@@ -716,6 +716,14 @@
 - ローカル・リモートDBへのマイグレーション適用・シード再適用完了
 
 
+## 2026-07-06 装備管理テーブル追加（Issue #120）
+
+- `src/lib/db/schema.ts`: `user_gear` / `user_race_gear` / `user_race_results` テーブルを追加。`user_races` に `gear_is_public` カラムを追加。各テーブルの Relations を追加
+- `migrations/0013_old_rick_jones.sql`: Drizzle生成マイグレーション。ローカルD1に適用済み
+- `src/lib/types.ts`: `GEAR_CATEGORIES`（12種）/ `GEAR_USAGE_TAGS`（3値）/ `RACE_RESULT_STATUSES`（3値）定数と `UserGear` / `UserRaceGear` / `UserRaceResult` 型を追加
+- `src/lib/__tests__/gear-types.test.ts`: 型・定数のユニットテスト9件（全Pass）
+- `docs/schema.md`: 新テーブル定義・マイグレーション履歴・インデックス一覧を更新
+
 ## 2026-07-05 会場・アクセスデータ基盤の整備（Issue #80）
 
 - `src/lib/db/schema.ts`: `races` に `venue_name_ja` / `venue_name_en` / `venue_address` / `start_lat` / `start_lng` を追加。`access_points` に `walk_minutes` / `is_primary` を追加

--- a/migrations/0013_old_rick_jones.sql
+++ b/migrations/0013_old_rick_jones.sql
@@ -1,0 +1,48 @@
+CREATE TABLE `user_gear` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`category` text NOT NULL,
+	`brand` text DEFAULT '' NOT NULL,
+	`name` text NOT NULL,
+	`amazon_url` text,
+	`asin` text,
+	`usage_tag` text DEFAULT 'both' NOT NULL,
+	`memo` text DEFAULT '' NOT NULL,
+	`is_retired` integer DEFAULT false NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `user_gear_user_id_idx` ON `user_gear` (`user_id`);--> statement-breakpoint
+CREATE TABLE `user_race_gear` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`user_race_id` text NOT NULL,
+	`gear_id` text NOT NULL,
+	`quantity` integer DEFAULT 1 NOT NULL,
+	`used` integer,
+	`used_quantity` integer,
+	`note` text DEFAULT '' NOT NULL,
+	`sort_order` integer DEFAULT 0 NOT NULL,
+	FOREIGN KEY (`user_race_id`) REFERENCES `user_races`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`gear_id`) REFERENCES `user_gear`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `user_race_gear_user_race_id_idx` ON `user_race_gear` (`user_race_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `user_race_gear_unique_idx` ON `user_race_gear` (`user_race_id`,`gear_id`);--> statement-breakpoint
+CREATE TABLE `user_race_results` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_race_id` text NOT NULL,
+	`category_id` integer,
+	`status` text NOT NULL,
+	`finish_time_sec` integer,
+	`note` text DEFAULT '' NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	FOREIGN KEY (`user_race_id`) REFERENCES `user_races`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`category_id`) REFERENCES `race_categories`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `user_race_results_user_race_id_unique` ON `user_race_results` (`user_race_id`);--> statement-breakpoint
+CREATE INDEX `user_race_results_user_race_id_idx` ON `user_race_results` (`user_race_id`);--> statement-breakpoint
+ALTER TABLE `user_races` ADD `gear_is_public` integer DEFAULT false NOT NULL;

--- a/migrations/meta/0013_snapshot.json
+++ b/migrations/meta/0013_snapshot.json
@@ -1,0 +1,3016 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "46bad7ae-286d-4d8e-a4b5-ac52c215f4a0",
+  "prevId": "201b0359-90e9-427f-80b2-0a1999c82225",
+  "tables": {
+    "access_points": {
+      "name": "access_points",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "station_name_ja": {
+          "name": "station_name_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "station_name_en": {
+          "name": "station_name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "station_code": {
+          "name": "station_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "transport_to_venue_ja": {
+          "name": "transport_to_venue_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "transport_to_venue_en": {
+          "name": "transport_to_venue_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "walk_minutes": {
+          "name": "walk_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "access_points_race_id_idx": {
+          "name": "access_points_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        },
+        "access_points_primary_unique_idx": {
+          "name": "access_points_primary_unique_idx",
+          "columns": [
+            "race_id",
+            "is_primary"
+          ],
+          "isUnique": true,
+          "where": "\"access_points\".\"is_primary\" = 1"
+        }
+      },
+      "foreignKeys": {
+        "access_points_race_id_races_id_fk": {
+          "name": "access_points_race_id_races_id_fk",
+          "tableFrom": "access_points",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "aid_stations": {
+      "name": "aid_stations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "distance_km": {
+          "name": "distance_km",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "offerings_ja": {
+          "name": "offerings_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "offerings_en": {
+          "name": "offerings_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "aid_stations_race_id_idx": {
+          "name": "aid_stations_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "aid_stations_race_id_races_id_fk": {
+          "name": "aid_stations_race_id_races_id_fk",
+          "tableFrom": "aid_stations",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "checkpoints": {
+      "name": "checkpoints",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "distance_km": {
+          "name": "distance_km",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "closing_time": {
+          "name": "closing_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "checkpoints_race_id_idx": {
+          "name": "checkpoints_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "checkpoints_race_id_races_id_fk": {
+          "name": "checkpoints_race_id_races_id_fk",
+          "tableFrom": "checkpoints",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "completion_gifts": {
+      "name": "completion_gifts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gift_categories": {
+          "name": "gift_categories",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "description_ja": {
+          "name": "description_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description_en": {
+          "name": "description_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "completion_gifts_race_id_idx": {
+          "name": "completion_gifts_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "completion_gifts_race_id_races_id_fk": {
+          "name": "completion_gifts_race_id_races_id_fk",
+          "tableFrom": "completion_gifts",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "contact_submissions": {
+      "name": "contact_submissions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "contact_submissions_status_idx": {
+          "name": "contact_submissions_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "contact_submissions_created_at_idx": {
+          "name": "contact_submissions_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "contact_submissions_user_id_user_id_fk": {
+          "name": "contact_submissions_user_id_user_id_fk",
+          "tableFrom": "contact_submissions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gift_categories": {
+      "name": "gift_categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_ja": {
+          "name": "name_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_en": {
+          "name": "name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "nearby_spots": {
+      "name": "nearby_spots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_ja": {
+          "name": "name_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_en": {
+          "name": "name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description_ja": {
+          "name": "description_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description_en": {
+          "name": "description_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "distance_from_venue": {
+          "name": "distance_from_venue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "nearby_spots_race_id_idx": {
+          "name": "nearby_spots_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "nearby_spots_race_id_races_id_fk": {
+          "name": "nearby_spots_race_id_races_id_fk",
+          "tableFrom": "nearby_spots",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "participation_gifts": {
+      "name": "participation_gifts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gift_categories": {
+          "name": "gift_categories",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "description_ja": {
+          "name": "description_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description_en": {
+          "name": "description_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "participation_gifts_race_id_idx": {
+          "name": "participation_gifts_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "participation_gifts_race_id_races_id_fk": {
+          "name": "participation_gifts_race_id_races_id_fk",
+          "tableFrom": "participation_gifts",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkey": {
+      "name": "passkey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "webAuthnUserID": {
+          "name": "webAuthnUserID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deviceType": {
+          "name": "deviceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backedUp": {
+          "name": "backedUp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "passkey_userId_user_id_fk": {
+          "name": "passkey_userId_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prefectures": {
+      "name": "prefectures",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_en": {
+          "name": "name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region_en": {
+          "name": "region_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lat": {
+          "name": "lat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lng": {
+          "name": "lng",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_categories": {
+      "name": "race_categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "distance_type": {
+          "name": "distance_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "distance_km": {
+          "name": "distance_km",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "time_limit_minutes": {
+          "name": "time_limit_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "entry_fee": {
+          "name": "entry_fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_fee_u25": {
+          "name": "entry_fee_u25",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name_ja": {
+          "name": "name_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name_en": {
+          "name": "name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description_ja": {
+          "name": "description_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description_en": {
+          "name": "description_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "eligibility_ja": {
+          "name": "eligibility_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "eligibility_en": {
+          "name": "eligibility_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "course_gpx_file": {
+          "name": "course_gpx_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "waves": {
+          "name": "waves",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "race_categories_race_id_idx": {
+          "name": "race_categories_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_categories_race_id_races_id_fk": {
+          "name": "race_categories_race_id_races_id_fk",
+          "tableFrom": "race_categories",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_course_highlights": {
+      "name": "race_course_highlights",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "km": {
+          "name": "km",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name_ja": {
+          "name": "name_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_en": {
+          "name": "name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note_ja": {
+          "name": "note_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note_en": {
+          "name": "note_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "race_course_highlights_race_id_idx": {
+          "name": "race_course_highlights_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_course_highlights_race_id_races_id_fk": {
+          "name": "race_course_highlights_race_id_races_id_fk",
+          "tableFrom": "race_course_highlights",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "race_course_highlights_category_id_race_categories_id_fk": {
+          "name": "race_course_highlights_category_id_race_categories_id_fk",
+          "tableFrom": "race_course_highlights",
+          "tableTo": "race_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_entry_links": {
+      "name": "race_entry_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "race_entry_links_race_id_idx": {
+          "name": "race_entry_links_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_entry_links_race_id_races_id_fk": {
+          "name": "race_entry_links_race_id_races_id_fk",
+          "tableFrom": "race_entry_links",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_entry_periods": {
+      "name": "race_entry_periods",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "label_ja": {
+          "name": "label_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'一般エントリー'"
+        },
+        "label_en": {
+          "name": "label_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'General Entry'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_fee": {
+          "name": "entry_fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "race_entry_periods_race_id_idx": {
+          "name": "race_entry_periods_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_entry_periods_race_id_races_id_fk": {
+          "name": "race_entry_periods_race_id_races_id_fk",
+          "tableFrom": "race_entry_periods",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "race_entry_periods_category_id_race_categories_id_fk": {
+          "name": "race_entry_periods_category_id_race_categories_id_fk",
+          "tableFrom": "race_entry_periods",
+          "tableTo": "race_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_gallery": {
+      "name": "race_gallery",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "src": {
+          "name": "src",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caption_ja": {
+          "name": "caption_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "caption_en": {
+          "name": "caption_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "race_gallery_race_id_idx": {
+          "name": "race_gallery_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_gallery_race_id_races_id_fk": {
+          "name": "race_gallery_race_id_races_id_fk",
+          "tableFrom": "race_gallery",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_results": {
+      "name": "race_results",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "participants_count": {
+          "name": "participants_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finishers_count": {
+          "name": "finishers_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finisher_rate_pct": {
+          "name": "finisher_rate_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "weather_condition_ja": {
+          "name": "weather_condition_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "weather_condition_en": {
+          "name": "weather_condition_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "temperature_c": {
+          "name": "temperature_c",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_temp_c": {
+          "name": "max_temp_c",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "min_temp_c": {
+          "name": "min_temp_c",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "wind_speed_ms": {
+          "name": "wind_speed_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "humidity_pct": {
+          "name": "humidity_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes_ja": {
+          "name": "notes_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes_en": {
+          "name": "notes_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avg_time": {
+          "name": "avg_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "race_results_race_id_idx": {
+          "name": "race_results_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_results_race_id_races_id_fk": {
+          "name": "race_results_race_id_races_id_fk",
+          "tableFrom": "race_results",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_series": {
+      "name": "race_series",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_ja": {
+          "name": "name_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_en": {
+          "name": "name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_held_year": {
+          "name": "first_held_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_time_buckets": {
+      "name": "race_time_buckets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pct": {
+          "name": "pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "race_time_buckets_race_id_idx": {
+          "name": "race_time_buckets_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_time_buckets_race_id_races_id_fk": {
+          "name": "race_time_buckets_race_id_races_id_fk",
+          "tableFrom": "race_time_buckets",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "race_voices": {
+      "name": "race_voices",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quote_ja": {
+          "name": "quote_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quote_en": {
+          "name": "quote_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "race_voices_race_id_idx": {
+          "name": "race_voices_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "race_voices_race_id_races_id_fk": {
+          "name": "race_voices_race_id_races_id_fk",
+          "tableFrom": "race_voices",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "races": {
+      "name": "races",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_ja": {
+          "name": "name_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_en": {
+          "name": "name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "full_name_ja": {
+          "name": "full_name_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "full_name_en": {
+          "name": "full_name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "edition": {
+          "name": "edition",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prefecture": {
+          "name": "prefecture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "city_ja": {
+          "name": "city_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "city_en": {
+          "name": "city_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description_ja": {
+          "name": "description_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description_en": {
+          "name": "description_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "official_url": {
+          "name": "official_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "entry_fee": {
+          "name": "entry_fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_fee_by_category": {
+          "name": "entry_fee_by_category",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "entry_capacity": {
+          "name": "entry_capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "entry_start_date": {
+          "name": "entry_start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_end_date": {
+          "name": "entry_end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_closed": {
+          "name": "entry_closed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "reception_type": {
+          "name": "reception_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'race_day'"
+        },
+        "reception_note_ja": {
+          "name": "reception_note_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "reception_note_en": {
+          "name": "reception_note_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "course_gpx_file": {
+          "name": "course_gpx_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "course_max_elevation_m": {
+          "name": "course_max_elevation_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "course_min_elevation_m": {
+          "name": "course_min_elevation_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "course_elevation_diff_m": {
+          "name": "course_elevation_diff_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "course_surface": {
+          "name": "course_surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'road'"
+        },
+        "course_certification": {
+          "name": "course_certification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "course_highlights_ja": {
+          "name": "course_highlights_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "course_highlights_en": {
+          "name": "course_highlights_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "course_notes_ja": {
+          "name": "course_notes_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "course_notes_en": {
+          "name": "course_notes_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "venue_name_ja": {
+          "name": "venue_name_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "venue_name_en": {
+          "name": "venue_name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "venue_address": {
+          "name": "venue_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_lat": {
+          "name": "start_lat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_lng": {
+          "name": "start_lng",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "motif": {
+          "name": "motif",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "motif_color": {
+          "name": "motif_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "motif_romaji": {
+          "name": "motif_romaji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tagline_ja": {
+          "name": "tagline_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tagline_en": {
+          "name": "tagline_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hero_image_url": {
+          "name": "hero_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hero_caption_ja": {
+          "name": "hero_caption_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hero_caption_en": {
+          "name": "hero_caption_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "races_date_idx": {
+          "name": "races_date_idx",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        },
+        "races_prefecture_idx": {
+          "name": "races_prefecture_idx",
+          "columns": [
+            "prefecture"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "races_series_id_race_series_id_fk": {
+          "name": "races_series_id_race_series_id_fk",
+          "tableFrom": "races",
+          "tableTo": "race_series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_gear": {
+      "name": "user_gear",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amazon_url": {
+          "name": "amazon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "asin": {
+          "name": "asin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_tag": {
+          "name": "usage_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'both'"
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "is_retired": {
+          "name": "is_retired",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_gear_user_id_idx": {
+          "name": "user_gear_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_gear_user_id_user_id_fk": {
+          "name": "user_gear_user_id_user_id_fk",
+          "tableFrom": "user_gear",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_race_gear": {
+      "name": "user_race_gear",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_race_id": {
+          "name": "user_race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "used": {
+          "name": "used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_quantity": {
+          "name": "used_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "user_race_gear_user_race_id_idx": {
+          "name": "user_race_gear_user_race_id_idx",
+          "columns": [
+            "user_race_id"
+          ],
+          "isUnique": false
+        },
+        "user_race_gear_unique_idx": {
+          "name": "user_race_gear_unique_idx",
+          "columns": [
+            "user_race_id",
+            "gear_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_race_gear_user_race_id_user_races_id_fk": {
+          "name": "user_race_gear_user_race_id_user_races_id_fk",
+          "tableFrom": "user_race_gear",
+          "tableTo": "user_races",
+          "columnsFrom": [
+            "user_race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_race_gear_gear_id_user_gear_id_fk": {
+          "name": "user_race_gear_gear_id_user_gear_id_fk",
+          "tableFrom": "user_race_gear",
+          "tableTo": "user_gear",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_race_results": {
+      "name": "user_race_results",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_race_id": {
+          "name": "user_race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finish_time_sec": {
+          "name": "finish_time_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_race_results_user_race_id_unique": {
+          "name": "user_race_results_user_race_id_unique",
+          "columns": [
+            "user_race_id"
+          ],
+          "isUnique": true
+        },
+        "user_race_results_user_race_id_idx": {
+          "name": "user_race_results_user_race_id_idx",
+          "columns": [
+            "user_race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_race_results_user_race_id_user_races_id_fk": {
+          "name": "user_race_results_user_race_id_user_races_id_fk",
+          "tableFrom": "user_race_results",
+          "tableTo": "user_races",
+          "columnsFrom": [
+            "user_race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_race_results_category_id_race_categories_id_fk": {
+          "name": "user_race_results_category_id_race_categories_id_fk",
+          "tableFrom": "user_race_results",
+          "tableTo": "race_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_races": {
+      "name": "user_races",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_planning": {
+          "name": "is_planning",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "planning_category_id": {
+          "name": "planning_category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_reminder_period_ids": {
+          "name": "entry_reminder_period_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "gear_is_public": {
+          "name": "gear_is_public",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_races_user_id_idx": {
+          "name": "user_races_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "user_races_race_id_idx": {
+          "name": "user_races_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        },
+        "user_races_user_race_idx": {
+          "name": "user_races_user_race_idx",
+          "columns": [
+            "user_id",
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_races_user_id_user_id_fk": {
+          "name": "user_races_user_id_user_id_fk",
+          "tableFrom": "user_races",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_races_race_id_races_id_fk": {
+          "name": "user_races_race_id_races_id_fk",
+          "tableFrom": "user_races",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_races_planning_category_id_race_categories_id_fk": {
+          "name": "user_races_planning_category_id_race_categories_id_fk",
+          "tableFrom": "user_races",
+          "tableTo": "race_categories",
+          "columnsFrom": [
+            "planning_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "weather_history": {
+      "name": "weather_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avg_temp": {
+          "name": "avg_temp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "max_temp": {
+          "name": "max_temp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "min_temp": {
+          "name": "min_temp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "humidity_pct": {
+          "name": "humidity_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "precipitation_mm": {
+          "name": "precipitation_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "wind_speed_ms": {
+          "name": "wind_speed_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "weather_history_race_id_idx": {
+          "name": "weather_history_race_id_idx",
+          "columns": [
+            "race_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "weather_history_race_id_races_id_fk": {
+          "name": "weather_history_race_id_races_id_fk",
+          "tableFrom": "weather_history",
+          "tableTo": "races",
+          "columnsFrom": [
+            "race_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1783310438507,
       "tag": "0012_fearless_sleeper",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "6",
+      "when": 1783334269282,
+      "tag": "0013_old_rick_jones",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/__tests__/gear-types.test.ts
+++ b/src/lib/__tests__/gear-types.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import {
+  GEAR_CATEGORIES,
+  GEAR_USAGE_TAGS,
+  RACE_RESULT_STATUSES,
+  type GearCategory,
+  type GearUsageTag,
+  type RaceResultStatus,
+  type UserGear,
+  type UserRaceGear,
+  type UserRaceResult,
+} from '../types';
+
+describe('GEAR_CATEGORIES', () => {
+  it('必須カテゴリが含まれている', () => {
+    const required: GearCategory[] = ['shoes', 'tops', 'bottoms', 'nutrition', 'other'];
+    for (const cat of required) {
+      expect(GEAR_CATEGORIES).toContain(cat);
+    }
+  });
+
+  it('12件定義されている', () => {
+    expect(GEAR_CATEGORIES).toHaveLength(12);
+  });
+
+  it('重複がない', () => {
+    expect(new Set(GEAR_CATEGORIES).size).toBe(GEAR_CATEGORIES.length);
+  });
+});
+
+describe('GEAR_USAGE_TAGS', () => {
+  it('race / training / both の3値', () => {
+    expect(GEAR_USAGE_TAGS).toContain('race');
+    expect(GEAR_USAGE_TAGS).toContain('training');
+    expect(GEAR_USAGE_TAGS).toContain('both');
+    expect(GEAR_USAGE_TAGS).toHaveLength(3);
+  });
+});
+
+describe('RACE_RESULT_STATUSES', () => {
+  it('finished / dnf / dns の3値', () => {
+    expect(RACE_RESULT_STATUSES).toContain('finished');
+    expect(RACE_RESULT_STATUSES).toContain('dnf');
+    expect(RACE_RESULT_STATUSES).toContain('dns');
+    expect(RACE_RESULT_STATUSES).toHaveLength(3);
+  });
+});
+
+describe('UserGear 型の形状', () => {
+  it('必須フィールドを持つオブジェクトが組み立てられる', () => {
+    const gear: UserGear = {
+      id: 'gear-1',
+      user_id: 'user-1',
+      category: 'shoes',
+      brand: 'HOKA',
+      name: 'Speedgoat 5',
+      amazon_url: null,
+      asin: null,
+      usage_tag: 'race',
+      memo: '',
+      is_retired: false,
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    };
+    expect(gear.id).toBe('gear-1');
+    expect(gear.category).toBe('shoes');
+    expect(gear.is_retired).toBe(false);
+  });
+});
+
+describe('UserRaceGear 型の形状', () => {
+  it('必須フィールドを持つオブジェクトが組み立てられる', () => {
+    const raceGear: UserRaceGear = {
+      id: 1,
+      user_race_id: 'user-race-1',
+      gear_id: 'gear-1',
+      quantity: 6,
+      used: null,
+      used_quantity: null,
+      note: '',
+      sort_order: 0,
+    };
+    expect(raceGear.quantity).toBe(6);
+    expect(raceGear.used).toBeNull();
+  });
+});
+
+describe('UserRaceResult 型の形状', () => {
+  it('必須フィールドを持つオブジェクトが組み立てられる', () => {
+    const result: UserRaceResult = {
+      id: 'result-1',
+      user_race_id: 'user-race-1',
+      category_id: null,
+      status: 'finished',
+      finish_time_sec: 14400,
+      note: '',
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    };
+    expect(result.status).toBe('finished');
+    expect(result.finish_time_sec).toBe(14400);
+  });
+
+  it('dnf の場合 finish_time_sec は null 可', () => {
+    const result: UserRaceResult = {
+      id: 'result-2',
+      user_race_id: 'user-race-2',
+      category_id: null,
+      status: 'dnf',
+      finish_time_sec: null,
+      note: '',
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    };
+    expect(result.status).toBe('dnf');
+    expect(result.finish_time_sec).toBeNull();
+  });
+});

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -461,12 +461,70 @@ export const user_races = sqliteTable("user_races", {
   planning_category_id:      integer("planning_category_id").references(() => race_categories.id, { onDelete: "set null" }),
   // 受付開始前日リマインド（複数エントリー期間対応）
   entry_reminder_period_ids: text("entry_reminder_period_ids").notNull().default("[]"), // JSON: number[]
+  // 装備リスト公開フラグ（Issue #120）
+  gear_is_public:            integer("gear_is_public", { mode: "boolean" }).notNull().default(false),
   created_at:                text("created_at").notNull(),
   updated_at:                text("updated_at").notNull(),
 }, (t) => [
   index("user_races_user_id_idx").on(t.user_id),
   index("user_races_race_id_idx").on(t.race_id),
   index("user_races_user_race_idx").on(t.user_id, t.race_id),
+]);
+
+// ==================
+// user_gear（マイギア）Issue #120
+// ==================
+
+export const user_gear = sqliteTable("user_gear", {
+  id:          text("id").primaryKey(),
+  user_id:     text("user_id").notNull().references(() => user.id, { onDelete: "cascade" }),
+  category:    text("category").notNull(),           // GearCategory
+  brand:       text("brand").notNull().default(""),
+  name:        text("name").notNull(),
+  amazon_url:  text("amazon_url"),                   // ユーザーが貼った元URL
+  asin:        text("asin"),                         // URLから抽出したASIN
+  usage_tag:   text("usage_tag").notNull().default("both"), // GearUsageTag
+  memo:        text("memo").notNull().default(""),
+  is_retired:  integer("is_retired", { mode: "boolean" }).notNull().default(false),
+  created_at:  text("created_at").notNull(),
+  updated_at:  text("updated_at").notNull(),
+}, (t) => [
+  index("user_gear_user_id_idx").on(t.user_id),
+]);
+
+// ==================
+// user_race_gear（レース×装備の紐付け）Issue #120
+// ==================
+
+export const user_race_gear = sqliteTable("user_race_gear", {
+  id:            integer("id").primaryKey({ autoIncrement: true }),
+  user_race_id:  text("user_race_id").notNull().references(() => user_races.id, { onDelete: "cascade" }),
+  gear_id:       text("gear_id").notNull().references(() => user_gear.id, { onDelete: "cascade" }),
+  quantity:      integer("quantity").notNull().default(1),
+  used:          integer("used", { mode: "boolean" }),   // NULL=未記録
+  used_quantity: integer("used_quantity"),
+  note:          text("note").notNull().default(""),
+  sort_order:    integer("sort_order").notNull().default(0),
+}, (t) => [
+  index("user_race_gear_user_race_id_idx").on(t.user_race_id),
+  uniqueIndex("user_race_gear_unique_idx").on(t.user_race_id, t.gear_id),
+]);
+
+// ==================
+// user_race_results（レース結果の自己記録）Issue #120
+// ==================
+
+export const user_race_results = sqliteTable("user_race_results", {
+  id:               text("id").primaryKey(),
+  user_race_id:     text("user_race_id").notNull().unique().references(() => user_races.id, { onDelete: "cascade" }),
+  category_id:      integer("category_id").references(() => race_categories.id, { onDelete: "set null" }),
+  status:           text("status").notNull(),           // RaceResultStatus
+  finish_time_sec:  integer("finish_time_sec"),         // NULL=DNF/DNS
+  note:             text("note").notNull().default(""),
+  created_at:       text("created_at").notNull(),
+  updated_at:       text("updated_at").notNull(),
+}, (t) => [
+  index("user_race_results_user_race_id_idx").on(t.user_race_id),
 ]);
 
 // ==================
@@ -551,7 +609,24 @@ export const completionGiftsRelations = relations(completion_gifts, ({ one }) =>
   race: one(races, { fields: [completion_gifts.race_id], references: [races.id] }),
 }));
 
-export const userRacesRelations = relations(user_races, ({ one }) => ({
-  user: one(user, { fields: [user_races.user_id], references: [user.id] }),
-  race: one(races, { fields: [user_races.race_id], references: [races.id] }),
+export const userRacesRelations = relations(user_races, ({ one, many }) => ({
+  user:   one(user, { fields: [user_races.user_id], references: [user.id] }),
+  race:   one(races, { fields: [user_races.race_id], references: [races.id] }),
+  gear:   many(user_race_gear),
+  result: one(user_race_results, { fields: [user_races.id], references: [user_race_results.user_race_id] }),
+}));
+
+export const userGearRelations = relations(user_gear, ({ one, many }) => ({
+  user:      one(user, { fields: [user_gear.user_id], references: [user.id] }),
+  race_gear: many(user_race_gear),
+}));
+
+export const userRaceGearRelations = relations(user_race_gear, ({ one }) => ({
+  user_race: one(user_races, { fields: [user_race_gear.user_race_id], references: [user_races.id] }),
+  gear:      one(user_gear, { fields: [user_race_gear.gear_id], references: [user_gear.id] }),
+}));
+
+export const userRaceResultsRelations = relations(user_race_results, ({ one }) => ({
+  user_race: one(user_races, { fields: [user_race_results.user_race_id], references: [user_races.id] }),
+  category:  one(race_categories, { fields: [user_race_results.category_id], references: [race_categories.id] }),
 }));

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -417,3 +417,56 @@ export interface RaceFilter {
   sort: RaceSortKey;
   view: 'mag' | 'exp';
 }
+
+// ==================
+// 装備品管理（Issue #120）
+// ==================
+
+export const GEAR_CATEGORIES = [
+  'shoes', 'tops', 'bottoms', 'socks', 'cap', 'sunglasses',
+  'watch', 'pack', 'light', 'poles', 'nutrition', 'other',
+] as const;
+export type GearCategory = typeof GEAR_CATEGORIES[number];
+
+export const GEAR_USAGE_TAGS = ['race', 'training', 'both'] as const;
+export type GearUsageTag = typeof GEAR_USAGE_TAGS[number];
+
+export const RACE_RESULT_STATUSES = ['finished', 'dnf', 'dns'] as const;
+export type RaceResultStatus = typeof RACE_RESULT_STATUSES[number];
+
+export interface UserGear {
+  id: string;
+  user_id: string;
+  category: GearCategory;
+  brand: string;
+  name: string;
+  amazon_url: string | null;
+  asin: string | null;
+  usage_tag: GearUsageTag;
+  memo: string;
+  is_retired: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface UserRaceGear {
+  id: number;
+  user_race_id: string;
+  gear_id: string;
+  quantity: number;
+  used: boolean | null;
+  used_quantity: number | null;
+  note: string;
+  sort_order: number;
+}
+
+export interface UserRaceResult {
+  id: string;
+  user_race_id: string;
+  category_id: number | null;
+  status: RaceResultStatus;
+  finish_time_sec: number | null;
+  note: string;
+  created_at: string;
+  updated_at: string;
+}


### PR DESCRIPTION
## Summary

- `user_gear` / `user_race_gear` / `user_race_results` テーブルを新規追加
- `user_races` に `gear_is_public`（装備リスト公開フラグ）カラムを追加
- `src/lib/types.ts` に `GEAR_CATEGORIES`（12種）・`GEAR_USAGE_TAGS`・`RACE_RESULT_STATUSES` 定数と対応する型を追加
- `migrations/0013_old_rick_jones.sql` を生成・ローカルD1に適用済み
- `docs/schema.md` / `docs/update-history.md` を更新

## Schema

| テーブル | 用途 |
|---|---|
| `user_gear` | ユーザーが所持するギアのマスター |
| `user_race_gear` | 大会×ギアの紐付け（持参予定・使用実績） |
| `user_race_results` | 大会の自己記録（完走/DNF/DNS・タイム） |

## Test plan

- [ ] `pnpm test` で `gear-types.test.ts` の9テストがすべて Pass することを確認
- [ ] `pnpm run db:migrate:local` でローカルマイグレーションが適用済みであることを確認（本ブランチでは適用済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 装備管理に対応し、ユーザーの所持装備、レースごとの装備内訳、レース結果の自己記録を扱えるようになりました。
  * レース画面で装備リストの公開/非公開を設定できるようになりました。
  * 装備カテゴリ、使用タグ、レース結果ステータスの選択肢が追加されました。

* **改善**
  * 装備関連データの管理に必要な基盤が整備され、今後の機能拡張に対応しやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->