### PR TITLE
test: API routeとsitemapのテストを追加（Issue #87）

### DIFF
--- a/src/app/__tests__/sitemap.test.ts
+++ b/src/app/__tests__/sitemap.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Race } from '@/lib/types';
+
+// ─── モック定義 ────────────────────────────────────────────────────────────
+const { mockGetRaces } = vi.hoisted(() => ({
+  mockGetRaces: vi.fn<[], Promise<Race[]>>(),
+}));
+
+vi.mock('@/lib/data', () => ({
+  getRaces: mockGetRaces,
+}));
+
+// ─── テスト対象インポート ─────────────────────────────────────────────────
+import sitemap from '../sitemap';
+
+// ─── テストデータ ──────────────────────────────────────────────────────────
+function makeRace(id: string, date: string): Race {
+  return {
+    id,
+    name_ja: `${id} ja`,
+    name_en: `${id} en`,
+    full_name_ja: null,
+    full_name_en: null,
+    date,
+    prefecture: 'tokyo',
+    city_ja: '東京都',
+    city_en: 'Tokyo',
+    description_ja: '',
+    description_en: '',
+    website_url: null,
+    image_url: null,
+    venue_ja: null,
+    venue_en: null,
+    categories: [],
+    participation_gifts: [],
+    completion_gifts: [],
+    tags: [],
+    entry_periods: [],
+    entry_start_date: null,
+    entry_end_date: null,
+    entry_closed: false,
+    course_info: null,
+    series_id: null,
+    entry_links: [],
+    access_points: [],
+    nearby_spots: [],
+    weather_info: [],
+    results: [],
+    gallery: [],
+    voices: [],
+    time_buckets: [],
+    course_highlights: [],
+    reception_sessions: [],
+    travel_times: [],
+  } as unknown as Race;
+}
+
+const MOCK_RACES = [
+  makeRace('tokyo-marathon-2026', '2026-03-01'),
+  makeRace('osaka-marathon-2026', '2026-11-29'),
+];
+
+const STATIC_PAGE_COUNT = 9; // STATIC_PAGES の件数
+const LOCALE_COUNT = 2;      // ['ja', 'en']
+
+// ─── sitemap() ──────────────────────────────────────────────────────────────
+describe('sitemap()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('静的ページ × ロケール数のエントリを含む', async () => {
+    mockGetRaces.mockResolvedValue([]);
+
+    const entries = await sitemap();
+
+    expect(entries).toHaveLength(STATIC_PAGE_COUNT * LOCALE_COUNT);
+  });
+
+  it('レース × ロケール数のエントリを追加する', async () => {
+    mockGetRaces.mockResolvedValue(MOCK_RACES);
+
+    const entries = await sitemap();
+
+    expect(entries).toHaveLength(STATIC_PAGE_COUNT * LOCALE_COUNT + MOCK_RACES.length * LOCALE_COUNT);
+  });
+
+  it('URLは BASE_URL/locale/... の形式', async () => {
+    mockGetRaces.mockResolvedValue([]);
+
+    const entries = await sitemap();
+    const urls = entries.map((e) => e.url);
+
+    expect(urls).toContain('https://hashiru.run/ja');
+    expect(urls).toContain('https://hashiru.run/en');
+    expect(urls).toContain('https://hashiru.run/ja/races');
+    expect(urls).toContain('https://hashiru.run/en/races');
+  });
+
+  it('レースエントリのURLは /locale/races/:id 形式', async () => {
+    mockGetRaces.mockResolvedValue(MOCK_RACES);
+
+    const entries = await sitemap();
+    const urls = entries.map((e) => e.url);
+
+    expect(urls).toContain('https://hashiru.run/ja/races/tokyo-marathon-2026');
+    expect(urls).toContain('https://hashiru.run/en/races/tokyo-marathon-2026');
+    expect(urls).toContain('https://hashiru.run/ja/races/osaka-marathon-2026');
+    expect(urls).toContain('https://hashiru.run/en/races/osaka-marathon-2026');
+  });
+
+  it('各エントリに alternates.languages が含まれる', async () => {
+    mockGetRaces.mockResolvedValue([]);
+
+    const entries = await sitemap();
+    const home = entries.find((e) => e.url === 'https://hashiru.run/ja');
+
+    expect(home?.alternates?.languages).toMatchObject({
+      ja: 'https://hashiru.run/ja',
+      en: 'https://hashiru.run/en',
+    });
+  });
+
+  it('レースエントリの lastModified は race.date から生成される', async () => {
+    mockGetRaces.mockResolvedValue([makeRace('test-race', '2026-03-01')]);
+
+    const entries = await sitemap();
+    const raceEntry = entries.find((e) => e.url === 'https://hashiru.run/ja/races/test-race');
+
+    expect(raceEntry?.lastModified).toBeInstanceOf(Date);
+    expect((raceEntry?.lastModified as Date).getFullYear()).toBe(2026);
+  });
+
+  it('トップページの priority は 1.0', async () => {
+    mockGetRaces.mockResolvedValue([]);
+
+    const entries = await sitemap();
+    const home = entries.find((e) => e.url === 'https://hashiru.run/ja');
+
+    expect(home?.priority).toBe(1.0);
+  });
+});

--- a/src/app/api/races/index/__tests__/route.test.ts
+++ b/src/app/api/races/index/__tests__/route.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ─── モック定義（vi.hoisted でホイスト） ────────────────────────────────────
+const { mockBatch } = vi.hoisted(() => ({
+  mockBatch: vi.fn<[], Promise<unknown[][]>>(),
+}));
+
+vi.mock('@opennextjs/cloudflare', () => ({
+  getCloudflareContext: vi.fn(() => ({ env: { DB: {} } })),
+}));
+
+vi.mock('drizzle-orm/d1', () => ({
+  drizzle: vi.fn(() => ({
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        orderBy: vi.fn(() => ({})),
+      })),
+    })),
+    batch: mockBatch,
+  })),
+}));
+
+vi.mock('drizzle-orm', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('drizzle-orm')>();
+  return { ...actual, asc: vi.fn((f) => f) };
+});
+
+// ─── テスト対象インポート ─────────────────────────────────────────────────
+import { GET } from '../route';
+
+// ─── テストデータ ──────────────────────────────────────────────────────────
+const MOCK_RACE_ROWS = [
+  { id: 'tokyo-2026', name_ja: '東京マラソン2026', full_name_ja: '東京マラソン 2026', date: '2026-03-01' },
+  { id: 'osaka-2026', name_ja: '大阪マラソン2026', full_name_ja: '大阪マラソン 2026', date: '2026-11-29' },
+];
+
+const MOCK_CATEGORY_ROWS = [
+  { id: 'cat-1', race_id: 'tokyo-2026', name_ja: 'フルマラソン', name_en: 'Full Marathon', distance_km: 42.195, distance_type: 'full' },
+  { id: 'cat-2', race_id: 'tokyo-2026', name_ja: '10km', name_en: '10km', distance_km: 10, distance_type: '10k' },
+  { id: 'cat-3', race_id: 'osaka-2026', name_ja: 'フルマラソン', name_en: 'Full Marathon', distance_km: 42.195, distance_type: 'full' },
+];
+
+// ─── GET /api/races/index ──────────────────────────────────────────────────
+describe('GET /api/races/index', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('200 とレース一覧を返す', async () => {
+    mockBatch.mockResolvedValue([MOCK_RACE_ROWS, MOCK_CATEGORY_ROWS]);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toHaveLength(2);
+  });
+
+  it('各レースにカテゴリが紐付く', async () => {
+    mockBatch.mockResolvedValue([MOCK_RACE_ROWS, MOCK_CATEGORY_ROWS]);
+
+    const res = await GET();
+    const body = await res.json();
+
+    const tokyo = body.find((r: { id: string }) => r.id === 'tokyo-2026');
+    expect(tokyo).toBeDefined();
+    expect(tokyo.categories).toHaveLength(2);
+    expect(tokyo.categories[0].distance_type).toBe('full');
+  });
+
+  it('カテゴリなしのレースは空配列を返す', async () => {
+    const raceWithNoCategory = [{ id: 'nara-2027', name_ja: '奈良マラソン2027', full_name_ja: null, date: '2027-12-14' }];
+    mockBatch.mockResolvedValue([raceWithNoCategory, []]);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body).toHaveLength(1);
+    expect(body[0].categories).toEqual([]);
+  });
+
+  it('レースが存在しない場合は空配列を返す', async () => {
+    mockBatch.mockResolvedValue([[], []]);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body).toEqual([]);
+  });
+
+  it('レースは id / name_ja / full_name_ja / date を含む', async () => {
+    mockBatch.mockResolvedValue([MOCK_RACE_ROWS, MOCK_CATEGORY_ROWS]);
+
+    const res = await GET();
+    const body = await res.json();
+
+    const race = body[0];
+    expect(race).toMatchObject({
+      id: 'tokyo-2026',
+      name_ja: '東京マラソン2026',
+      full_name_ja: '東京マラソン 2026',
+      date: '2026-03-01',
+    });
+  });
+});

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,1 +1,6 @@
 import '@testing-library/jest-dom';
+
+// window.open stub（jsdom 環境で "Not implemented" 警告を抑制）
+if (typeof window !== 'undefined') {
+  window.open = () => null;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,7 +10,19 @@ export default defineConfig({
     setupFiles: ['./src/test-setup.ts'],
     coverage: {
       provider: 'v8',
-      include: ['src/lib/utils.ts', 'src/components/**/*.tsx'],
+      include: [
+        'src/lib/**/*.ts',
+        'src/app/**/*.ts',
+        'src/app/**/*.tsx',
+        'src/components/**/*.tsx',
+      ],
+      exclude: [
+        'src/lib/db/schema.ts',
+        'src/lib/types.ts',
+        'src/**/__tests__/**',
+        'src/**/*.test.ts',
+        'src/**/*.test.tsx',
+      ],
       reporter: ['text', 'lcov'],
     },
   },


### PR DESCRIPTION
## Summary

- `GET /api/races/index` のユニットテスト5件追加
  - レース一覧・カテゴリ紐付け・空配列・レスポンス形式を検証
- `sitemap()` のユニットテスト7件追加
  - 静的ページ数・レースエントリ数・URL形式・priority・alternates・lastModified を検証
- `vitest.config.ts`: coverage.include を `src/lib/**/*.ts` / `src/app/**/*.{ts,tsx}` に拡張
- `src/test-setup.ts`: `window.open` スタブ追加（jsdom 環境の "Not implemented" 警告を抑制）

## Test plan

- [x] `pnpm run test` → 38 files, 391 tests passed
- [x] `pnpm run lint` → 0 errors

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)