### PR TITLE
fix: ぐんまマラソンのエントリー期間修正 & クロールプロンプト強化

### DIFF
--- a/docs/update-history.md
+++ b/docs/update-history.md
@@ -872,3 +872,19 @@ APIの調査中にGoogle Routes API v2がTRANSITモードで日本に非対応�
 - `src/messages/ja.json` / `en.json`：`lookingUp`キー追加、`formAmazonUrlHint`をJP限定に更新
 - テスト更新：amazon-creators・route・GearList・amazon各テストを追従修正、メモ欄テスト追加
 - 全体テスト587件パス
+
+## 2026-08-01 ぐんまマラソン エントリー期間修正 & クロールプロンプト強化
+
+### 問題
+クロールが毎回ぐんまマラソンを誤更新。一般エントリー(フルマラソン)の締切は5/13だが、
+ジョギング(10km)の8/17締切をLLMが「一般エントリー」の締切として抽出していた。
+
+### 変更内容
+- `src/data/races/gunma-marathon-2026.json`：`entry_periods` を2件に分割
+  - フルマラソン: start=2026-04-09, end=2026-05-13, fee=13500
+  - ジョギング（10km）: start=2026-04-09, end=2026-08-17, fee=6500
+- `tools/crawl/extractor.js`：`buildExtractionPrompt` に複数種目エントリー期間の指示を追加
+  - 種目ごとに個別の entry_periods を作成すること
+  - 既存の entry_periods が複数件の場合はその構造を維持すること
+- `tools/crawl/extractor.test.js`：上記プロンプト変更のテスト2件追加
+- `migrations/seed-races-all.sql`：シード再生成

--- a/migrations/seed-races-all.sql
+++ b/migrations/seed-races-all.sql
@@ -1,6 +1,6 @@
 -- 自動生成: generate-seed-races.js
--- 生成日時: 2026-07-06T15:42:06.657Z
--- 対象ファイル数: 87 件（既存 2 件はskip）
+-- 生成日時: 2026-07-31T15:01:03.682Z
+-- 対象ファイル数: 93 件（既存 2 件はskip）
 
 -- ==================
 -- オホーツク網走マラソン (abashiri-marathon-2026)
@@ -17,6 +17,7 @@ DELETE FROM completion_gifts WHERE race_id = 'abashiri-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'abashiri-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'abashiri-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'abashiri-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'abashiri-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'abashiri-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'abashiri-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'abashiri-marathon-2026';
@@ -151,6 +152,7 @@ DELETE FROM completion_gifts WHERE race_id = 'akita-nairiku-ultra-2026';
 DELETE FROM race_entry_links WHERE race_id = 'akita-nairiku-ultra-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'akita-nairiku-ultra-2026';
 DELETE FROM reception_sessions WHERE race_id = 'akita-nairiku-ultra-2026';
+DELETE FROM race_travel_times WHERE race_id = 'akita-nairiku-ultra-2026';
 DELETE FROM race_results WHERE race_id = 'akita-nairiku-ultra-2026';
 DELETE FROM race_gallery WHERE race_id = 'akita-nairiku-ultra-2026';
 DELETE FROM race_voices WHERE race_id = 'akita-nairiku-ultra-2026';
@@ -291,6 +293,7 @@ DELETE FROM completion_gifts WHERE race_id = 'aomori-sakura-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'aomori-sakura-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'aomori-sakura-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'aomori-sakura-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'aomori-sakura-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'aomori-sakura-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'aomori-sakura-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'aomori-sakura-marathon-2026';
@@ -437,6 +440,7 @@ DELETE FROM completion_gifts WHERE race_id = 'aoshima-taiheyo-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'aoshima-taiheyo-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'aoshima-taiheyo-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'aoshima-taiheyo-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'aoshima-taiheyo-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'aoshima-taiheyo-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'aoshima-taiheyo-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'aoshima-taiheyo-marathon-2026';
@@ -563,6 +567,7 @@ DELETE FROM completion_gifts WHERE race_id = 'asahikawa-half-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'asahikawa-half-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'asahikawa-half-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'asahikawa-half-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'asahikawa-half-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'asahikawa-half-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'asahikawa-half-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'asahikawa-half-marathon-2026';
@@ -697,6 +702,7 @@ DELETE FROM completion_gifts WHERE race_id = 'beppu-oita-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'beppu-oita-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'beppu-oita-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'beppu-oita-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'beppu-oita-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'beppu-oita-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'beppu-oita-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'beppu-oita-marathon-2026';
@@ -837,6 +843,7 @@ DELETE FROM completion_gifts WHERE race_id = 'biwako-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'biwako-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'biwako-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'biwako-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'biwako-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'biwako-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'biwako-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'biwako-marathon-2026';
@@ -961,6 +968,157 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
   ('biwako-marathon-2026', NULL, NULL, '比叡山', 'Mt. Hiei', NULL, NULL, 1);
 
 -- ==================
+-- びわ湖マラソン (biwako-marathon-2027)
+-- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'biwako-marathon-2027';
+DELETE FROM race_categories WHERE race_id = 'biwako-marathon-2027';
+DELETE FROM aid_stations WHERE race_id = 'biwako-marathon-2027';
+DELETE FROM checkpoints WHERE race_id = 'biwako-marathon-2027';
+DELETE FROM access_points WHERE race_id = 'biwako-marathon-2027';
+DELETE FROM nearby_spots WHERE race_id = 'biwako-marathon-2027';
+DELETE FROM weather_history WHERE race_id = 'biwako-marathon-2027';
+DELETE FROM participation_gifts WHERE race_id = 'biwako-marathon-2027';
+DELETE FROM completion_gifts WHERE race_id = 'biwako-marathon-2027';
+DELETE FROM race_entry_links WHERE race_id = 'biwako-marathon-2027';
+DELETE FROM race_entry_periods WHERE race_id = 'biwako-marathon-2027';
+DELETE FROM reception_sessions WHERE race_id = 'biwako-marathon-2027';
+DELETE FROM race_travel_times WHERE race_id = 'biwako-marathon-2027';
+DELETE FROM race_results WHERE race_id = 'biwako-marathon-2027';
+DELETE FROM race_gallery WHERE race_id = 'biwako-marathon-2027';
+DELETE FROM race_voices WHERE race_id = 'biwako-marathon-2027';
+DELETE FROM race_time_buckets WHERE race_id = 'biwako-marathon-2027';
+INSERT INTO races (
+  id, name_ja, name_en, date, prefecture, city_ja, city_en,
+  description_ja, description_en, official_url,
+  entry_fee, entry_fee_by_category, entry_capacity,
+  entry_start_date, entry_end_date, entry_closed,
+  reception_type, reception_note_ja, reception_note_en,
+  tags, course_gpx_file,
+  course_max_elevation_m, course_min_elevation_m, course_elevation_diff_m,
+  course_surface, course_certification,
+  course_highlights_ja, course_highlights_en,
+  course_notes_ja, course_notes_en,
+  motif, motif_color, motif_romaji,
+  tagline_ja, tagline_en,
+  hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
+  created_at, updated_at
+) VALUES (
+  'biwako-marathon-2027',
+  'びわ湖マラソン',
+  'Biwako Marathon',
+  '2027-03-14',
+  '25',
+  '大津市',
+  'Otsu City',
+  '日本最大の湖・琵琶湖畔を走るフルマラソン。湖と比叡山の絶景を楽しめるフラットなコース。',
+  'A full marathon along Lake Biwa, Japan''s largest lake. A flat course with views of the lake and Mt. Hiei.',
+  'https://biwako-marathon.com',
+  15000,
+  0,
+  8000,
+  '2026-08-03',
+  '2026-10-30',
+  0,
+  'pre_mail',
+  'アスリートビブス（ゼッケン）、計測チップ、参加賞等を事前に郵送。大会前日・当日の受付なし。',
+  'Bib, timing chip, and participation gift will be mailed in advance. No race-day or day-before pick-up.',
+  '["フラット","景色が良い","湖畔"]',
+  NULL,
+  0,
+  0,
+  0,
+  'road',
+  '["JAAF","WA"]',
+  '琵琶湖畔、比叡山',
+  'Lake Biwa shore, Mt. Hiei',
+  NULL,
+  NULL,
+  '琵琶湖',
+  '#93c5fd',
+  'Biwako',
+  '日本最大の湖を舞台に、水の都を走る',
+  'Run along Japan''s largest lake',
+  NULL,
+  NULL,
+  NULL,
+  '皇子山陸上競技場',
+  'Ojiyama Stadium',
+  NULL,
+  NULL,
+  NULL,
+  '2026-07-27T14:07:25.820Z',
+  '2026-07-27T14:07:25.820Z'
+) ON CONFLICT(id) DO UPDATE SET
+  name_ja = excluded.name_ja,
+  name_en = excluded.name_en,
+  date = excluded.date,
+  prefecture = excluded.prefecture,
+  city_ja = excluded.city_ja,
+  city_en = excluded.city_en,
+  description_ja = excluded.description_ja,
+  description_en = excluded.description_en,
+  official_url = excluded.official_url,
+  entry_fee = excluded.entry_fee,
+  entry_fee_by_category = excluded.entry_fee_by_category,
+  entry_capacity = excluded.entry_capacity,
+  entry_start_date = excluded.entry_start_date,
+  entry_end_date = excluded.entry_end_date,
+  entry_closed = excluded.entry_closed,
+  reception_type = excluded.reception_type,
+  reception_note_ja = excluded.reception_note_ja,
+  reception_note_en = excluded.reception_note_en,
+  tags = excluded.tags,
+  course_gpx_file = excluded.course_gpx_file,
+  course_max_elevation_m = excluded.course_max_elevation_m,
+  course_min_elevation_m = excluded.course_min_elevation_m,
+  course_elevation_diff_m = excluded.course_elevation_diff_m,
+  course_surface = excluded.course_surface,
+  course_certification = excluded.course_certification,
+  course_highlights_ja = excluded.course_highlights_ja,
+  course_highlights_en = excluded.course_highlights_en,
+  course_notes_ja = excluded.course_notes_ja,
+  course_notes_en = excluded.course_notes_en,
+  motif = excluded.motif,
+  motif_color = excluded.motif_color,
+  motif_romaji = excluded.motif_romaji,
+  tagline_ja = excluded.tagline_ja,
+  tagline_en = excluded.tagline_en,
+  hero_image_url = excluded.hero_image_url,
+  hero_caption_ja = excluded.hero_caption_ja,
+  hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
+  updated_at = excluded.updated_at;
+INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
+  ('biwako-marathon-2027', 'full', 42.195, 360, '08:20', 7000, 15000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
+INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, walk_minutes, is_primary, sort_order) VALUES
+  ('biwako-marathon-2027', '京阪大津京駅', 'Keihan Otsu-kyo Station', '', '徒歩3分', '3 min walk', 0, 0, 3, 1, 0);
+INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, walk_minutes, is_primary, sort_order) VALUES
+  ('biwako-marathon-2027', '大津京駅（JR湖西線）', 'Otsu-kyo Station (JR Kosei Line)', '', '徒歩6分', '6 min walk', 0, 0, 6, 0, 1);
+INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, walk_minutes, is_primary, sort_order) VALUES
+  ('biwako-marathon-2027', '大津駅（JR琵琶湖線）', 'Otsu Station (JR Biwako Line)', '', '徒歩35分', '35 min walk', 0, 0, 35, 0, 2);
+INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
+  ('biwako-marathon-2027', '観光地', '琵琶湖', 'Lake Biwa', '日本最大の湖。コース全体で湖畔を走る。水面に映る比叡山の景色が美しい。', 'Japan''s largest lake. The entire course runs along the lakeshore. Beautiful views of Mt. Hiei reflected on the water.', 'コース上', NULL, 35.3506, 136.0689);
+INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
+  ('biwako-marathon-2027', '温泉', 'おごと温泉', 'Ogoto Onsen', '琵琶湖西岸の温泉地。コース付近。レース後のリカバリーに便利。', 'Hot spring town on the west shore of Lake Biwa. Near the course. Convenient for post-race recovery.', 'コース付近', NULL, 35.1167, 135.8833);
+INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('biwako-marathon-2027', '["tshirt"]', 'Tシャツ・ロングTシャツ・ランニンググローブのいずれか1つ', 'Choice of one: T-shirt, long-sleeve T-shirt, or running gloves', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('biwako-marathon-2027', '["medal"]', '完走メダル', 'Finisher medal', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('biwako-marathon-2027', '["towel"]', '完走タオル', 'Finisher towel', NULL, 1);
+INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
+  ('biwako-marathon-2027', NULL, '一般エントリー', 'General Entry', '2026-08-03', '2026-10-30', 15000, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('biwako-marathon-2027', NULL, NULL, '琵琶湖畔', 'Lake Biwa shore', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('biwako-marathon-2027', NULL, NULL, '比叡山', 'Mt. Hiei', NULL, NULL, 1);
+
+-- ==================
 -- ちばアクアラインマラソン (chiba-aqualine-marathon-2026)
 -- ==================
 DELETE FROM race_course_highlights WHERE race_id = 'chiba-aqualine-marathon-2026';
@@ -975,6 +1133,7 @@ DELETE FROM completion_gifts WHERE race_id = 'chiba-aqualine-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'chiba-aqualine-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'chiba-aqualine-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'chiba-aqualine-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'chiba-aqualine-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'chiba-aqualine-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'chiba-aqualine-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'chiba-aqualine-marathon-2026';
@@ -1119,6 +1278,7 @@ DELETE FROM completion_gifts WHERE race_id = 'ehime-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'ehime-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'ehime-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'ehime-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'ehime-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'ehime-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'ehime-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'ehime-marathon-2026';
@@ -1261,6 +1421,7 @@ DELETE FROM completion_gifts WHERE race_id = 'ehime-marathon-2027';
 DELETE FROM race_entry_links WHERE race_id = 'ehime-marathon-2027';
 DELETE FROM race_entry_periods WHERE race_id = 'ehime-marathon-2027';
 DELETE FROM reception_sessions WHERE race_id = 'ehime-marathon-2027';
+DELETE FROM race_travel_times WHERE race_id = 'ehime-marathon-2027';
 DELETE FROM race_results WHERE race_id = 'ehime-marathon-2027';
 DELETE FROM race_gallery WHERE race_id = 'ehime-marathon-2027';
 DELETE FROM race_voices WHERE race_id = 'ehime-marathon-2027';
@@ -1407,6 +1568,7 @@ DELETE FROM completion_gifts WHERE race_id = 'fuji-mountain-race-2026';
 DELETE FROM race_entry_links WHERE race_id = 'fuji-mountain-race-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'fuji-mountain-race-2026';
 DELETE FROM reception_sessions WHERE race_id = 'fuji-mountain-race-2026';
+DELETE FROM race_travel_times WHERE race_id = 'fuji-mountain-race-2026';
 DELETE FROM race_results WHERE race_id = 'fuji-mountain-race-2026';
 DELETE FROM race_gallery WHERE race_id = 'fuji-mountain-race-2026';
 DELETE FROM race_voices WHERE race_id = 'fuji-mountain-race-2026';
@@ -1547,6 +1709,7 @@ DELETE FROM completion_gifts WHERE race_id = 'fujisan-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'fujisan-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'fujisan-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'fujisan-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'fujisan-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'fujisan-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'fujisan-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'fujisan-marathon-2026';
@@ -1612,7 +1775,7 @@ INSERT INTO races (
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-06-08T14:30:14.213Z'
+  '2026-07-31T14:27:54.483Z'
 ) ON CONFLICT(id) DO UPDATE SET
   name_ja = excluded.name_ja,
   name_en = excluded.name_en,
@@ -1668,7 +1831,7 @@ INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_j
 INSERT OR REPLACE INTO race_entry_links (race_id, site_name, url, sort_order) VALUES
   ('fujisan-marathon-2026', 'RUNNET', 'https://runnet.jp/parts/2026/392477/entry2.html', 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
-  ('fujisan-marathon-2026', NULL, '富士河口湖町民限定エントリー', 'Fujikawaguchiko Residents Entry', '2026-04-20', '2026-05-31', NULL, 0);
+  ('fujisan-marathon-2026', NULL, '富士河口湖町民限定エントリー', 'Fujikawaguchiko Residents Entry', '2026-04-20', '2026-07-31', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('fujisan-marathon-2026', NULL, 'アーリーエントリー（国内在住者）', 'Early Entry (Japanese Residents)', '2026-04-20', '2026-05-04', NULL, 1);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
@@ -1693,6 +1856,7 @@ DELETE FROM completion_gifts WHERE race_id = 'fukuchiyama-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'fukuchiyama-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'fukuchiyama-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'fukuchiyama-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'fukuchiyama-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'fukuchiyama-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'fukuchiyama-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'fukuchiyama-marathon-2026';
@@ -1835,6 +1999,7 @@ DELETE FROM completion_gifts WHERE race_id = 'fukui-sakura-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'fukui-sakura-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'fukui-sakura-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'fukui-sakura-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'fukui-sakura-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'fukui-sakura-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'fukui-sakura-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'fukui-sakura-marathon-2026';
@@ -1981,6 +2146,7 @@ DELETE FROM completion_gifts WHERE race_id = 'fukuoka-international-marathon-202
 DELETE FROM race_entry_links WHERE race_id = 'fukuoka-international-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'fukuoka-international-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'fukuoka-international-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'fukuoka-international-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'fukuoka-international-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'fukuoka-international-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'fukuoka-international-marathon-2026';
@@ -2119,6 +2285,7 @@ DELETE FROM completion_gifts WHERE race_id = 'fukuoka-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'fukuoka-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'fukuoka-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'fukuoka-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'fukuoka-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'fukuoka-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'fukuoka-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'fukuoka-marathon-2026';
@@ -2269,6 +2436,7 @@ DELETE FROM completion_gifts WHERE race_id = 'gunma-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'gunma-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'gunma-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'gunma-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'gunma-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'gunma-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'gunma-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'gunma-marathon-2026';
@@ -2304,7 +2472,7 @@ INSERT INTO races (
   1,
   5500,
   '2026-04-09',
-  '2026-05-13',
+  '2026-08-17',
   0,
   'pre_mail',
   '参加者には、アスリートビブス、計測チップ、参加マニュアル等を申込時の住所に事前に発送します（10月下旬発送予定）。大会前日・当日の受付は行いません。
@@ -2338,13 +2506,13 @@ If you are unable to participate after registering, you do not need to contact u
   NULL,
   NULL,
   NULL,
-  NULL,
-  NULL,
+  '正田醤油スタジアム群馬',
+  'Shoda Shoyu Stadium Gunma',
   NULL,
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-06-22T15:01:11.589Z'
+  '2026-07-31T14:28:47.306Z'
 ) ON CONFLICT(id) DO UPDATE SET
   name_ja = excluded.name_ja,
   name_en = excluded.name_en,
@@ -2393,6 +2561,12 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
   ('gunma-marathon-2026', 'full', 42.195, 360, '08:55', 5500, 13500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('gunma-marathon-2026', '10k', 10, 90, '10:00', 4000, 6500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 1);
+INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, walk_minutes, is_primary, sort_order) VALUES
+  ('gunma-marathon-2026', '前橋駅', 'Maebashi Station', '', '無料シャトルバス利用（5〜10分間隔）', 'Free shuttle bus (every 5–10 min)', 0, 0, 0, 1, 0);
+INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, walk_minutes, is_primary, sort_order) VALUES
+  ('gunma-marathon-2026', '新前橋駅', 'Shin-Maebashi Station', '', '無料シャトルバス利用（5〜10分間隔）', 'Free shuttle bus (every 5–10 min)', 0, 0, 0, 0, 1);
+INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, walk_minutes, is_primary, sort_order) VALUES
+  ('gunma-marathon-2026', '高崎駅', 'Takasaki Station', '', '無料シャトルバス利用（5〜10分間隔）', 'Free shuttle bus (every 5–10 min)', 0, 0, 0, 0, 2);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('gunma-marathon-2026', '温泉', '伊香保温泉', 'Ikaho Onsen', '石段街で有名な群馬の温泉地。黄金の湯と白銀の湯の2種。前橋から車約40分。', 'Famous for its stone steps. Two types of springs: Golden and Silver. About 40 min by car from Maebashi.', '前橋市から車約40分', 'https://www.ikaho-kankou.com/', 36.4886, 138.9311);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -2404,7 +2578,9 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
 INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('gunma-marathon-2026', '["towel"]', 'フルマラソン完走記念タオル（スポーツタオル、ミントブルー基調）', 'Full marathon finisher towel (sports towel, mint blue design)', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
-  ('gunma-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-09', '2026-05-13', NULL, 0);
+  ('gunma-marathon-2026', NULL, 'フルマラソン', 'Full Marathon', '2026-04-09', '2026-05-13', 13500, 0);
+INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
+  ('gunma-marathon-2026', NULL, 'ジョギング（10km）', 'Jogging (10km)', '2026-04-09', '2026-08-17', 6500, 1);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
   ('gunma-marathon-2026', NULL, NULL, '赤城山', 'Mt. Akagi', NULL, NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -2429,6 +2605,7 @@ DELETE FROM completion_gifts WHERE race_id = 'higashine-sakuranbo-marathon-2026'
 DELETE FROM race_entry_links WHERE race_id = 'higashine-sakuranbo-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'higashine-sakuranbo-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'higashine-sakuranbo-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'higashine-sakuranbo-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'higashine-sakuranbo-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'higashine-sakuranbo-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'higashine-sakuranbo-marathon-2026';
@@ -2569,6 +2746,7 @@ DELETE FROM completion_gifts WHERE race_id = 'higashinipon-half-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'higashinipon-half-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'higashinipon-half-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'higashinipon-half-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'higashinipon-half-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'higashinipon-half-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'higashinipon-half-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'higashinipon-half-marathon-2026';
@@ -2705,6 +2883,7 @@ DELETE FROM completion_gifts WHERE race_id = 'himeji-castle-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'himeji-castle-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'himeji-castle-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'himeji-castle-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'himeji-castle-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'himeji-castle-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'himeji-castle-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'himeji-castle-marathon-2026';
@@ -2843,6 +3022,7 @@ DELETE FROM completion_gifts WHERE race_id = 'hitachi-seaside-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'hitachi-seaside-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'hitachi-seaside-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'hitachi-seaside-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'hitachi-seaside-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'hitachi-seaside-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'hitachi-seaside-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'hitachi-seaside-marathon-2026';
@@ -2894,8 +3074,8 @@ With the scenery and the sea breeze pushing you forward, you can fully savor the
   0,
   'road',
   '[]',
-  '',
-  '',
+  '太平洋を望む日立シーサイドロードを走る非日常の絶景コース。河原子海岸沿いで海を間近に感じながら走れる。アップダウンのある走りごたえのあるコースで、マラソンシーズン初戦の脚試しに最適。',
+  'A spectacular course along Hitachi Seaside Road overlooking the Pacific Ocean. Runners can feel the ocean up close along Kawarago Beach. A challenging course with hills, ideal as a season opener.',
   '',
   '',
   'コキア',
@@ -2912,7 +3092,7 @@ With the scenery and the sea breeze pushing you forward, you can fully savor the
   NULL,
   NULL,
   '2026-04-11T14:28:19.021Z',
-  '2026-04-11T14:28:19.021Z'
+  '2026-07-27T14:10:45.345Z'
 ) ON CONFLICT(id) DO UPDATE SET
   name_ja = excluded.name_ja,
   name_en = excluded.name_en,
@@ -2960,17 +3140,11 @@ With the scenery and the sea breeze pushing you forward, you can fully savor the
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('hitachi-seaside-marathon-2026', 'full', 42.195, 360, '10:00', 6000, 10000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('hitachi-seaside-marathon-2026', '["towel"]', '出走特典
-（タオル）
-
-完走賞
-（完走メダル）', '', NULL, 0);
+  ('hitachi-seaside-marathon-2026', '["tshirt"]', '参加賞（ロングTシャツ）', 'Participation gift (Long T-shirt)', NULL, 0);
+INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('hitachi-seaside-marathon-2026', '["towel"]', '出走特典（タオル）', 'Running benefit (Towel)', NULL, 1);
 INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('hitachi-seaside-marathon-2026', '["medal"]', '出走特典
-（タオル）
-
-完走賞
-（完走メダル）', '', NULL, 0);
+  ('hitachi-seaside-marathon-2026', '["medal"]', '完走賞（完走メダル）', 'Finisher award (Finisher medal)', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('hitachi-seaside-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-13', '2026-08-31', 10000, 0);
 
@@ -2989,6 +3163,7 @@ DELETE FROM completion_gifts WHERE race_id = 'hofu-yomiuri-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'hofu-yomiuri-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'hofu-yomiuri-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'hofu-yomiuri-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'hofu-yomiuri-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'hofu-yomiuri-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'hofu-yomiuri-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'hofu-yomiuri-marathon-2026';
@@ -3026,9 +3201,9 @@ INSERT INTO races (
   '2026-06-22',
   '2026-07-06',
   0,
-  'pre_day',
-  '',
-  '',
+  'pre_mail',
+  '11月下旬にアスリートビブス・計測チップを事前郵送',
+  'Athlete bibs and timing chips mailed in advance in late November',
   '["エリート大会","日本陸連公認","記録狙い"]',
   NULL,
   0,
@@ -3054,7 +3229,7 @@ INSERT INTO races (
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-06-12T13:57:36.968Z'
+  '2026-07-27T14:11:03.160Z'
 ) ON CONFLICT(id) DO UPDATE SET
   name_ja = excluded.name_ja,
   name_en = excluded.name_en,
@@ -3131,6 +3306,7 @@ DELETE FROM completion_gifts WHERE race_id = 'hokkaido-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'hokkaido-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'hokkaido-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'hokkaido-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'hokkaido-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'hokkaido-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'hokkaido-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'hokkaido-marathon-2026';
@@ -3190,13 +3366,13 @@ INSERT INTO races (
   NULL,
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
+  '大通公園（大通西4丁目）',
+  'Odori Park (Odori West 4-chome)',
+  '北海道札幌市中央区大通西4丁目',
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-06-27T13:29:05.102Z'
+  '2026-07-31T14:29:42.206Z'
 ) ON CONFLICT(id) DO UPDATE SET
   name_ja = excluded.name_ja,
   name_en = excluded.name_en,
@@ -3250,11 +3426,11 @@ INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, descriptio
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('hokkaido-marathon-2026', '温泉', '定山渓温泉', 'Jozankei Onsen', '札幌の奥座敷と呼ばれる温泉地。レース翌日の観光に。札幌中心部からバスで約60分。', 'Known as Sapporo''s inner parlor. For sightseeing the day after. About 60 min by bus from central Sapporo.', '札幌中心部からバス約60分', NULL, 42.9694, 141.1667);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('hokkaido-marathon-2026', '["tshirt"]', '大会オリジナルTシャツ、完走メダル', 'Official race T-shirt, Finisher medal', NULL, 0);
+  ('hokkaido-marathon-2026', '["tshirt"]', '大会オリジナルTシャツ', 'Official race T-shirt', NULL, 0);
 INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('hokkaido-marathon-2026', '["medal"]', '大会オリジナルTシャツ、完走メダル', 'Official race T-shirt, Finisher medal', NULL, 0);
+  ('hokkaido-marathon-2026', '["medal"]', '完走メダル', 'Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
-  ('hokkaido-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-03-29', '2026-04-24', NULL, 0);
+  ('hokkaido-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-03-29', '2026-04-24', 16500, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
   ('hokkaido-marathon-2026', NULL, NULL, '大通公園', 'Odori Park', NULL, NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -3277,6 +3453,7 @@ DELETE FROM completion_gifts WHERE race_id = 'ibusuki-nanohana-2026';
 DELETE FROM race_entry_links WHERE race_id = 'ibusuki-nanohana-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'ibusuki-nanohana-2026';
 DELETE FROM reception_sessions WHERE race_id = 'ibusuki-nanohana-2026';
+DELETE FROM race_travel_times WHERE race_id = 'ibusuki-nanohana-2026';
 DELETE FROM race_results WHERE race_id = 'ibusuki-nanohana-2026';
 DELETE FROM race_gallery WHERE race_id = 'ibusuki-nanohana-2026';
 DELETE FROM race_voices WHERE race_id = 'ibusuki-nanohana-2026';
@@ -3421,6 +3598,7 @@ DELETE FROM completion_gifts WHERE race_id = 'ichinoseki-half-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'ichinoseki-half-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'ichinoseki-half-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'ichinoseki-half-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'ichinoseki-half-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'ichinoseki-half-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'ichinoseki-half-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'ichinoseki-half-marathon-2026';
@@ -3456,11 +3634,11 @@ INSERT INTO races (
   1,
   2500,
   '2026-04-01',
-  '2026-06-30',
+  '2026-07-10',
   0,
-  'pre_day',
-  '',
-  '',
+  'pre_mail',
+  'アスリートビブス・計測用タグは参加者全員に事前郵送。当日の受付は行わない。再発行は会場にて1,000円。',
+  'Athlete bibs and timing chips are mailed to all participants in advance. No on-site reception on race day. Reissuance fee: 1,000 yen at venue.',
   '["フラット","日本陸連公認","記録狙い","歴史ある大会"]',
   NULL,
   0,
@@ -3480,13 +3658,13 @@ INSERT INTO races (
   NULL,
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
+  '一関ヒロセユードーム',
+  'Ichinoseki Hirose U-Dome',
+  '岩手県一関市狐禅寺字石ノ瀬25-3',
   NULL,
   NULL,
   '2026-03-29T00:00:00Z',
-  '2026-05-30T06:35:21.220Z'
+  '2026-07-27T14:13:53.576Z'
 ) ON CONFLICT(id) DO UPDATE SET
   name_ja = excluded.name_ja,
   name_en = excluded.name_en,
@@ -3536,7 +3714,9 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('ichinoseki-half-marathon-2026', '10k', 10, 85, '09:00', 500, 6000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 1);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
-  ('ichinoseki-half-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-01', '2026-06-30', NULL, 0);
+  ('ichinoseki-half-marathon-2026', NULL, '一般エントリー（RUNNET）', 'General Entry (RUNNET)', '2026-04-01', '2026-07-10', 6000, 0);
+INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
+  ('ichinoseki-half-marathon-2026', NULL, '一般エントリー（振替用紙・窓口）', 'General Entry (Paper / In-person)', '2026-04-01', '2026-06-30', 6000, 1);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
   ('ichinoseki-half-marathon-2026', NULL, NULL, '最大高低差15mのフラットコース', 'Flat course with only 15m elevation difference', NULL, NULL, 0);
 
@@ -3555,6 +3735,7 @@ DELETE FROM completion_gifts WHERE race_id = 'iki-ultra-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'iki-ultra-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'iki-ultra-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'iki-ultra-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'iki-ultra-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'iki-ultra-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'iki-ultra-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'iki-ultra-marathon-2026';
@@ -3689,6 +3870,7 @@ DELETE FROM completion_gifts WHERE race_id = 'itabashi-city-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'itabashi-city-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'itabashi-city-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'itabashi-city-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'itabashi-city-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'itabashi-city-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'itabashi-city-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'itabashi-city-marathon-2026';
@@ -3829,6 +4011,7 @@ DELETE FROM completion_gifts WHERE race_id = 'iwaki-sunshine-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'iwaki-sunshine-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'iwaki-sunshine-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'iwaki-sunshine-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'iwaki-sunshine-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'iwaki-sunshine-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'iwaki-sunshine-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'iwaki-sunshine-marathon-2026';
@@ -3973,6 +4156,7 @@ DELETE FROM completion_gifts WHERE race_id = 'iwaki-sunshine-marathon-2027';
 DELETE FROM race_entry_links WHERE race_id = 'iwaki-sunshine-marathon-2027';
 DELETE FROM race_entry_periods WHERE race_id = 'iwaki-sunshine-marathon-2027';
 DELETE FROM reception_sessions WHERE race_id = 'iwaki-sunshine-marathon-2027';
+DELETE FROM race_travel_times WHERE race_id = 'iwaki-sunshine-marathon-2027';
 DELETE FROM race_results WHERE race_id = 'iwaki-sunshine-marathon-2027';
 DELETE FROM race_gallery WHERE race_id = 'iwaki-sunshine-marathon-2027';
 DELETE FROM race_voices WHERE race_id = 'iwaki-sunshine-marathon-2027';
@@ -4117,6 +4301,7 @@ DELETE FROM completion_gifts WHERE race_id = 'iwate-morioka-city-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'iwate-morioka-city-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'iwate-morioka-city-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'iwate-morioka-city-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'iwate-morioka-city-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'iwate-morioka-city-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'iwate-morioka-city-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'iwate-morioka-city-marathon-2026';
@@ -4178,7 +4363,7 @@ Translated with DeepL.com (free version)',
   1,
   6000,
   '2026-04-01',
-  '2026-07-20',
+  '2026-08-03',
   0,
   'pre_day',
   '前日の2026年10月3日（土）10時から18時まできたぎんボールパーク（盛岡市永井７地割16番地２）で参加者受付を行います。受付時にアスリートビブス、計測チップ及び参加案内等をお渡しします。なお、再発行や大会当日の受付は行いません。
@@ -4206,13 +4391,13 @@ Translated with DeepL.com (free version)',
   NULL,
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
+  'きたぎんボールパーク',
+  'Kitagin Ballpark',
+  '岩手県盛岡市永井7地割16番地2',
   NULL,
   NULL,
   '2026-04-16T15:23:52.019Z',
-  '2026-06-08T14:33:03.724Z'
+  '2026-07-27T14:14:28.754Z'
 ) ON CONFLICT(id) DO UPDATE SET
   name_ja = excluded.name_ja,
   name_en = excluded.name_en,
@@ -4262,7 +4447,9 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
 INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('iwate-morioka-city-marathon-2026', '["towel","medal"]', 'フィニッシャータオル、南部鉄器製完走メダル', 'Finisher towel, Nanbu ironware finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
-  ('iwate-morioka-city-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-01', '2026-07-20', 12000, 0);
+  ('iwate-morioka-city-marathon-2026', NULL, '一般エントリー（前日受付）', 'General Entry (On-site Pickup)', '2026-04-01', '2026-08-03', 12000, 0);
+INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
+  ('iwate-morioka-city-marathon-2026', NULL, '一般エントリー（事前送付）', 'General Entry (Pre-delivery +¥600)', '2026-04-01', '2026-07-20', 12600, 1);
 
 -- ==================
 -- いわて奥州きらめきマラソン (iwate-oshu-kirameki-marathon-2026)
@@ -4279,6 +4466,7 @@ DELETE FROM completion_gifts WHERE race_id = 'iwate-oshu-kirameki-marathon-2026'
 DELETE FROM race_entry_links WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'iwate-oshu-kirameki-marathon-2026';
@@ -4417,6 +4605,7 @@ DELETE FROM completion_gifts WHERE race_id = 'izu-oshima-2026';
 DELETE FROM race_entry_links WHERE race_id = 'izu-oshima-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'izu-oshima-2026';
 DELETE FROM reception_sessions WHERE race_id = 'izu-oshima-2026';
+DELETE FROM race_travel_times WHERE race_id = 'izu-oshima-2026';
 DELETE FROM race_results WHERE race_id = 'izu-oshima-2026';
 DELETE FROM race_gallery WHERE race_id = 'izu-oshima-2026';
 DELETE FROM race_voices WHERE race_id = 'izu-oshima-2026';
@@ -4586,6 +4775,7 @@ DELETE FROM completion_gifts WHERE race_id = 'kagawa-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'kagawa-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'kagawa-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'kagawa-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'kagawa-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'kagawa-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'kagawa-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'kagawa-marathon-2026';
@@ -4712,6 +4902,149 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
   ('kagawa-marathon-2026', NULL, NULL, '瀬戸内海', 'Seto Inland Sea', NULL, NULL, 0);
 
 -- ==================
+-- かがわマラソン (kagawa-marathon-2027)
+-- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'kagawa-marathon-2027';
+DELETE FROM race_categories WHERE race_id = 'kagawa-marathon-2027';
+DELETE FROM aid_stations WHERE race_id = 'kagawa-marathon-2027';
+DELETE FROM checkpoints WHERE race_id = 'kagawa-marathon-2027';
+DELETE FROM access_points WHERE race_id = 'kagawa-marathon-2027';
+DELETE FROM nearby_spots WHERE race_id = 'kagawa-marathon-2027';
+DELETE FROM weather_history WHERE race_id = 'kagawa-marathon-2027';
+DELETE FROM participation_gifts WHERE race_id = 'kagawa-marathon-2027';
+DELETE FROM completion_gifts WHERE race_id = 'kagawa-marathon-2027';
+DELETE FROM race_entry_links WHERE race_id = 'kagawa-marathon-2027';
+DELETE FROM race_entry_periods WHERE race_id = 'kagawa-marathon-2027';
+DELETE FROM reception_sessions WHERE race_id = 'kagawa-marathon-2027';
+DELETE FROM race_travel_times WHERE race_id = 'kagawa-marathon-2027';
+DELETE FROM race_results WHERE race_id = 'kagawa-marathon-2027';
+DELETE FROM race_gallery WHERE race_id = 'kagawa-marathon-2027';
+DELETE FROM race_voices WHERE race_id = 'kagawa-marathon-2027';
+DELETE FROM race_time_buckets WHERE race_id = 'kagawa-marathon-2027';
+INSERT INTO races (
+  id, name_ja, name_en, date, prefecture, city_ja, city_en,
+  description_ja, description_en, official_url,
+  entry_fee, entry_fee_by_category, entry_capacity,
+  entry_start_date, entry_end_date, entry_closed,
+  reception_type, reception_note_ja, reception_note_en,
+  tags, course_gpx_file,
+  course_max_elevation_m, course_min_elevation_m, course_elevation_diff_m,
+  course_surface, course_certification,
+  course_highlights_ja, course_highlights_en,
+  course_notes_ja, course_notes_en,
+  motif, motif_color, motif_romaji,
+  tagline_ja, tagline_en,
+  hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
+  created_at, updated_at
+) VALUES (
+  'kagawa-marathon-2027',
+  'かがわマラソン',
+  'Kagawa Marathon',
+  '2027-03-21',
+  '37',
+  '高松市',
+  'Takamatsu City',
+  '2026年が第1回大会の新しいフルマラソン。香川県の瀬戸内海沿いを走る。うどん県ならではのエイドに期待。',
+  'A brand new marathon with its first edition in 2026. Run along the Seto Inland Sea in Kagawa, the udon prefecture.',
+  'https://kagawa-marathon.com',
+  14000,
+  1,
+  10000,
+  NULL,
+  NULL,
+  0,
+  'pre_day',
+  '',
+  '',
+  '["ご当地エイド","海沿い","第1回大会"]',
+  NULL,
+  0,
+  0,
+  0,
+  'road',
+  '["JAAF"]',
+  '瀬戸内海、島々、栗林公園、里山、讃岐平野',
+  'Seto Inland Sea, islands, Ritsurin Garden, satoyama, Sanuki Plain',
+  NULL,
+  NULL,
+  '瀬戸内海',
+  '#0284c7',
+  'Setonaikai',
+  '瀬戸内の穏やかな海を見渡しながら走る42km',
+  'Run along the serene shores of the Seto Inland Sea',
+  NULL,
+  NULL,
+  NULL,
+  'あなぶきアリーナ香川',
+  'Anabuki Arena Kagawa',
+  '香川県高松市サンポート',
+  NULL,
+  NULL,
+  '2026-07-27T14:15:58.429Z',
+  '2026-07-27T14:15:58.429Z'
+) ON CONFLICT(id) DO UPDATE SET
+  name_ja = excluded.name_ja,
+  name_en = excluded.name_en,
+  date = excluded.date,
+  prefecture = excluded.prefecture,
+  city_ja = excluded.city_ja,
+  city_en = excluded.city_en,
+  description_ja = excluded.description_ja,
+  description_en = excluded.description_en,
+  official_url = excluded.official_url,
+  entry_fee = excluded.entry_fee,
+  entry_fee_by_category = excluded.entry_fee_by_category,
+  entry_capacity = excluded.entry_capacity,
+  entry_start_date = excluded.entry_start_date,
+  entry_end_date = excluded.entry_end_date,
+  entry_closed = excluded.entry_closed,
+  reception_type = excluded.reception_type,
+  reception_note_ja = excluded.reception_note_ja,
+  reception_note_en = excluded.reception_note_en,
+  tags = excluded.tags,
+  course_gpx_file = excluded.course_gpx_file,
+  course_max_elevation_m = excluded.course_max_elevation_m,
+  course_min_elevation_m = excluded.course_min_elevation_m,
+  course_elevation_diff_m = excluded.course_elevation_diff_m,
+  course_surface = excluded.course_surface,
+  course_certification = excluded.course_certification,
+  course_highlights_ja = excluded.course_highlights_ja,
+  course_highlights_en = excluded.course_highlights_en,
+  course_notes_ja = excluded.course_notes_ja,
+  course_notes_en = excluded.course_notes_en,
+  motif = excluded.motif,
+  motif_color = excluded.motif_color,
+  motif_romaji = excluded.motif_romaji,
+  tagline_ja = excluded.tagline_ja,
+  tagline_en = excluded.tagline_en,
+  hero_image_url = excluded.hero_image_url,
+  hero_caption_ja = excluded.hero_caption_ja,
+  hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
+  updated_at = excluded.updated_at;
+INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
+  ('kagawa-marathon-2027', 'full', 42.195, 360, '10:00', 10000, 14000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
+INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, walk_minutes, is_primary, sort_order) VALUES
+  ('kagawa-marathon-2027', 'JR高松駅', 'JR Takamatsu Station', '', '徒歩約4分（300m）', 'approx. 4 min walk (300m)', 0, 0, 4, 1, 0);
+INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, walk_minutes, is_primary, sort_order) VALUES
+  ('kagawa-marathon-2027', 'ことでん高松築港駅', 'Kotoden Takamatsu-Chikkō Station', '', '徒歩約4分（320m）', 'approx. 4 min walk (320m)', 0, 0, 4, 0, 1);
+INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
+  ('kagawa-marathon-2027', 'グルメ', '讃岐うどん', 'Sanuki Udon', '香川を代表するご当地グルメ。コシの強い麺とシンプルなだしが特徴。市内に多数の名店。', 'Kagawa''s signature dish. Characterized by chewy noodles and simple broth. Many famous shops in the city.', '高松市内各所', NULL, 34.3403, 134.0472);
+INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
+  ('kagawa-marathon-2027', '観光地', '栗林公園', 'Ritsurin Garden', '国の特別名勝。日本を代表する回遊式大名庭園。', 'A Special Place of Scenic Beauty. One of Japan''s finest strolling gardens.', '高松市内', NULL, 34.3289, 134.0467);
+INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('kagawa-marathon-2027', '["tshirt"]', 'オリジナルTシャツと記念品', 'Original T-shirt and commemorative item', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('kagawa-marathon-2027', '["medal","towel"]', '完走メダルとフィニッシャータオル', 'Finisher medal and finisher towel', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kagawa-marathon-2027', NULL, NULL, '瀬戸内海', 'Seto Inland Sea', NULL, NULL, 0);
+
+-- ==================
 -- 鹿児島マラソン (kagoshima-marathon-2026)
 -- ==================
 DELETE FROM race_course_highlights WHERE race_id = 'kagoshima-marathon-2026';
@@ -4726,6 +5059,7 @@ DELETE FROM completion_gifts WHERE race_id = 'kagoshima-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'kagoshima-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'kagoshima-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'kagoshima-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'kagoshima-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'kagoshima-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'kagoshima-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'kagoshima-marathon-2026';
@@ -4763,9 +5097,9 @@ INSERT INTO races (
   '2025-08-08',
   '2025-11-16',
   0,
-  'pre_day',
-  '',
-  '',
+  'pre_mail',
+  'アスリートビブスは事前郵送。参加賞は2月28日（土）・3月1日（日）に受け取り可能（二次元コードメールを使用）。',
+  'Athlete bibs sent by mail in advance. Participation gifts available for pickup on Feb 28 (Sat) and Mar 1 (Sun) via QR code email.',
   '["景色が良い","火山"]',
   NULL,
   0,
@@ -4785,13 +5119,13 @@ INSERT INTO races (
   NULL,
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
+  '中央公園（おもてなし広場）',
+  'Chuo Park (Omotenashi Hiroba)',
+  '鹿児島市山下町4-1',
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-05-30T06:36:35.675Z'
+  '2026-07-27T14:16:44.298Z'
 ) ON CONFLICT(id) DO UPDATE SET
   name_ja = excluded.name_ja,
   name_en = excluded.name_en,
@@ -4868,6 +5202,7 @@ DELETE FROM completion_gifts WHERE race_id = 'kaikyo-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'kaikyo-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'kaikyo-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'kaikyo-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'kaikyo-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'kaikyo-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'kaikyo-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'kaikyo-marathon-2026';
@@ -4905,9 +5240,9 @@ INSERT INTO races (
   '2026-05-15',
   '2026-07-12',
   0,
-  'pre_day',
-  '',
-  '',
+  'pre_mail',
+  'アスリートビブス（ナンバーカード）・計測チップ・参加賞・大会プログラム・参加案内等を10月上旬に郵送',
+  'Athlete bibs, timing chip, participation gift, race program, and entry guide will be mailed in early October',
   '["海峡","絶景","ご当地エイド充実","観光"]',
   NULL,
   0,
@@ -4933,7 +5268,7 @@ INSERT INTO races (
   NULL,
   NULL,
   '2026-04-30T00:00:00Z',
-  '2026-05-30T06:36:44.764Z'
+  '2026-07-27T14:17:08.917Z'
 ) ON CONFLICT(id) DO UPDATE SET
   name_ja = excluded.name_ja,
   name_en = excluded.name_en,
@@ -5014,6 +5349,7 @@ DELETE FROM completion_gifts WHERE race_id = 'kanazawa-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'kanazawa-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'kanazawa-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'kanazawa-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'kanazawa-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'kanazawa-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'kanazawa-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'kanazawa-marathon-2026';
@@ -5052,15 +5388,15 @@ INSERT INTO races (
   '2026-05-20',
   0,
   'pre_day',
-  '',
-  '',
+  'ランナー受付：10月23日(金) 13:30～20:30、10月24日(土) 9:30～19:30。大会当日の受付は行いません。代理受付不可。',
+  'Runner check-in: Oct 23 (Fri) 13:30–20:30, Oct 24 (Sat) 9:30–19:30. No race-day check-in. No proxy check-in.',
   '["ご当地エイド充実","城下町","景色が良い","観光"]',
   NULL,
   0,
   0,
   0,
   'road',
-  '[]',
+  '["JAAF","WA","AIMS"]',
   '兼六園、金沢城、ひがし茶屋街付近',
   'Kenroku-en Garden, Kanazawa Castle, Higashi Chaya District area',
   NULL,
@@ -5073,13 +5409,13 @@ INSERT INTO races (
   NULL,
   NULL,
   NULL,
-  NULL,
-  NULL,
+  '石川県西部緑地公園（産業展示館4号館前）',
+  'Ishikawa Prefecture Seibu Green Park (in front of Industrial Exhibition Hall Bldg. 4)',
   NULL,
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-05-30T06:36:53.964Z'
+  '2026-07-31T14:32:03.226Z'
 ) ON CONFLICT(id) DO UPDATE SET
   name_ja = excluded.name_ja,
   name_en = excluded.name_en,
@@ -5126,6 +5462,8 @@ INSERT INTO races (
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kanazawa-marathon-2026', 'full', 42.195, 420, '08:30', 15000, 14000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
+INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, walk_minutes, is_primary, sort_order) VALUES
+  ('kanazawa-marathon-2026', '金沢駅', 'Kanazawa Station', '', '徒歩約20分（スタート会場）／シャトルバス有料（スタート会場行き）・無料（フィニッシュ会場行き）', 'Approx. 20 min walk to start venue / Paid shuttle bus to start venue / Free shuttle bus to finish venue', 0, 0, 20, 1, 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('kanazawa-marathon-2026', '観光地', '兼六園', 'Kenroku-en Garden', '日本三名園の一つ。コース上から望める。秋の紅葉が美しい。', 'One of Japan''s three most beautiful gardens. Visible from the course. Beautiful autumn foliage.', 'コース付近', NULL, 36.5625, 136.6625);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -5154,6 +5492,7 @@ DELETE FROM completion_gifts WHERE race_id = 'kasama-togeinosato-half-2025-2025'
 DELETE FROM race_entry_links WHERE race_id = 'kasama-togeinosato-half-2025-2025';
 DELETE FROM race_entry_periods WHERE race_id = 'kasama-togeinosato-half-2025-2025';
 DELETE FROM reception_sessions WHERE race_id = 'kasama-togeinosato-half-2025-2025';
+DELETE FROM race_travel_times WHERE race_id = 'kasama-togeinosato-half-2025-2025';
 DELETE FROM race_results WHERE race_id = 'kasama-togeinosato-half-2025-2025';
 DELETE FROM race_gallery WHERE race_id = 'kasama-togeinosato-half-2025-2025';
 DELETE FROM race_voices WHERE race_id = 'kasama-togeinosato-half-2025-2025';
@@ -5294,6 +5633,153 @@ INSERT OR REPLACE INTO race_time_buckets (race_id, bucket, pct, sort_order) VALU
   ('kasama-togeinosato-half-2025-2025', '2:30-2:45', 2.4, 6);
 
 -- ==================
+-- かさま陶芸の里ハーフマラソン (kasama-togeinosato-half-2025-2026)
+-- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'kasama-togeinosato-half-2025-2026';
+DELETE FROM race_categories WHERE race_id = 'kasama-togeinosato-half-2025-2026';
+DELETE FROM aid_stations WHERE race_id = 'kasama-togeinosato-half-2025-2026';
+DELETE FROM checkpoints WHERE race_id = 'kasama-togeinosato-half-2025-2026';
+DELETE FROM access_points WHERE race_id = 'kasama-togeinosato-half-2025-2026';
+DELETE FROM nearby_spots WHERE race_id = 'kasama-togeinosato-half-2025-2026';
+DELETE FROM weather_history WHERE race_id = 'kasama-togeinosato-half-2025-2026';
+DELETE FROM participation_gifts WHERE race_id = 'kasama-togeinosato-half-2025-2026';
+DELETE FROM completion_gifts WHERE race_id = 'kasama-togeinosato-half-2025-2026';
+DELETE FROM race_entry_links WHERE race_id = 'kasama-togeinosato-half-2025-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'kasama-togeinosato-half-2025-2026';
+DELETE FROM reception_sessions WHERE race_id = 'kasama-togeinosato-half-2025-2026';
+DELETE FROM race_travel_times WHERE race_id = 'kasama-togeinosato-half-2025-2026';
+DELETE FROM race_results WHERE race_id = 'kasama-togeinosato-half-2025-2026';
+DELETE FROM race_gallery WHERE race_id = 'kasama-togeinosato-half-2025-2026';
+DELETE FROM race_voices WHERE race_id = 'kasama-togeinosato-half-2025-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'kasama-togeinosato-half-2025-2026';
+INSERT INTO races (
+  id, name_ja, name_en, date, prefecture, city_ja, city_en,
+  description_ja, description_en, official_url,
+  entry_fee, entry_fee_by_category, entry_capacity,
+  entry_start_date, entry_end_date, entry_closed,
+  reception_type, reception_note_ja, reception_note_en,
+  tags, course_gpx_file,
+  course_max_elevation_m, course_min_elevation_m, course_elevation_diff_m,
+  course_surface, course_certification,
+  course_highlights_ja, course_highlights_en,
+  course_notes_ja, course_notes_en,
+  motif, motif_color, motif_romaji,
+  tagline_ja, tagline_en,
+  hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
+  created_at, updated_at
+) VALUES (
+  'kasama-togeinosato-half-2025-2026',
+  'かさま陶芸の里ハーフマラソン',
+  'Kasama Pottery Village Half Marathon',
+  '2026-12-20',
+  '08',
+  '笠間市',
+  'Kasama City',
+  '',
+  '',
+  'https://www.kasa-mara.jp/',
+  5000,
+  1,
+  2000,
+  '2026-08-10',
+  '2026-10-16',
+  0,
+  'pre_mail',
+  '受付 午前7:30〜9:30。ナンバーカード・計測用チップ・参加賞引換券は事前郵送。当日忘れた場合は再交付受付（手数料2,000円）',
+  'Reception 7:30–9:30 AM. Race bib, timing chip, and gift voucher are mailed in advance. Same-day reissue available at HQ (¥2,000 fee).',
+  '[]',
+  NULL,
+  0,
+  0,
+  0,
+  'road',
+  '["JAAF"]',
+  '',
+  '',
+  '',
+  '',
+  '笠間焼',
+  '#7b7878',
+  'KASAMA-YAKI',
+  'アップダウンが自慢の大会となります。日本全国の「ガチランナー」の皆さん、エントリーお待ちしております',
+  'This race is known for its challenging terrain. We look forward to your entries, serious runners from all over Japan!',
+  NULL,
+  NULL,
+  NULL,
+  '笠間芸術の森公園',
+  'Kasama Art Forest Park',
+  '茨城県笠間市笠間2345番地',
+  NULL,
+  NULL,
+  '2026-07-27T14:17:55.973Z',
+  '2026-07-27T14:17:55.973Z'
+) ON CONFLICT(id) DO UPDATE SET
+  name_ja = excluded.name_ja,
+  name_en = excluded.name_en,
+  date = excluded.date,
+  prefecture = excluded.prefecture,
+  city_ja = excluded.city_ja,
+  city_en = excluded.city_en,
+  description_ja = excluded.description_ja,
+  description_en = excluded.description_en,
+  official_url = excluded.official_url,
+  entry_fee = excluded.entry_fee,
+  entry_fee_by_category = excluded.entry_fee_by_category,
+  entry_capacity = excluded.entry_capacity,
+  entry_start_date = excluded.entry_start_date,
+  entry_end_date = excluded.entry_end_date,
+  entry_closed = excluded.entry_closed,
+  reception_type = excluded.reception_type,
+  reception_note_ja = excluded.reception_note_ja,
+  reception_note_en = excluded.reception_note_en,
+  tags = excluded.tags,
+  course_gpx_file = excluded.course_gpx_file,
+  course_max_elevation_m = excluded.course_max_elevation_m,
+  course_min_elevation_m = excluded.course_min_elevation_m,
+  course_elevation_diff_m = excluded.course_elevation_diff_m,
+  course_surface = excluded.course_surface,
+  course_certification = excluded.course_certification,
+  course_highlights_ja = excluded.course_highlights_ja,
+  course_highlights_en = excluded.course_highlights_en,
+  course_notes_ja = excluded.course_notes_ja,
+  course_notes_en = excluded.course_notes_en,
+  motif = excluded.motif,
+  motif_color = excluded.motif_color,
+  motif_romaji = excluded.motif_romaji,
+  tagline_ja = excluded.tagline_ja,
+  tagline_en = excluded.tagline_en,
+  hero_image_url = excluded.hero_image_url,
+  hero_caption_ja = excluded.hero_caption_ja,
+  hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
+  updated_at = excluded.updated_at;
+INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
+  ('kasama-togeinosato-half-2025-2026', 'half', 21.0975, 150, '10:00', 2000, 5000, NULL, NULL, NULL, NULL, NULL, '18歳以上（高校生を除く）で健康に異常がなく２時間30分以内で完走できる方。なお、安全管理運営上、車いすやベビーカーを使用しての参加はできません。
+
+視覚障害の方への伴走者は、同種目に選手として参加することはできません。また、伴走者は、伴走と表示したゼッケンを持参してください。
+
+年齢起算は、大会日現在とします。', NULL, 'kasama-togeinosato-half-2025-2025', '[]', 0);
+INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, walk_minutes, is_primary, sort_order) VALUES
+  ('kasama-togeinosato-half-2025-2026', '笠間駅', 'Kasama Station', '', 'タクシーで約10分。無料シャトルバスあり', 'Approx. 10 min by taxi. Free shuttle bus available.', 0, 0, NULL, 1, 0);
+INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, walk_minutes, is_primary, sort_order) VALUES
+  ('kasama-togeinosato-half-2025-2026', '友部駅', 'Tomobe Station', '', 'タクシーで約20分。無料シャトルバスあり', 'Approx. 20 min by taxi. Free shuttle bus available.', 0, 0, NULL, 0, 1);
+INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
+  ('kasama-togeinosato-half-2025-2026', '観光地', '笠間稲荷神社', 'Kasama Inari Shrine', '651年創建と伝わる1360年以上の歴史を持つ日本三大稲荷のひとつです。宇迦之御魂神（うかのみたまのかみ）を祀り、五穀豊穣、商売繁盛、殖産興業の守護神として全国から参拝者が訪れます', 'Founded in 651, it is one of Japan’s Three Great Inari Shrines, boasting a history of over 1,360 years. Dedicated to the deity Ukanomitama-no-kami, it attracts visitors from across the country as a guardian deity of bountiful harvests, prosperous business, and industrial development.', '', 'https://www.ibarakiguide.jp/spot.php?mode=detail&code=738', 0, 0);
+INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('kasama-togeinosato-half-2025-2026', '["local_product","food"]', '毎年好評をいただいている「笠間焼」と古くから名物として親しまれている「いなり寿司」を今年もご用意します', '', NULL, 0);
+INSERT OR REPLACE INTO race_entry_links (race_id, site_name, url, sort_order) VALUES
+  ('kasama-togeinosato-half-2025-2026', 'RUNNET', 'https://runnet.jp/parts/2025/377734/entry.html', 0);
+INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
+  ('kasama-togeinosato-half-2025-2026', NULL, '一般エントリー', 'General Entry', '2026-08-10', '2026-10-16', 5000, 0);
+INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
+  ('kasama-togeinosato-half-2025-2026', NULL, 'ふるさと納税枠', 'Hometown Tax Donation Entry', '2026-08-10', '2026-10-09', NULL, 1);
+
+-- ==================
 -- かすみがうらマラソン (kasumigaura-marathon-2026)
 -- ==================
 DELETE FROM race_course_highlights WHERE race_id = 'kasumigaura-marathon-2026';
@@ -5308,6 +5794,7 @@ DELETE FROM completion_gifts WHERE race_id = 'kasumigaura-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'kasumigaura-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'kasumigaura-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'kasumigaura-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'kasumigaura-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'kasumigaura-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'kasumigaura-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'kasumigaura-marathon-2026';
@@ -5450,6 +5937,7 @@ DELETE FROM completion_gifts WHERE race_id = 'katsuta-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'katsuta-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'katsuta-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'katsuta-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'katsuta-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'katsuta-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'katsuta-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'katsuta-marathon-2026';
@@ -5588,6 +6076,7 @@ DELETE FROM completion_gifts WHERE race_id = 'kitakyushu-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'kitakyushu-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'kitakyushu-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'kitakyushu-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'kitakyushu-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'kitakyushu-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'kitakyushu-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'kitakyushu-marathon-2026';
@@ -5730,6 +6219,7 @@ DELETE FROM completion_gifts WHERE race_id = 'kix-senshu-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'kix-senshu-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'kix-senshu-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'kix-senshu-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'kix-senshu-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'kix-senshu-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'kix-senshu-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'kix-senshu-marathon-2026';
@@ -5866,6 +6356,7 @@ DELETE FROM completion_gifts WHERE race_id = 'kobe-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'kobe-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'kobe-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'kobe-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'kobe-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'kobe-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'kobe-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'kobe-marathon-2026';
@@ -5903,7 +6394,7 @@ INSERT INTO races (
   '2026-04-17',
   '2026-06-01',
   0,
-  'both',
+  'pre_day',
   '日時
 2026年11月13日（金曜）　13：00～20：00（最終入場）
 2026年11月14日（土曜）　10：00～19：00（最終入場）　
@@ -5943,13 +6434,13 @@ For relay runs, both runners must register together. Registration by one person,
   NULL,
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
+  '神戸市役所前',
+  'Kobe City Hall',
+  '兵庫県神戸市中央区加納町6-5-1',
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-06-27T13:30:41.348Z'
+  '2026-07-27T14:19:45.923Z'
 ) ON CONFLICT(id) DO UPDATE SET
   name_ja = excluded.name_ja,
   name_en = excluded.name_en,
@@ -6026,6 +6517,7 @@ DELETE FROM completion_gifts WHERE race_id = 'kochi-ryoma-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'kochi-ryoma-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'kochi-ryoma-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'kochi-ryoma-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'kochi-ryoma-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'kochi-ryoma-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'kochi-ryoma-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'kochi-ryoma-marathon-2026';
@@ -6170,6 +6662,7 @@ DELETE FROM completion_gifts WHERE race_id = 'kochi-ryoma-marathon-2027';
 DELETE FROM race_entry_links WHERE race_id = 'kochi-ryoma-marathon-2027';
 DELETE FROM race_entry_periods WHERE race_id = 'kochi-ryoma-marathon-2027';
 DELETE FROM reception_sessions WHERE race_id = 'kochi-ryoma-marathon-2027';
+DELETE FROM race_travel_times WHERE race_id = 'kochi-ryoma-marathon-2027';
 DELETE FROM race_results WHERE race_id = 'kochi-ryoma-marathon-2027';
 DELETE FROM race_gallery WHERE race_id = 'kochi-ryoma-marathon-2027';
 DELETE FROM race_voices WHERE race_id = 'kochi-ryoma-marathon-2027';
@@ -6229,13 +6722,13 @@ INSERT INTO races (
   NULL,
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
+  '高知県庁前（スタート）／高知県立春野総合運動公園（フィニッシュ）',
+  'Kochi Prefectural Office (Start) / Haruno Sogo Undo Koen (Finish)',
+  '高知県高知市丸ノ内1-2-20',
   NULL,
   NULL,
   '2026-06-29T14:13:35.752Z',
-  '2026-06-29T14:13:35.752Z'
+  '2026-07-31T14:32:35.280Z'
 ) ON CONFLICT(id) DO UPDATE SET
   name_ja = excluded.name_ja,
   name_en = excluded.name_en,
@@ -6282,6 +6775,8 @@ INSERT INTO races (
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('kochi-ryoma-marathon-2027', 'full', 42.195, 420, '09:00', 10000, 13000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
+INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, walk_minutes, is_primary, sort_order) VALUES
+  ('kochi-ryoma-marathon-2027', '高知駅', 'Kochi Station', '', '徒歩約15分（高知県庁スタート地点）', '15 min walk to start (Kochi Prefectural Office)', 0, 0, 15, 1, 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('kochi-ryoma-marathon-2027', '観光地', '桂浜', 'Katsurahama Beach', '坂本龍馬像がある高知を代表する景勝地。太平洋の荒波が美しい。', 'A scenic spot representing Kochi with a statue of Sakamoto Ryoma. Beautiful Pacific waves.', '高知市から車約30分', NULL, 33.4997, 133.575);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -6292,6 +6787,8 @@ INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_j
   ('kochi-ryoma-marathon-2027', '["medal"]', '完走メダル', 'Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('kochi-ryoma-marathon-2027', NULL, '一般エントリー', 'General Entry', '2026-08-01', '2026-10-31', 13000, 0);
+INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
+  ('kochi-ryoma-marathon-2027', NULL, '新宿シティ連携協定枠', 'Shinjuku City Partnership Entry', '2026-08-22', '2026-10-20', 26000, 1);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
   ('kochi-ryoma-marathon-2027', NULL, NULL, '太平洋', 'Pacific Ocean', NULL, NULL, 0);
 INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
@@ -6314,6 +6811,7 @@ DELETE FROM completion_gifts WHERE race_id = 'kumamoto-castle-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'kumamoto-castle-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'kumamoto-castle-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'kumamoto-castle-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'kumamoto-castle-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'kumamoto-castle-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'kumamoto-castle-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'kumamoto-castle-marathon-2026';
@@ -6440,6 +6938,147 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
   ('kumamoto-castle-marathon-2026', NULL, NULL, '熊本城', 'Kumamoto Castle', NULL, NULL, 0);
 
 -- ==================
+-- 熊本城マラソン (kumamoto-castle-marathon-2027)
+-- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'kumamoto-castle-marathon-2027';
+DELETE FROM race_categories WHERE race_id = 'kumamoto-castle-marathon-2027';
+DELETE FROM aid_stations WHERE race_id = 'kumamoto-castle-marathon-2027';
+DELETE FROM checkpoints WHERE race_id = 'kumamoto-castle-marathon-2027';
+DELETE FROM access_points WHERE race_id = 'kumamoto-castle-marathon-2027';
+DELETE FROM nearby_spots WHERE race_id = 'kumamoto-castle-marathon-2027';
+DELETE FROM weather_history WHERE race_id = 'kumamoto-castle-marathon-2027';
+DELETE FROM participation_gifts WHERE race_id = 'kumamoto-castle-marathon-2027';
+DELETE FROM completion_gifts WHERE race_id = 'kumamoto-castle-marathon-2027';
+DELETE FROM race_entry_links WHERE race_id = 'kumamoto-castle-marathon-2027';
+DELETE FROM race_entry_periods WHERE race_id = 'kumamoto-castle-marathon-2027';
+DELETE FROM reception_sessions WHERE race_id = 'kumamoto-castle-marathon-2027';
+DELETE FROM race_travel_times WHERE race_id = 'kumamoto-castle-marathon-2027';
+DELETE FROM race_results WHERE race_id = 'kumamoto-castle-marathon-2027';
+DELETE FROM race_gallery WHERE race_id = 'kumamoto-castle-marathon-2027';
+DELETE FROM race_voices WHERE race_id = 'kumamoto-castle-marathon-2027';
+DELETE FROM race_time_buckets WHERE race_id = 'kumamoto-castle-marathon-2027';
+INSERT INTO races (
+  id, name_ja, name_en, date, prefecture, city_ja, city_en,
+  description_ja, description_en, official_url,
+  entry_fee, entry_fee_by_category, entry_capacity,
+  entry_start_date, entry_end_date, entry_closed,
+  reception_type, reception_note_ja, reception_note_en,
+  tags, course_gpx_file,
+  course_max_elevation_m, course_min_elevation_m, course_elevation_diff_m,
+  course_surface, course_certification,
+  course_highlights_ja, course_highlights_en,
+  course_notes_ja, course_notes_en,
+  motif, motif_color, motif_romaji,
+  tagline_ja, tagline_en,
+  hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
+  created_at, updated_at
+) VALUES (
+  'kumamoto-castle-marathon-2027',
+  '熊本城マラソン',
+  'Kumamoto Castle Marathon',
+  '2027-02-21',
+  '43',
+  '熊本市',
+  'Kumamoto City',
+  '熊本城を発着点とするフルマラソン。復興のシンボル・熊本城を目指してゴールする感動のフィニッシュ。',
+  'A full marathon starting and finishing at Kumamoto Castle, the symbol of the city''s recovery.',
+  'https://kumamotojyo-marathon.jp',
+  13750,
+  1,
+  13000,
+  '2026-07-28',
+  '2026-09-24',
+  0,
+  'pre_day',
+  '2027年2月19日（金）12:00〜20:00、2月20日（土）10:00〜20:00。当日受付なし。顔認証システム導入。本人のみ受付可（代理不可）。',
+  'February 19, 2027 (Fri) 12:00–20:00, February 20, 2027 (Sat) 10:00–20:00. No race-day reception. Face recognition system in use. Participant must present in person (no proxy).',
+  '["城下町","景色が良い"]',
+  NULL,
+  0,
+  0,
+  0,
+  'road',
+  '["JAAF"]',
+  '熊本城',
+  'Kumamoto Castle',
+  NULL,
+  NULL,
+  '熊本城',
+  '#1c1917',
+  'Kumamoto-jo',
+  '不落の名城・熊本城をめぐる感動の42km',
+  '42km around the legendary Kumamoto Castle',
+  NULL,
+  NULL,
+  NULL,
+  '花畑広場（くまもと街なか広場）',
+  'Hanabata Plaza (Kumamoto City Center Square)',
+  '熊本市中央区花畑町',
+  NULL,
+  NULL,
+  '2026-07-27T14:20:33.431Z',
+  '2026-07-27T14:20:33.431Z'
+) ON CONFLICT(id) DO UPDATE SET
+  name_ja = excluded.name_ja,
+  name_en = excluded.name_en,
+  date = excluded.date,
+  prefecture = excluded.prefecture,
+  city_ja = excluded.city_ja,
+  city_en = excluded.city_en,
+  description_ja = excluded.description_ja,
+  description_en = excluded.description_en,
+  official_url = excluded.official_url,
+  entry_fee = excluded.entry_fee,
+  entry_fee_by_category = excluded.entry_fee_by_category,
+  entry_capacity = excluded.entry_capacity,
+  entry_start_date = excluded.entry_start_date,
+  entry_end_date = excluded.entry_end_date,
+  entry_closed = excluded.entry_closed,
+  reception_type = excluded.reception_type,
+  reception_note_ja = excluded.reception_note_ja,
+  reception_note_en = excluded.reception_note_en,
+  tags = excluded.tags,
+  course_gpx_file = excluded.course_gpx_file,
+  course_max_elevation_m = excluded.course_max_elevation_m,
+  course_min_elevation_m = excluded.course_min_elevation_m,
+  course_elevation_diff_m = excluded.course_elevation_diff_m,
+  course_surface = excluded.course_surface,
+  course_certification = excluded.course_certification,
+  course_highlights_ja = excluded.course_highlights_ja,
+  course_highlights_en = excluded.course_highlights_en,
+  course_notes_ja = excluded.course_notes_ja,
+  course_notes_en = excluded.course_notes_en,
+  motif = excluded.motif,
+  motif_color = excluded.motif_color,
+  motif_romaji = excluded.motif_romaji,
+  tagline_ja = excluded.tagline_ja,
+  tagline_en = excluded.tagline_en,
+  hero_image_url = excluded.hero_image_url,
+  hero_caption_ja = excluded.hero_caption_ja,
+  hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
+  updated_at = excluded.updated_at;
+INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
+  ('kumamoto-castle-marathon-2027', 'full', 42.195, 420, '09:00', 13000, 13750, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
+INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
+  ('kumamoto-castle-marathon-2027', '観光地', '熊本城', 'Kumamoto Castle', '日本三名城の一つ。震災復興のシンボル。ゴール地点から近い。', 'One of Japan''s three famous castles. Symbol of earthquake recovery. Close to the finish.', 'ゴール付近', NULL, 32.806, 130.7058);
+INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
+  ('kumamoto-castle-marathon-2027', 'グルメ', '馬刺し・太平燕', 'Horse Sashimi & Taipien', '熊本を代表するグルメ。馬刺しと太平燕（春雨スープ）はぜひ試したい。', 'Kumamoto''s signature dishes. Horse sashimi and taipien (glass noodle soup) are must-tries.', '熊本市内', NULL, 32.8032, 130.7079);
+INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('kumamoto-castle-marathon-2027', '["tshirt"]', '大会Tシャツ', 'Race T-shirt', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('kumamoto-castle-marathon-2027', '["medal"]', '完走メダル', 'Finisher medal', NULL, 0);
+INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
+  ('kumamoto-castle-marathon-2027', NULL, '一般エントリー', 'General Entry', '2026-07-28', '2026-09-24', 13750, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('kumamoto-castle-marathon-2027', NULL, NULL, '熊本城', 'Kumamoto Castle', NULL, NULL, 0);
+
+-- ==================
 -- 京都マラソン (kyoto-marathon-2026)
 -- ==================
 DELETE FROM race_course_highlights WHERE race_id = 'kyoto-marathon-2026';
@@ -6454,6 +7093,7 @@ DELETE FROM completion_gifts WHERE race_id = 'kyoto-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'kyoto-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'kyoto-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'kyoto-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'kyoto-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'kyoto-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'kyoto-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'kyoto-marathon-2026';
@@ -6604,6 +7244,7 @@ DELETE FROM completion_gifts WHERE race_id = 'kyoto-marathon-2027';
 DELETE FROM race_entry_links WHERE race_id = 'kyoto-marathon-2027';
 DELETE FROM race_entry_periods WHERE race_id = 'kyoto-marathon-2027';
 DELETE FROM reception_sessions WHERE race_id = 'kyoto-marathon-2027';
+DELETE FROM race_travel_times WHERE race_id = 'kyoto-marathon-2027';
 DELETE FROM race_results WHERE race_id = 'kyoto-marathon-2027';
 DELETE FROM race_gallery WHERE race_id = 'kyoto-marathon-2027';
 DELETE FROM race_voices WHERE race_id = 'kyoto-marathon-2027';
@@ -6754,6 +7395,7 @@ DELETE FROM completion_gifts WHERE race_id = 'mie-matsusaka-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'mie-matsusaka-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'mie-matsusaka-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'mie-matsusaka-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'mie-matsusaka-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'mie-matsusaka-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'mie-matsusaka-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'mie-matsusaka-marathon-2026';
@@ -6791,9 +7433,9 @@ INSERT INTO races (
   '2026-05-24',
   '2026-07-31',
   0,
-  'pre_day',
-  '',
-  '',
+  'pre_mail',
+  '12月上旬頃、登録住所へ大会プログラム・ビブス（ナンバーカード）・記録計測用チップ等を発送予定（健康ウオークの部を除く）',
+  'Race program, bib (race number), timing chip, etc. will be mailed to your registered address in early December (excluding Health Walk participants)',
   '["ご当地グルメ"]',
   NULL,
   0,
@@ -6813,13 +7455,13 @@ INSERT INTO races (
   NULL,
   NULL,
   NULL,
-  NULL,
-  NULL,
+  'クラギ文化ホール前',
+  'Kuragi Culture Hall (Front)',
   NULL,
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-06-22T15:05:11.803Z'
+  '2026-07-31T14:33:07.527Z'
 ) ON CONFLICT(id) DO UPDATE SET
   name_ja = excluded.name_ja,
   name_en = excluded.name_en,
@@ -6875,7 +7517,7 @@ INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_j
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('mie-matsusaka-marathon-2026', NULL, '三重県民先行エントリー', 'Mie Residents Priority Entry', '2026-05-24', '2026-05-31', 12900, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
-  ('mie-matsusaka-marathon-2026', NULL, '宿泊付きエントリー', 'Entry with Accommodation', '2026-05-24', '2026-05-31', NULL, 1);
+  ('mie-matsusaka-marathon-2026', NULL, '宿泊付きエントリー', 'Entry with Accommodation', '2026-05-24', '2026-05-31', 12900, 1);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('mie-matsusaka-marathon-2026', NULL, 'ふるさと納税エントリー', 'Hometown Tax Entry', '2026-05-24', '2026-07-24', 44000, 2);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
@@ -6898,6 +7540,7 @@ DELETE FROM completion_gifts WHERE race_id = 'mito-komon-manyu-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'mito-komon-manyu-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'mito-komon-manyu-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'mito-komon-manyu-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'mito-komon-manyu-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'mito-komon-manyu-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'mito-komon-manyu-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'mito-komon-manyu-marathon-2026';
@@ -6957,13 +7600,13 @@ INSERT INTO races (
   NULL,
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
+  '茨城県三の丸庁舎広場',
+  'Ibaraki Prefectural Sanno-maru Building Square',
+  '茨城県水戸市三の丸1丁目',
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-06-12T14:00:15.434Z'
+  '2026-07-27T14:22:40.297Z'
 ) ON CONFLICT(id) DO UPDATE SET
   name_ja = excluded.name_ja,
   name_en = excluded.name_en,
@@ -7010,6 +7653,8 @@ INSERT INTO races (
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('mito-komon-manyu-marathon-2026', 'full', 42.195, 360, '', 10000, 10000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 'mito-komon-manyu-marathon-2026', '[]', 0);
+INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, walk_minutes, is_primary, sort_order) VALUES
+  ('mito-komon-manyu-marathon-2026', '水戸駅', 'Mito Station', '', '徒歩約5分', 'approx. 5 min walk', 0, 0, 5, 1, 0);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('mito-komon-manyu-marathon-2026', '観光地', '偕楽園', 'Kairakuen Garden', '日本三名園の一つ。2〜3月は梅まつりで有名。コース上から望める。', 'One of Japan''s three most beautiful gardens. Famous for plum blossom festival in Feb-Mar.', 'コース付近', NULL, 36.3811, 140.4511);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
@@ -7038,6 +7683,7 @@ DELETE FROM completion_gifts WHERE race_id = 'mtfuji-climb-run-2026';
 DELETE FROM race_entry_links WHERE race_id = 'mtfuji-climb-run-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'mtfuji-climb-run-2026';
 DELETE FROM reception_sessions WHERE race_id = 'mtfuji-climb-run-2026';
+DELETE FROM race_travel_times WHERE race_id = 'mtfuji-climb-run-2026';
 DELETE FROM race_results WHERE race_id = 'mtfuji-climb-run-2026';
 DELETE FROM race_gallery WHERE race_id = 'mtfuji-climb-run-2026';
 DELETE FROM race_voices WHERE race_id = 'mtfuji-climb-run-2026';
@@ -7091,20 +7737,20 @@ Translated with DeepL.com (free version)',
   '2026-04-24',
   '2026-07-31',
   0,
-  'pre_day',
-  '9/12（土）13:00～18:00
-9/13（日） 6:30～各ウェーブのスタート時刻30分前まで',
-  'Saturday, September 12, 1:00 PM – 6:00 PM
-Sunday, September 13, 6:30 AM – 30 minutes before the start time of each wave',
+  'both',
+  '9月12日（土）（大会前日）13:00～18:00　場所：富士北麓公園 富士山GXスタジアム
+9月13日（日）（大会当日）6:30～各ウェーブのスタート時間の30分前まで　場所：富士北麓公園 富士山GXスタジアム',
+  'Saturday, September 12 (pre-race day): 1:00 PM – 6:00 PM / Venue: Fuji Hokuroku Park Fujisan GX Stadium
+Sunday, September 13 (race day): 6:30 AM – 30 minutes before the start time of each wave / Venue: Fuji Hokuroku Park Fujisan GX Stadium',
   '[]',
   'mtfuji-climb-run-2026.kml',
   0,
   0,
-  0,
-  'road',
+  1200,
+  'trail',
   '[]',
-  '',
-  '',
+  '富士北麓公園 富士山GXスタジアムをスタートし、吉田口登山道を経て五合目フィニッシュまで約12km・標高差約1,200m。補助具（ストック・杖等）使用禁止。関門：馬返し12:12、三合目12:34、ゴール制限13:00。',
+  'Approx. 12km from Fuji Hokuroku Park Fujisan GX Stadium via the Yoshida Trail to the 5th station finish, with approx. 1,200m elevation gain. Poles and walking sticks are prohibited. Cutoffs: Umagaeshi 12:12, 3rd station 12:34, finish 13:00.',
   '',
   '',
   '富士山頂',
@@ -7115,13 +7761,13 @@ Sunday, September 13, 6:30 AM – 30 minutes before the start time of each wave'
   NULL,
   NULL,
   NULL,
-  NULL,
-  NULL,
+  '富士北麓公園 富士山GXスタジアム',
+  'Fuji Hokuroku Park Fujisan GX Stadium',
   NULL,
   NULL,
   NULL,
   '2026-04-28T13:53:53.451Z',
-  '2026-05-30T06:38:26.366Z'
+  '2026-07-31T14:33:27.699Z'
 ) ON CONFLICT(id) DO UPDATE SET
   name_ja = excluded.name_ja,
   name_en = excluded.name_en,
@@ -7168,6 +7814,8 @@ Sunday, September 13, 6:30 AM – 30 minutes before the start time of each wave'
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('mtfuji-climb-run-2026', 'other', 12, 180, '09:00', 2000, 15000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
+INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, walk_minutes, is_primary, sort_order) VALUES
+  ('mtfuji-climb-run-2026', '富士山駅（富士急行線）', 'Fujisan Station (Fujikyu Railway)', '', 'タクシーで10〜15分。大会当日（9/13）は無料シャトルバス運行（富士山駅発7:30・8:00・8:30）', '10-15 min by taxi. Free shuttle bus on race day (Sep 13) departs Fujisan Station at 7:30, 8:00, and 8:30 AM', 0, 0, 0, 1, 0);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('mtfuji-climb-run-2026', '["goods"]', 'オリジナルソフトカップ', 'Original Soft Cup', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
@@ -7188,6 +7836,7 @@ DELETE FROM completion_gifts WHERE race_id = 'nagai-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'nagai-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'nagai-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'nagai-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'nagai-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'nagai-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'nagai-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'nagai-marathon-2026';
@@ -7328,6 +7977,7 @@ DELETE FROM completion_gifts WHERE race_id = 'nagoya-womens-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'nagoya-womens-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'nagoya-womens-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'nagoya-womens-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'nagoya-womens-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'nagoya-womens-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'nagoya-womens-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'nagoya-womens-marathon-2026';
@@ -7468,6 +8118,7 @@ DELETE FROM completion_gifts WHERE race_id = 'naha-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'naha-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'naha-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'naha-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'naha-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'naha-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'naha-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'naha-marathon-2026';
@@ -7505,9 +8156,9 @@ INSERT INTO races (
   NULL,
   NULL,
   0,
-  'pre_day',
-  '',
-  '',
+  'both',
+  '前日受付：12月5日（土）10:00〜20:00、県立武道館アリーナ棟。当日受付：6:00〜スタートまで、県立武道館',
+  'Pre-race reception: Dec 5 (Sat) 10:00–20:00, Kenritsu Budokan Arena. Race-day reception: 6:00 until start, Kenritsu Budokan',
   '["大規模","沖縄","温暖"]',
   NULL,
   0,
@@ -7527,13 +8178,13 @@ INSERT INTO races (
   NULL,
   NULL,
   NULL,
-  NULL,
-  NULL,
+  '奥武山陸上競技場',
+  'Ounoyama Athletic Stadium',
   NULL,
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-06-08T14:35:07.903Z'
+  '2026-07-27T14:24:47.686Z'
 ) ON CONFLICT(id) DO UPDATE SET
   name_ja = excluded.name_ja,
   name_en = excluded.name_en,
@@ -7580,6 +8231,12 @@ INSERT INTO races (
   updated_at = excluded.updated_at;
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('naha-marathon-2026', 'full', 42.195, 375, '09:00', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
+INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, walk_minutes, is_primary, sort_order) VALUES
+  ('naha-marathon-2026', '奥武山公園駅', 'Onoyama Park Station', '', '徒歩約1分', 'approx. 1 min walk', 0, 0, 1, 1, 0);
+INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, walk_minutes, is_primary, sort_order) VALUES
+  ('naha-marathon-2026', '壺川駅', 'Tsubogawa Station', '', '徒歩約1分', 'approx. 1 min walk', 0, 0, 1, 0, 1);
+INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, walk_minutes, is_primary, sort_order) VALUES
+  ('naha-marathon-2026', '旭橋駅（那覇バスターミナル）', 'Asahibashi Station (Naha Bus Terminal)', '', '徒歩約10分', 'approx. 10 min walk', 0, 0, 10, 0, 2);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('naha-marathon-2026', '観光地', '首里城', 'Shuri Castle', '琉球王国の歴史を伝える世界遺産。復元工事が進む。コースからも比較的近い。', 'A World Heritage site conveying the history of the Ryukyu Kingdom. Restoration work in progress.', '那覇市街から車で約15分', NULL, 26.217, 127.7195);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -7604,6 +8261,7 @@ DELETE FROM completion_gifts WHERE race_id = 'nara-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'nara-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'nara-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'nara-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'nara-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'nara-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'nara-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'nara-marathon-2026';
@@ -7641,9 +8299,9 @@ INSERT INTO races (
   '2026-05-27',
   '2026-07-09',
   0,
-  'race_day',
-  '',
-  '',
+  'pre_day',
+  'ランナー受付は12月12日（土）10:00〜20:00のみ。受付をしないと出走できない。参加者認証コードを事前に準備して来場すること。',
+  'Runner check-in is on Saturday, December 12 only (10:00–20:00). You cannot participate without completing check-in. Bring your participant authentication code.',
   '["世界遺産","観光","アップダウン多い","景色が良い"]',
   NULL,
   0,
@@ -7669,7 +8327,7 @@ INSERT INTO races (
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-06-29T14:14:30.479Z'
+  '2026-07-27T14:25:12.645Z'
 ) ON CONFLICT(id) DO UPDATE SET
   name_ja = excluded.name_ja,
   name_en = excluded.name_en,
@@ -7752,6 +8410,7 @@ DELETE FROM completion_gifts WHERE race_id = 'niigata-city-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'niigata-city-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'niigata-city-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'niigata-city-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'niigata-city-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'niigata-city-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'niigata-city-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'niigata-city-marathon-2026';
@@ -7817,7 +8476,7 @@ INSERT INTO races (
   NULL,
   NULL,
   '2026-04-05T07:57:29.198Z',
-  '2026-06-29T14:15:05.114Z'
+  '2026-07-27T14:25:50.699Z'
 ) ON CONFLICT(id) DO UPDATE SET
   name_ja = excluded.name_ja,
   name_en = excluded.name_en,
@@ -7888,6 +8547,7 @@ DELETE FROM completion_gifts WHERE race_id = 'nishio-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'nishio-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'nishio-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'nishio-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'nishio-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'nishio-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'nishio-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'nishio-marathon-2026';
@@ -8020,6 +8680,7 @@ DELETE FROM completion_gifts WHERE race_id = 'ohtawara-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'ohtawara-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'ohtawara-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'ohtawara-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'ohtawara-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'ohtawara-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'ohtawara-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'ohtawara-marathon-2026';
@@ -8147,6 +8808,7 @@ DELETE FROM completion_gifts WHERE race_id = 'okayama-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'okayama-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'okayama-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'okayama-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'okayama-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'okayama-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'okayama-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'okayama-marathon-2026';
@@ -8288,6 +8950,7 @@ DELETE FROM completion_gifts WHERE race_id = 'okushinano100-2026';
 DELETE FROM race_entry_links WHERE race_id = 'okushinano100-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'okushinano100-2026';
 DELETE FROM reception_sessions WHERE race_id = 'okushinano100-2026';
+DELETE FROM race_travel_times WHERE race_id = 'okushinano100-2026';
 DELETE FROM race_results WHERE race_id = 'okushinano100-2026';
 DELETE FROM race_gallery WHERE race_id = 'okushinano100-2026';
 DELETE FROM race_voices WHERE race_id = 'okushinano100-2026';
@@ -8449,6 +9112,7 @@ DELETE FROM completion_gifts WHERE race_id = 'osaka-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'osaka-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'osaka-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'osaka-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'osaka-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'osaka-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'osaka-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'osaka-marathon-2026';
@@ -8595,6 +9259,7 @@ DELETE FROM completion_gifts WHERE race_id = 'osaka-yodo-river-citizens-marathon
 DELETE FROM race_entry_links WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'osaka-yodo-river-citizens-marathon-2026';
@@ -8652,8 +9317,8 @@ Based on themes such as “people,” “environment,” and “the Yodogawa Riv
   '[]',
   '淀川河川公園の河川敷のみを走るフラットコース。通常は通行できない淀川大堰を渡れる特徴がある。フルマラソン9:00・ハーフマラソン8:30・10km 13:00スタート。給水所7地点、救護所4地点設置。',
   'A flat course running entirely along the Yodo River riverbank park. Runners can cross the Yodo River Weir, normally closed to the public. Full marathon starts at 9:00, half at 8:30, 10km at 13:00. 7 water stations and 4 first-aid stations.',
-  NULL,
-  NULL,
+  '救護所設置予定地点：スタート・ゴール地点、赤川地区、西中島地区、塚本地区。',
+  'Planned first-aid station locations: Start/Finish area, Akagawa district, Nishinakajima district, and Tsukamoto district.',
   '淀川',
   '#0284c7',
   'Yodogawa',
@@ -8668,7 +9333,7 @@ Based on themes such as “people,” “environment,” and “the Yodogawa Riv
   NULL,
   NULL,
   '2026-04-11T14:42:59.225Z',
-  '2026-06-27T13:32:25.650Z'
+  '2026-07-31T14:34:51.766Z'
 ) ON CONFLICT(id) DO UPDATE SET
   name_ja = excluded.name_ja,
   name_en = excluded.name_en,
@@ -8724,7 +9389,11 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
 参加賞：Ｔシャツ（フリーサイズ）
 完走証：タオル
 【10km】
-参加賞：タオル', '', NULL, 0);
+参加賞：タオル', '[Full / Half]
+Participation gift: T-shirt (free size)
+Finisher certificate: Towel
+[10km]
+Participation gift: Towel', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
   ('osaka-yodo-river-citizens-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-17', '2026-09-27', NULL, 0);
 
@@ -8743,6 +9412,7 @@ DELETE FROM completion_gifts WHERE race_id = 'osj-ontake100-2026';
 DELETE FROM race_entry_links WHERE race_id = 'osj-ontake100-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'osj-ontake100-2026';
 DELETE FROM reception_sessions WHERE race_id = 'osj-ontake100-2026';
+DELETE FROM race_travel_times WHERE race_id = 'osj-ontake100-2026';
 DELETE FROM race_results WHERE race_id = 'osj-ontake100-2026';
 DELETE FROM race_gallery WHERE race_id = 'osj-ontake100-2026';
 DELETE FROM race_voices WHERE race_id = 'osj-ontake100-2026';
@@ -8781,8 +9451,8 @@ INSERT INTO races (
   '2026-06-14',
   0,
   'pre_day',
-  '一般エントリー：2025年11月14日〜12月12日（終了）。追加エントリー：2026年2月1日〜6月14日（空きがある場合）。',
-  'General entry: Nov 14 – Dec 12, 2025 (closed). Additional entry: Feb 1 – Jun 14, 2026 (if spots available).',
+  '選手受付：7月18日(土) 13:00〜19:00（松原スポーツ公園）',
+  'Athlete check-in: Jul 18 (Sat) 13:00–19:00 (Matsubara Sports Park)',
   '["ウルトラマラソン","アップダウン多い","景色が良い","歴史ある大会","火山"]',
   NULL,
   0,
@@ -8802,13 +9472,13 @@ INSERT INTO races (
   NULL,
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
+  '松原スポーツ公園',
+  'Matsubara Sports Park',
+  '長野県木曽郡王滝村',
   NULL,
   NULL,
   '2026-03-30T00:00:00Z',
-  '2026-06-08T14:39:14.413Z'
+  '2026-07-27T14:29:48.574Z'
 ) ON CONFLICT(id) DO UPDATE SET
   name_ja = excluded.name_ja,
   name_en = excluded.name_en,
@@ -8857,6 +9527,8 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
   ('osj-ontake100-2026', 'ultra', 163, 1440, '20:00', 200, 21000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('osj-ontake100-2026', 'ultra', 109, 1200, '00:00', 1200, 19000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 1);
+INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, walk_minutes, is_primary, sort_order) VALUES
+  ('osj-ontake100-2026', '木曽福島駅', 'Kiso-Fukushima Station', '', '無料シャトルバスで約40分', 'Free shuttle bus, approx. 40 min', 0, 0, NULL, 1, 0);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('osj-ontake100-2026', '["tshirt"]', 'オリジナルTシャツ（有料オプション、+1,500円）', 'Original T-shirt (paid option, +¥1,500)', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
@@ -8887,6 +9559,7 @@ DELETE FROM completion_gifts WHERE race_id = 'sado-toki-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'sado-toki-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'sado-toki-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'sado-toki-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'sado-toki-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'sado-toki-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'sado-toki-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'sado-toki-marathon-2026';
@@ -9025,6 +9698,7 @@ DELETE FROM completion_gifts WHERE race_id = 'saga-sakura-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'saga-sakura-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'saga-sakura-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'saga-sakura-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'saga-sakura-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'saga-sakura-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'saga-sakura-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'saga-sakura-marathon-2026';
@@ -9163,6 +9837,7 @@ DELETE FROM completion_gifts WHERE race_id = 'saitama-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'saitama-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'saitama-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'saitama-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'saitama-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'saitama-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'saitama-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'saitama-marathon-2026';
@@ -9293,6 +9968,7 @@ DELETE FROM completion_gifts WHERE race_id = 'saitama-marathon-2027';
 DELETE FROM race_entry_links WHERE race_id = 'saitama-marathon-2027';
 DELETE FROM race_entry_periods WHERE race_id = 'saitama-marathon-2027';
 DELETE FROM reception_sessions WHERE race_id = 'saitama-marathon-2027';
+DELETE FROM race_travel_times WHERE race_id = 'saitama-marathon-2027';
 DELETE FROM race_results WHERE race_id = 'saitama-marathon-2027';
 DELETE FROM race_gallery WHERE race_id = 'saitama-marathon-2027';
 DELETE FROM race_voices WHERE race_id = 'saitama-marathon-2027';
@@ -9427,6 +10103,7 @@ DELETE FROM completion_gifts WHERE race_id = 'sapporo-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'sapporo-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'sapporo-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'sapporo-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'sapporo-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'sapporo-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'sapporo-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'sapporo-marathon-2026';
@@ -9486,13 +10163,13 @@ INSERT INTO races (
   NULL,
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
+  '真駒内セキスイハイムスタジアム',
+  'Makomanai Sekisui Heim Stadium',
+  '札幌市南区真駒内公園3番1号',
   NULL,
   NULL,
   '2026-05-15T14:40:14.753Z',
-  '2026-06-08T14:40:01.427Z'
+  '2026-07-31T14:36:22.238Z'
 ) ON CONFLICT(id) DO UPDATE SET
   name_ja = excluded.name_ja,
   name_en = excluded.name_en,
@@ -9544,6 +10221,8 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('sapporo-marathon-2026', '["tshirt"]', 'オリジナルTシャツ
 https://satumara.sapporo-sport.jp/prizes.html', '', NULL, 0);
+INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('sapporo-marathon-2026', '["other"]', 'マイボトル・マイカップ（ソフトフラスク400ml／ソフトカップ200ml）希望者に事前配布。ハーフマラソン参加者はソフトフラスク＋ソフトカップ、10km参加者はソフトカップ。', 'My bottle / my cup (soft flask 400ml or soft cup 200ml), distributed in advance upon request. Half marathon: soft flask + soft cup; 10km: soft cup only.', NULL, 1);
 INSERT OR REPLACE INTO race_entry_links (race_id, site_name, url, sort_order) VALUES
   ('sapporo-marathon-2026', 'RUNNET', 'https://satumara.sapporo-sport.jp/images/entry/runnet.svg', 0);
 INSERT OR REPLACE INTO race_entry_links (race_id, site_name, url, sort_order) VALUES
@@ -9572,6 +10251,7 @@ DELETE FROM completion_gifts WHERE race_id = 'shiga-kogen100-2026';
 DELETE FROM race_entry_links WHERE race_id = 'shiga-kogen100-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'shiga-kogen100-2026';
 DELETE FROM reception_sessions WHERE race_id = 'shiga-kogen100-2026';
+DELETE FROM race_travel_times WHERE race_id = 'shiga-kogen100-2026';
 DELETE FROM race_results WHERE race_id = 'shiga-kogen100-2026';
 DELETE FROM race_gallery WHERE race_id = 'shiga-kogen100-2026';
 DELETE FROM race_voices WHERE race_id = 'shiga-kogen100-2026';
@@ -9615,94 +10295,8 @@ INSERT INTO races (
   '2026-07-27',
   0,
   'pre_day',
-  '
-ABOUT
-大会概要
-大会名	志賀高原100
-開催日	2026年8月28日（金）、29日（土）、30日（日）
-（金曜日：100km受付）（土曜日：レーススタート）（日曜日：表彰式）
-開催場所	長野県下高井郡山ノ内町
-コース	100km／累積標高　約4400m／制限時間26時間
-40km／累積標高　約1690m／制限時間10時間30分
-18km／累積標高　約1100m／制限時間6時間30分
-ITRAポイント	※申請中
-募集定員	100km／700名、40km／400名、18km／200名
-募集期間	2026年4月5日（日）～ 7月27日（月）
-※定員になり次第締め切りとなります。
-参加資格	
-100km
-18歳以上の健康な男女。
-レース前日の大会宿泊プラン申込が必要となります。（長野市、須坂市、中野市、飯山市、千曲市、山ノ内町、信濃町、飯綱町、小布施町、高山村、木島平村、野沢温泉村、栄村にお住まいの方は必要ありません）
-40km
-18歳以上の健康な男女。
-18km
-中学生以上の健康な男女。
-※自然に対する配慮とマナーを守って大会に参加できる方。
-レース参加費	
-100km
-28,000円
-100km（登山道整備）
-27,500円　※登山道整備への参加が必要となります。
-40km
-9,900円
-40km（登山道整備）
-9,400円　※登山道整備への参加が必要となります。
-18km
-7,500円
-登山道整備協力金	100㎞と40㎞のエントリー費には、登山道整備費用（500円）が含まれています。
-事前の草刈り及び10月予定の整備イベントにご参加される方は「登山道整備参加」エントリーからお申し込みください（人数限定、先着制）。
-
-本大会は素晴らしい自然景観を有する国立公園内にて実施されております。この自然を守りながら持続的に大会を実施していくためには、レースでトレイルを「使った」分、トレイルの整備も行うことが大切です。レースを走ることが未来に向けてこの自然景観を守っていくことにつながる様に、ぜひ、皆さまのご協力、どうぞ宜しくお願いいいたします。
-表彰	
-100km
-男女総合1位～6位、男女年代別1位～3位（29歳以下、30代、40代、50代、60歳以上）
-40km
-男女総合1位～6位
-18km
-男女総合1位～6位
-参加賞	大会オリジナルTシャツ
-大会HP	http://www.nature-scene.net/shiga100/
-主催	志賀高原100実行委員会
-企画・運営	NPO法人 北信濃トレイルフリークス、株式会社Nature Scene、株式会社共立プラニング
-後援	山ノ内町、志賀高原観光協会
-協賛	MERRELL、パワーバー、zen nutrition、SMITH、ニューハレ、いろは堂、桜井甘精堂、アスザックフーズ、マルコメ、北信ファーム、ERGSTAR、SATOH SPORTS
-ルール
-RULE
-photo
-定められたコースのタイムレース方式（所要時間の少ない選手から順位を決定）とします。
-レースには制限時間を設け、これを超えた選手はレースを中止し、役員の指示に従い下山してください。
-※各種目の関門、ゴール制限時間は別途ご案内します。
-全コースにおいて、ストック・ポール等はキャップを必ず着用しマナーを守って使用しましょう。キャップがない場合は使用することができません。
-レースを中断（棄権）する場合は、必ずコース中の役員に申し出てください。
-競技続行が不可能と判断された選手は、役員が競技を中断させることがあります。
-下記を守らない選手は失格とします。
-競技規則に違反し、役員の指示に従わなかった選手
-参加資格を偽って参加した選手
-ゼッケンを着用しなかった選手
-自然保護に違反する行為があった選手
-参加資格を偽って参加したり、不正行為を行った選手
-装備
-EQUIPMENT
-＜必携装備＞
-※100kmは受付時に必携装備品のチェックを行います。
-※レース中、必携装備品のチェックを行う場合があります。必携装備品不足が判明した場合、理由の如何を問わず失格となり、レースを続けることはできません。
-エントリー時に番号を届け出た携帯電話
-各自必要な水分と食料
-ライトと予備バッテリー（ライト2個でも可）　※100kmのみ
-マイカップ
-サバイバルブランケット
-フード付きレインウエア（完全防水、透湿機能を持ち、縫い目をシームテープで防水加工してあるもの）
-レインパンツ
-ファーストエイドキット（絆創膏、消毒薬など）
-健康保険証（コピー可）
-受付時に配布されたゼッケン及び計測チップ
-携帯トイレ（山岳セクションに携帯トイレ使用ブースを設置予定）
-＜推奨装備＞
-熊鈴
-手袋・グローブ
-防寒着（夜間はかなり寒くなります）
-ポイズンリムーバー',
-  '',
+  '100kmは前日（8月28日・金曜日）に受付・必携装備品チェックあり。参加通知書（はがき）は開催1週間前までに郵送。',
+  '100km check-in is on the eve of the race (Friday, August 28) with mandatory gear inspection. Participation card mailed approximately one week before the event.',
   '["ウルトラマラソン","初ウルトラおすすめ","景色が良い"]',
   NULL,
   0,
@@ -9722,13 +10316,13 @@ EQUIPMENT
   NULL,
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
+  '志賀高原 サンバレー',
+  'Shiga Kogen Sun Valley',
+  '長野県下高井郡山ノ内町平穏7149',
   NULL,
   NULL,
   '2026-04-05T06:01:54.559Z',
-  '2026-06-22T15:06:42.561Z'
+  '2026-07-27T14:32:24.164Z'
 ) ON CONFLICT(id) DO UPDATE SET
   name_ja = excluded.name_ja,
   name_en = excluded.name_en,
@@ -9779,10 +10373,20 @@ INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, tim
   ('shiga-kogen100-2026', 'other', 40, 630, '06:30', 400, 9900, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 1);
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('shiga-kogen100-2026', 'other', 18, 390, '10:00', 200, 7500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 2);
+INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, walk_minutes, is_primary, sort_order) VALUES
+  ('shiga-kogen100-2026', '長野駅', 'Nagano Station', '', '長電バス急行「志賀高原線」で一の瀬バス停下車、または大会送迎シャトルバス利用', 'Take Nagaden Bus express Shiga Kogen Line to Ichinose bus stop, or use event shuttle bus from Nagano Station', 0, 0, 0, 1, 0);
 INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
-  ('shiga-kogen100-2026', '["tshirt"]', '大会オリジナルTシャツ', '', NULL, 0);
+  ('shiga-kogen100-2026', '["tshirt"]', '大会オリジナルTシャツ', 'Original event T-shirt', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
-  ('shiga-kogen100-2026', NULL, '一般エントリー', 'General Entry', '2026-04-05', '2026-07-27', NULL, 0);
+  ('shiga-kogen100-2026', NULL, '100km 一般', '100km General', '2026-04-05', '2026-07-27', 28000, 0);
+INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
+  ('shiga-kogen100-2026', NULL, '100km 登山道整備参加', '100km Trail Maintenance', '2026-04-05', '2026-07-27', 27500, 1);
+INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
+  ('shiga-kogen100-2026', NULL, '40km 一般', '40km General', '2026-04-05', '2026-07-27', 9900, 2);
+INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
+  ('shiga-kogen100-2026', NULL, '40km 登山道整備参加', '40km Trail Maintenance', '2026-04-05', '2026-07-27', 9400, 3);
+INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
+  ('shiga-kogen100-2026', NULL, '18km', '18km', '2026-04-05', '2026-07-27', 7500, 4);
 
 -- ==================
 -- しまだ大井川マラソン (shimada-oigawa-marathon-2026)
@@ -9799,6 +10403,7 @@ DELETE FROM completion_gifts WHERE race_id = 'shimada-oigawa-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'shimada-oigawa-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'shimada-oigawa-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'shimada-oigawa-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'shimada-oigawa-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'shimada-oigawa-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'shimada-oigawa-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'shimada-oigawa-marathon-2026';
@@ -9939,6 +10544,7 @@ DELETE FROM completion_gifts WHERE race_id = 'shinetsu5mountains-trail-100-2026'
 DELETE FROM race_entry_links WHERE race_id = 'shinetsu5mountains-trail-100-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'shinetsu5mountains-trail-100-2026';
 DELETE FROM reception_sessions WHERE race_id = 'shinetsu5mountains-trail-100-2026';
+DELETE FROM race_travel_times WHERE race_id = 'shinetsu5mountains-trail-100-2026';
 DELETE FROM race_results WHERE race_id = 'shinetsu5mountains-trail-100-2026';
 DELETE FROM race_gallery WHERE race_id = 'shinetsu5mountains-trail-100-2026';
 DELETE FROM race_voices WHERE race_id = 'shinetsu5mountains-trail-100-2026';
@@ -10082,6 +10688,7 @@ DELETE FROM completion_gifts WHERE race_id = 'shizuoka-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'shizuoka-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'shizuoka-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'shizuoka-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'shizuoka-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'shizuoka-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'shizuoka-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'shizuoka-marathon-2026';
@@ -10216,6 +10823,7 @@ DELETE FROM completion_gifts WHERE race_id = 'shonan-international-marathon-2026
 DELETE FROM race_entry_links WHERE race_id = 'shonan-international-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'shonan-international-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'shonan-international-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'shonan-international-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'shonan-international-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'shonan-international-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'shonan-international-marathon-2026';
@@ -10281,7 +10889,7 @@ INSERT INTO races (
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-06-08T14:40:37.321Z'
+  '2026-07-27T14:32:56.841Z'
 ) ON CONFLICT(id) DO UPDATE SET
   name_ja = excluded.name_ja,
   name_en = excluded.name_en,
@@ -10337,9 +10945,7 @@ INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, descriptio
 INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
   ('shonan-international-marathon-2026', '["medal"]', '完走メダル', 'Finisher medal', NULL, 0);
 INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
-  ('shonan-international-marathon-2026', NULL, '一次募集', 'First Round Entry', '2026-04-04', '2026-09-09', 16000, 0);
-INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label_en, start_date, end_date, entry_fee, sort_order) VALUES
-  ('shonan-international-marathon-2026', NULL, '二次募集', 'Secondary Entry', '2026-06-05', '2026-09-09', NULL, 1);
+  ('shonan-international-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-04', '2026-09-09', 16000, 0);
 
 -- ==================
 -- そうじゃ吉備路マラソン (soja-kibiji-marathon-2026)
@@ -10356,6 +10962,7 @@ DELETE FROM completion_gifts WHERE race_id = 'soja-kibiji-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'soja-kibiji-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'soja-kibiji-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'soja-kibiji-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'soja-kibiji-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'soja-kibiji-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'soja-kibiji-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'soja-kibiji-marathon-2026';
@@ -10487,6 +11094,154 @@ INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja
   ('soja-kibiji-marathon-2026', NULL, NULL, '吉備路', 'Kibiji', NULL, NULL, 2);
 
 -- ==================
+-- そうじゃ吉備路マラソン (soja-kibiji-marathon-2027)
+-- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'soja-kibiji-marathon-2027';
+DELETE FROM race_categories WHERE race_id = 'soja-kibiji-marathon-2027';
+DELETE FROM aid_stations WHERE race_id = 'soja-kibiji-marathon-2027';
+DELETE FROM checkpoints WHERE race_id = 'soja-kibiji-marathon-2027';
+DELETE FROM access_points WHERE race_id = 'soja-kibiji-marathon-2027';
+DELETE FROM nearby_spots WHERE race_id = 'soja-kibiji-marathon-2027';
+DELETE FROM weather_history WHERE race_id = 'soja-kibiji-marathon-2027';
+DELETE FROM participation_gifts WHERE race_id = 'soja-kibiji-marathon-2027';
+DELETE FROM completion_gifts WHERE race_id = 'soja-kibiji-marathon-2027';
+DELETE FROM race_entry_links WHERE race_id = 'soja-kibiji-marathon-2027';
+DELETE FROM race_entry_periods WHERE race_id = 'soja-kibiji-marathon-2027';
+DELETE FROM reception_sessions WHERE race_id = 'soja-kibiji-marathon-2027';
+DELETE FROM race_travel_times WHERE race_id = 'soja-kibiji-marathon-2027';
+DELETE FROM race_results WHERE race_id = 'soja-kibiji-marathon-2027';
+DELETE FROM race_gallery WHERE race_id = 'soja-kibiji-marathon-2027';
+DELETE FROM race_voices WHERE race_id = 'soja-kibiji-marathon-2027';
+DELETE FROM race_time_buckets WHERE race_id = 'soja-kibiji-marathon-2027';
+INSERT INTO races (
+  id, name_ja, name_en, date, prefecture, city_ja, city_en,
+  description_ja, description_en, official_url,
+  entry_fee, entry_fee_by_category, entry_capacity,
+  entry_start_date, entry_end_date, entry_closed,
+  reception_type, reception_note_ja, reception_note_en,
+  tags, course_gpx_file,
+  course_max_elevation_m, course_min_elevation_m, course_elevation_diff_m,
+  course_surface, course_certification,
+  course_highlights_ja, course_highlights_en,
+  course_notes_ja, course_notes_en,
+  motif, motif_color, motif_romaji,
+  tagline_ja, tagline_en,
+  hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
+  created_at, updated_at
+) VALUES (
+  'soja-kibiji-marathon-2027',
+  'そうじゃ吉備路マラソン',
+  'Soja Kibiji Marathon',
+  '2027-02-28',
+  '33',
+  '総社市',
+  'Soja City',
+  '岡山県総社市で開催。吉備路の歴史ある風景の中を走るマラソン。五重塔や古墳群を眺めながら走れる。',
+  'Held in Soja City, Okayama. Run through the historic Kibiji landscape, passing a five-story pagoda and ancient burial mounds.',
+  'https://soja-kibijimarathon.jp',
+  9100,
+  1,
+  15000,
+  NULL,
+  NULL,
+  0,
+  'pre_mail',
+  'すべての種目でナンバーカードを事前に発送させていただきます。
+そのため受付はございません。',
+  'Number cards for all events will be sent out in advance.
+
+Therefore, there is no registration required.',
+  '["景色が良い","歴史"]',
+  NULL,
+  0,
+  0,
+  0,
+  'road',
+  '[]',
+  '備中国分寺五重塔、古墳群、吉備路',
+  'Bitchu Kokubunji five-story pagoda, burial mounds, Kibiji',
+  NULL,
+  NULL,
+  '吉備路',
+  '#854d0e',
+  'Kibiji',
+  '吉備路の古代ロマンを感じながら走る42km',
+  'Run the ancient Kibiji road through Soja''s historic landscape',
+  NULL,
+  NULL,
+  NULL,
+  '総社商工会館東交差点（発着）・総社市スポーツセンター',
+  'Soja Chamber of Commerce East Intersection (Start/Finish) / Soja Sports Center',
+  '岡山県総社市',
+  NULL,
+  NULL,
+  '2026-07-27T14:33:45.113Z',
+  '2026-07-27T14:33:45.113Z'
+) ON CONFLICT(id) DO UPDATE SET
+  name_ja = excluded.name_ja,
+  name_en = excluded.name_en,
+  date = excluded.date,
+  prefecture = excluded.prefecture,
+  city_ja = excluded.city_ja,
+  city_en = excluded.city_en,
+  description_ja = excluded.description_ja,
+  description_en = excluded.description_en,
+  official_url = excluded.official_url,
+  entry_fee = excluded.entry_fee,
+  entry_fee_by_category = excluded.entry_fee_by_category,
+  entry_capacity = excluded.entry_capacity,
+  entry_start_date = excluded.entry_start_date,
+  entry_end_date = excluded.entry_end_date,
+  entry_closed = excluded.entry_closed,
+  reception_type = excluded.reception_type,
+  reception_note_ja = excluded.reception_note_ja,
+  reception_note_en = excluded.reception_note_en,
+  tags = excluded.tags,
+  course_gpx_file = excluded.course_gpx_file,
+  course_max_elevation_m = excluded.course_max_elevation_m,
+  course_min_elevation_m = excluded.course_min_elevation_m,
+  course_elevation_diff_m = excluded.course_elevation_diff_m,
+  course_surface = excluded.course_surface,
+  course_certification = excluded.course_certification,
+  course_highlights_ja = excluded.course_highlights_ja,
+  course_highlights_en = excluded.course_highlights_en,
+  course_notes_ja = excluded.course_notes_ja,
+  course_notes_en = excluded.course_notes_en,
+  motif = excluded.motif,
+  motif_color = excluded.motif_color,
+  motif_romaji = excluded.motif_romaji,
+  tagline_ja = excluded.tagline_ja,
+  tagline_en = excluded.tagline_en,
+  hero_image_url = excluded.hero_image_url,
+  hero_caption_ja = excluded.hero_caption_ja,
+  hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
+  updated_at = excluded.updated_at;
+INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
+  ('soja-kibiji-marathon-2027', 'full', 42.195, 360, '09:20', 2000, 9100, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
+INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, walk_minutes, is_primary, sort_order) VALUES
+  ('soja-kibiji-marathon-2027', '総社駅', 'Soja Station', '', '徒歩約20分', 'approx. 20 min walk', 0, 0, 20, 1, 0);
+INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, walk_minutes, is_primary, sort_order) VALUES
+  ('soja-kibiji-marathon-2027', '東総社駅', 'Higashi-Soja Station', '', '徒歩約20分', 'approx. 20 min walk', 0, 0, 20, 0, 1);
+INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
+  ('soja-kibiji-marathon-2027', '観光地', '備中国分寺五重塔', 'Bitchu Kokubunji Five-Story Pagoda', '吉備路のシンボル。コース上から望める。田園風景の中に立つ姿が美しい。', 'Symbol of Kibiji. Visible from the course. Beautiful standing among rice paddies.', 'コース上', NULL, 34.65, 133.7833);
+INSERT OR REPLACE INTO participation_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('soja-kibiji-marathon-2027', '["tshirt"]', '大会Tシャツ', 'Race T-shirt', NULL, 0);
+INSERT OR REPLACE INTO completion_gifts (race_id, gift_categories, description_ja, description_en, image, sort_order) VALUES
+  ('soja-kibiji-marathon-2027', '["medal"]', '完走メダル', 'Finisher medal', NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('soja-kibiji-marathon-2027', NULL, NULL, '備中国分寺五重塔', 'Bitchu Kokubunji five-story pagoda', NULL, NULL, 0);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('soja-kibiji-marathon-2027', NULL, NULL, '古墳群', 'burial mounds', NULL, NULL, 1);
+INSERT OR REPLACE INTO race_course_highlights (race_id, category_id, km, name_ja, name_en, note_ja, note_en, sort_order) VALUES
+  ('soja-kibiji-marathon-2027', NULL, NULL, '吉備路', 'Kibiji', NULL, NULL, 2);
+
+-- ==================
 -- 丹波篠山ABCマラソン (tamba-sasayama-abc-marathon-2026)
 -- ==================
 DELETE FROM race_course_highlights WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
@@ -10501,6 +11256,7 @@ DELETE FROM completion_gifts WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'tamba-sasayama-abc-marathon-2026';
@@ -10637,6 +11393,7 @@ DELETE FROM completion_gifts WHERE race_id = 'tateyama-wakashio-2026';
 DELETE FROM race_entry_links WHERE race_id = 'tateyama-wakashio-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'tateyama-wakashio-2026';
 DELETE FROM reception_sessions WHERE race_id = 'tateyama-wakashio-2026';
+DELETE FROM race_travel_times WHERE race_id = 'tateyama-wakashio-2026';
 DELETE FROM race_results WHERE race_id = 'tateyama-wakashio-2026';
 DELETE FROM race_gallery WHERE race_id = 'tateyama-wakashio-2026';
 DELETE FROM race_voices WHERE race_id = 'tateyama-wakashio-2026';
@@ -10775,6 +11532,7 @@ DELETE FROM completion_gifts WHERE race_id = 'tazawako-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'tazawako-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'tazawako-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'tazawako-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'tazawako-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'tazawako-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'tazawako-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'tazawako-marathon-2026';
@@ -10898,6 +11656,133 @@ INSERT OR REPLACE INTO race_entry_periods (race_id, category_id, label_ja, label
   ('tazawako-marathon-2026', NULL, '一般エントリー', 'General Entry', '2026-04-01', '2026-05-27', NULL, 0);
 
 -- ==================
+-- テストマラソン (test-marathon-2026)
+-- ==================
+DELETE FROM race_course_highlights WHERE race_id = 'test-marathon-2026';
+DELETE FROM race_categories WHERE race_id = 'test-marathon-2026';
+DELETE FROM aid_stations WHERE race_id = 'test-marathon-2026';
+DELETE FROM checkpoints WHERE race_id = 'test-marathon-2026';
+DELETE FROM access_points WHERE race_id = 'test-marathon-2026';
+DELETE FROM nearby_spots WHERE race_id = 'test-marathon-2026';
+DELETE FROM weather_history WHERE race_id = 'test-marathon-2026';
+DELETE FROM participation_gifts WHERE race_id = 'test-marathon-2026';
+DELETE FROM completion_gifts WHERE race_id = 'test-marathon-2026';
+DELETE FROM race_entry_links WHERE race_id = 'test-marathon-2026';
+DELETE FROM race_entry_periods WHERE race_id = 'test-marathon-2026';
+DELETE FROM reception_sessions WHERE race_id = 'test-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'test-marathon-2026';
+DELETE FROM race_results WHERE race_id = 'test-marathon-2026';
+DELETE FROM race_gallery WHERE race_id = 'test-marathon-2026';
+DELETE FROM race_voices WHERE race_id = 'test-marathon-2026';
+DELETE FROM race_time_buckets WHERE race_id = 'test-marathon-2026';
+INSERT INTO races (
+  id, name_ja, name_en, date, prefecture, city_ja, city_en,
+  description_ja, description_en, official_url,
+  entry_fee, entry_fee_by_category, entry_capacity,
+  entry_start_date, entry_end_date, entry_closed,
+  reception_type, reception_note_ja, reception_note_en,
+  tags, course_gpx_file,
+  course_max_elevation_m, course_min_elevation_m, course_elevation_diff_m,
+  course_surface, course_certification,
+  course_highlights_ja, course_highlights_en,
+  course_notes_ja, course_notes_en,
+  motif, motif_color, motif_romaji,
+  tagline_ja, tagline_en,
+  hero_image_url, hero_caption_ja, hero_caption_en,
+  venue_name_ja, venue_name_en, venue_address, start_lat, start_lng,
+  created_at, updated_at
+) VALUES (
+  'test-marathon-2026',
+  'テストマラソン',
+  NULL,
+  '2027-03-01',
+  NULL,
+  NULL,
+  NULL,
+  '',
+  '',
+  '',
+  16200,
+  0,
+  38000,
+  '2025-08-01',
+  '2025-10-31',
+  0,
+  'race_day',
+  '',
+  '',
+  '{}',
+  NULL,
+  0,
+  0,
+  0,
+  'road',
+  '{}',
+  '',
+  '',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  '2026-07-31T14:58:53.991Z'
+) ON CONFLICT(id) DO UPDATE SET
+  name_ja = excluded.name_ja,
+  name_en = excluded.name_en,
+  date = excluded.date,
+  prefecture = excluded.prefecture,
+  city_ja = excluded.city_ja,
+  city_en = excluded.city_en,
+  description_ja = excluded.description_ja,
+  description_en = excluded.description_en,
+  official_url = excluded.official_url,
+  entry_fee = excluded.entry_fee,
+  entry_fee_by_category = excluded.entry_fee_by_category,
+  entry_capacity = excluded.entry_capacity,
+  entry_start_date = excluded.entry_start_date,
+  entry_end_date = excluded.entry_end_date,
+  entry_closed = excluded.entry_closed,
+  reception_type = excluded.reception_type,
+  reception_note_ja = excluded.reception_note_ja,
+  reception_note_en = excluded.reception_note_en,
+  tags = excluded.tags,
+  course_gpx_file = excluded.course_gpx_file,
+  course_max_elevation_m = excluded.course_max_elevation_m,
+  course_min_elevation_m = excluded.course_min_elevation_m,
+  course_elevation_diff_m = excluded.course_elevation_diff_m,
+  course_surface = excluded.course_surface,
+  course_certification = excluded.course_certification,
+  course_highlights_ja = excluded.course_highlights_ja,
+  course_highlights_en = excluded.course_highlights_en,
+  course_notes_ja = excluded.course_notes_ja,
+  course_notes_en = excluded.course_notes_en,
+  motif = excluded.motif,
+  motif_color = excluded.motif_color,
+  motif_romaji = excluded.motif_romaji,
+  tagline_ja = excluded.tagline_ja,
+  tagline_en = excluded.tagline_en,
+  hero_image_url = excluded.hero_image_url,
+  hero_caption_ja = excluded.hero_caption_ja,
+  hero_caption_en = excluded.hero_caption_en,
+  venue_name_ja = excluded.venue_name_ja,
+  venue_name_en = excluded.venue_name_en,
+  venue_address = excluded.venue_address,
+  start_lat = excluded.start_lat,
+  start_lng = excluded.start_lng,
+  updated_at = excluded.updated_at;
+
+-- ==================
 -- とくしまマラソン (tokushima-marathon-2026)
 -- ==================
 DELETE FROM race_course_highlights WHERE race_id = 'tokushima-marathon-2026';
@@ -10912,6 +11797,7 @@ DELETE FROM completion_gifts WHERE race_id = 'tokushima-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'tokushima-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'tokushima-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'tokushima-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'tokushima-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'tokushima-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'tokushima-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'tokushima-marathon-2026';
@@ -11048,6 +11934,7 @@ DELETE FROM completion_gifts WHERE race_id = 'tokyo-legacy-half-2026';
 DELETE FROM race_entry_links WHERE race_id = 'tokyo-legacy-half-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'tokyo-legacy-half-2026';
 DELETE FROM reception_sessions WHERE race_id = 'tokyo-legacy-half-2026';
+DELETE FROM race_travel_times WHERE race_id = 'tokyo-legacy-half-2026';
 DELETE FROM race_results WHERE race_id = 'tokyo-legacy-half-2026';
 DELETE FROM race_gallery WHERE race_id = 'tokyo-legacy-half-2026';
 DELETE FROM race_voices WHERE race_id = 'tokyo-legacy-half-2026';
@@ -11119,13 +12006,13 @@ MUFG Stadium (National Stadium): 10-1 Kasumigaoka-cho, Shinjuku-ku, Tokyo',
   NULL,
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
+  'MUFGスタジアム（国立競技場）',
+  'MUFG Stadium (National Stadium)',
+  '東京都新宿区霞ヶ丘町10-1',
   NULL,
   NULL,
   '2026-05-14T14:47:07.523Z',
-  '2026-05-14T14:47:07.523Z'
+  '2026-07-27T14:34:07.789Z'
 ) ON CONFLICT(id) DO UPDATE SET
   name_ja = excluded.name_ja,
   name_en = excluded.name_en,
@@ -11255,6 +12142,7 @@ DELETE FROM completion_gifts WHERE race_id = 'tokyo-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'tokyo-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'tokyo-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'tokyo-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'tokyo-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'tokyo-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'tokyo-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'tokyo-marathon-2026';
@@ -11411,6 +12299,7 @@ DELETE FROM completion_gifts WHERE race_id = 'tokyo-marathon-2027';
 DELETE FROM race_entry_links WHERE race_id = 'tokyo-marathon-2027';
 DELETE FROM race_entry_periods WHERE race_id = 'tokyo-marathon-2027';
 DELETE FROM reception_sessions WHERE race_id = 'tokyo-marathon-2027';
+DELETE FROM race_travel_times WHERE race_id = 'tokyo-marathon-2027';
 DELETE FROM race_results WHERE race_id = 'tokyo-marathon-2027';
 DELETE FROM race_gallery WHERE race_id = 'tokyo-marathon-2027';
 DELETE FROM race_voices WHERE race_id = 'tokyo-marathon-2027';
@@ -11470,13 +12359,13 @@ INSERT INTO races (
   NULL,
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
+  '東京都庁前',
+  'Tokyo Metropolitan Government Plaza',
+  '東京都新宿区西新宿2丁目8-1',
   NULL,
   NULL,
   '2026-06-24T00:00:00Z',
-  '2026-06-27T00:00:00Z'
+  '2026-07-27T14:34:48.172Z'
 ) ON CONFLICT(id) DO UPDATE SET
   name_ja = excluded.name_ja,
   name_en = excluded.name_en,
@@ -11524,9 +12413,9 @@ INSERT INTO races (
 INSERT OR REPLACE INTO race_categories (race_id, distance_type, distance_km, time_limit_minutes, start_time, capacity, entry_fee, entry_fee_u25, name_ja, name_en, description_ja, description_en, eligibility_ja, eligibility_en, course_gpx_file, waves, sort_order) VALUES
   ('tokyo-marathon-2027', 'full', 42.195, 420, '09:10', 38500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '[]', 0);
 INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, walk_minutes, is_primary, sort_order) VALUES
-  ('tokyo-marathon-2027', '新宿駅', 'Shinjuku Station', 'shinjuku', '新宿駅西口から徒歩約10分でスタート会場（東京都庁前）', '10 min walk from Shinjuku Station West Exit to the start (Tokyo Metropolitan Government)', 35.6896, 139.6999, NULL, 0, 0);
+  ('tokyo-marathon-2027', '新宿駅', 'Shinjuku Station', 'shinjuku', '新宿駅西口から徒歩約10分でスタート会場（東京都庁前）', '10 min walk from Shinjuku Station West Exit to the start (Tokyo Metropolitan Government)', 35.6896, 139.6999, 10, 0, 0);
 INSERT OR REPLACE INTO access_points (race_id, station_name_ja, station_name_en, station_code, transport_to_venue_ja, transport_to_venue_en, latitude, longitude, walk_minutes, is_primary, sort_order) VALUES
-  ('tokyo-marathon-2027', '都庁前駅', 'Tochomae Station', 'tochomae', '都営大江戸線都庁前駅直結', 'Direct access from Toei Oedo Line Tochomae Station', 35.6915, 139.6917, NULL, 0, 1);
+  ('tokyo-marathon-2027', '都庁前駅', 'Tochomae Station', 'tochomae', '都営大江戸線都庁前駅直結', 'Direct access from Toei Oedo Line Tochomae Station', 35.6915, 139.6917, NULL, 1, 1);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
   ('tokyo-marathon-2027', '観光地', '浅草寺・雷門', 'Sensoji Temple & Kaminarimon', 'コース上を通過する東京を代表する観光名所。外国人ランナーにも人気のスポット。', 'An iconic Tokyo landmark on the course. Popular with international runners.', 'コース上（約15km地点）', NULL, 35.7148, 139.7967);
 INSERT OR REPLACE INTO nearby_spots (race_id, type, name_ja, name_en, description_ja, description_en, distance_from_venue, url, latitude, longitude) VALUES
@@ -11573,6 +12462,7 @@ DELETE FROM completion_gifts WHERE race_id = 'tomisato-suikaroad-2026';
 DELETE FROM race_entry_links WHERE race_id = 'tomisato-suikaroad-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'tomisato-suikaroad-2026';
 DELETE FROM reception_sessions WHERE race_id = 'tomisato-suikaroad-2026';
+DELETE FROM race_travel_times WHERE race_id = 'tomisato-suikaroad-2026';
 DELETE FROM race_results WHERE race_id = 'tomisato-suikaroad-2026';
 DELETE FROM race_gallery WHERE race_id = 'tomisato-suikaroad-2026';
 DELETE FROM race_voices WHERE race_id = 'tomisato-suikaroad-2026';
@@ -11709,6 +12599,7 @@ DELETE FROM completion_gifts WHERE race_id = 'tottori-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'tottori-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'tottori-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'tottori-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'tottori-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'tottori-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'tottori-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'tottori-marathon-2026';
@@ -11863,6 +12754,7 @@ DELETE FROM completion_gifts WHERE race_id = 'toyako-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'toyako-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'toyako-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'toyako-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'toyako-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'toyako-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'toyako-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'toyako-marathon-2026';
@@ -12005,6 +12897,7 @@ DELETE FROM completion_gifts WHERE race_id = 'toyama-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'toyama-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'toyama-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'toyama-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'toyama-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'toyama-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'toyama-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'toyama-marathon-2026';
@@ -12052,8 +12945,8 @@ INSERT INTO races (
   0,
   'road',
   '["JAAF"]',
-  '立山連峰、新湊大橋、富山湾',
-  'Tateyama Mountains, Shinminato Bridge, Toyama Bay',
+  '高岡古城公園、高岡大仏、山町筋、新湊漁港、新湊大橋、海王丸パーク、立山連峰、富岩運河環水公園',
+  'Takaoka Kojyo Park, Takaoka Daibutsu, Yamachosuji, Shinminato Port, Shinminato Bridge, Kaiomaru Park, Tateyama Mountains, Fugan Canal Kansui Park',
   NULL,
   NULL,
   '立山連峰',
@@ -12070,7 +12963,7 @@ INSERT INTO races (
   NULL,
   NULL,
   '2026-03-15T00:00:00Z',
-  '2026-06-08T14:41:11.626Z'
+  '2026-07-31T14:37:23.223Z'
 ) ON CONFLICT(id) DO UPDATE SET
   name_ja = excluded.name_ja,
   name_en = excluded.name_en,
@@ -12149,6 +13042,7 @@ DELETE FROM completion_gifts WHERE race_id = 'tsukuba-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'tsukuba-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'tsukuba-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'tsukuba-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'tsukuba-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'tsukuba-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'tsukuba-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'tsukuba-marathon-2026';
@@ -12283,6 +13177,7 @@ DELETE FROM completion_gifts WHERE race_id = 'wakkanai-peace-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'wakkanai-peace-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'wakkanai-peace-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'wakkanai-peace-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'wakkanai-peace-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'wakkanai-peace-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'wakkanai-peace-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'wakkanai-peace-marathon-2026';
@@ -12427,6 +13322,7 @@ DELETE FROM completion_gifts WHERE race_id = 'yokohama-marathon-2026';
 DELETE FROM race_entry_links WHERE race_id = 'yokohama-marathon-2026';
 DELETE FROM race_entry_periods WHERE race_id = 'yokohama-marathon-2026';
 DELETE FROM reception_sessions WHERE race_id = 'yokohama-marathon-2026';
+DELETE FROM race_travel_times WHERE race_id = 'yokohama-marathon-2026';
 DELETE FROM race_results WHERE race_id = 'yokohama-marathon-2026';
 DELETE FROM race_gallery WHERE race_id = 'yokohama-marathon-2026';
 DELETE FROM race_voices WHERE race_id = 'yokohama-marathon-2026';

--- a/src/data/races/fujisan-marathon-2026.json
+++ b/src/data/races/fujisan-marathon-2026.json
@@ -87,15 +87,16 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-06-08T14:30:14.213Z",
+  "updated_at": "2026-07-31T14:27:54.483Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
       "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
       "秋冬大会の日程は例年パターンからの推定を含む。正式発表後に要更新",
-      "2026-06-08: 自動クロールで更新"
+      "2026-06-08: 自動クロールで更新",
+      "2026-07-31: 自動クロールで更新"
     ],
-    "last_verified": "2026-06-08",
+    "last_verified": "2026-07-31",
     "detail_level": "medium"
   },
   "entry_periods": [
@@ -103,7 +104,7 @@
       "label_ja": "富士河口湖町民限定エントリー",
       "label_en": "Fujikawaguchiko Residents Entry",
       "start_date": "2026-04-20",
-      "end_date": "2026-05-31",
+      "end_date": "2026-07-31",
       "entry_fee": null,
       "category_id": null,
       "sort_order": 0

--- a/src/data/races/gunma-marathon-2026.json
+++ b/src/data/races/gunma-marathon-2026.json
@@ -16,7 +16,7 @@
   "entry_fee_by_category": true,
   "entry_capacity": 5500,
   "entry_start_date": "2026-04-09",
-  "entry_end_date": "2026-05-13",
+  "entry_end_date": "2026-08-17",
   "reception_type": "pre_mail",
   "reception_note_ja": "参加者には、アスリートビブス、計測チップ、参加マニュアル等を申込時の住所に事前に発送します（10月下旬発送予定）。大会前日・当日の受付は行いません。\n\nエントリー締切後の住所変更は、郵便局にて転送手続きをお願いします。\n計測チップは、アスリートビブスに貼り付けてあります。外さずに参加してください。なお、詳細につきましてはアスリートビブスが入ったビニール袋同封の案内をご覧ください。\n大会にエントリー後、出場できなくなった場合のご連絡は不要です。参加賞の受取方法は「参加マニュアル」をご参照ください。",
   "reception_note_en": "Participants will receive their athlete bibs, timing chips, and participation manuals in advance at the address provided during registration (scheduled for late October). There will be no registration on the day before or the day of the event.\n\nFor address changes after the entry deadline, please arrange for mail forwarding at the post office.\n\nThe timing chip is attached to the athlete bib. Please do not remove it during the event. For further details, please refer to the instructions enclosed in the plastic bag containing the athlete bib.\n\nIf you are unable to participate after registering, you do not need to contact us. Please refer to the \"Participation Manual\" for instructions on how to receive your participation prize.",
@@ -57,7 +57,41 @@
   ],
   "aid_stations": [],
   "checkpoints": [],
-  "access_points": [],
+  "access_points": [
+    {
+      "station_name_ja": "前橋駅",
+      "station_name_en": "Maebashi Station",
+      "station_code": "",
+      "transport_to_venue_ja": "無料シャトルバス利用（5〜10分間隔）",
+      "transport_to_venue_en": "Free shuttle bus (every 5–10 min)",
+      "latitude": 0,
+      "longitude": 0,
+      "walk_minutes": 0,
+      "is_primary": true
+    },
+    {
+      "station_name_ja": "新前橋駅",
+      "station_name_en": "Shin-Maebashi Station",
+      "station_code": "",
+      "transport_to_venue_ja": "無料シャトルバス利用（5〜10分間隔）",
+      "transport_to_venue_en": "Free shuttle bus (every 5–10 min)",
+      "latitude": 0,
+      "longitude": 0,
+      "walk_minutes": 0,
+      "is_primary": false
+    },
+    {
+      "station_name_ja": "高崎駅",
+      "station_name_en": "Takasaki Station",
+      "station_code": "",
+      "transport_to_venue_ja": "無料シャトルバス利用（5〜10分間隔）",
+      "transport_to_venue_en": "Free shuttle bus (every 5–10 min)",
+      "latitude": 0,
+      "longitude": 0,
+      "walk_minutes": 0,
+      "is_primary": false
+    }
+  ],
   "nearby_spots": [
     {
       "type": "温泉",
@@ -95,7 +129,7 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-06-22T15:01:11.589Z",
+  "updated_at": "2026-07-31T14:28:47.306Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
@@ -104,9 +138,10 @@
       "2026-05-25: 自動クロールで更新",
       "2026-05-27: 自動クロールで更新",
       "2026-06-12: 自動クロールで更新",
-      "2026-06-22: 自動クロールで更新"
+      "2026-06-22: 自動クロールで更新",
+      "2026-07-31: 自動クロールで更新"
     ],
-    "last_verified": "2026-06-22",
+    "last_verified": "2026-07-31",
     "detail_level": "medium"
   },
   "entry_periods": [
@@ -114,8 +149,10 @@
       "label_ja": "一般エントリー",
       "label_en": "General Entry",
       "start_date": "2026-04-09",
-      "end_date": "2026-05-13",
-      "entry_fee": null
+      "end_date": "2026-08-17",
+      "entry_fee": 13500,
+      "category_id": null,
+      "sort_order": 0
     }
   ],
   "motif": "赤城山",
@@ -187,8 +224,8 @@
       "image": null
     }
   ],
-  "venue_name_ja": null,
-  "venue_name_en": null,
+  "venue_name_ja": "正田醤油スタジアム群馬",
+  "venue_name_en": "Shoda Shoyu Stadium Gunma",
   "venue_address": null,
   "start_lat": null,
   "start_lng": null

--- a/src/data/races/gunma-marathon-2026.json
+++ b/src/data/races/gunma-marathon-2026.json
@@ -146,13 +146,22 @@
   },
   "entry_periods": [
     {
-      "label_ja": "一般エントリー",
-      "label_en": "General Entry",
+      "label_ja": "フルマラソン",
+      "label_en": "Full Marathon",
       "start_date": "2026-04-09",
-      "end_date": "2026-08-17",
+      "end_date": "2026-05-13",
       "entry_fee": 13500,
       "category_id": null,
       "sort_order": 0
+    },
+    {
+      "label_ja": "ジョギング（10km）",
+      "label_en": "Jogging (10km)",
+      "start_date": "2026-04-09",
+      "end_date": "2026-08-17",
+      "entry_fee": 6500,
+      "category_id": null,
+      "sort_order": 1
     }
   ],
   "motif": "赤城山",

--- a/src/data/races/hokkaido-marathon-2026.json
+++ b/src/data/races/hokkaido-marathon-2026.json
@@ -102,22 +102,23 @@
       "gift_categories": [
         "tshirt"
       ],
-      "description_ja": "大会オリジナルTシャツ、完走メダル",
-      "description_en": "Official race T-shirt, Finisher medal",
+      "description_ja": "大会オリジナルTシャツ",
+      "description_en": "Official race T-shirt",
       "image": null
     }
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-06-27T13:29:05.102Z",
+  "updated_at": "2026-07-31T14:29:42.206Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
       "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
       "2026-05-30: 自動クロールで更新",
-      "2026-06-27: 自動クロールで更新"
+      "2026-06-27: 自動クロールで更新",
+      "2026-07-31: 自動クロールで更新"
     ],
-    "last_verified": "2026-06-27",
+    "last_verified": "2026-07-31",
     "detail_level": "medium"
   },
   "entry_periods": [
@@ -126,7 +127,7 @@
       "label_en": "General Entry",
       "start_date": "2026-03-29",
       "end_date": "2026-04-24",
-      "entry_fee": null
+      "entry_fee": 16500
     }
   ],
   "motif": "ライラック",
@@ -187,14 +188,14 @@
       "gift_categories": [
         "medal"
       ],
-      "description_ja": "大会オリジナルTシャツ、完走メダル",
-      "description_en": "Official race T-shirt, Finisher medal",
+      "description_ja": "完走メダル",
+      "description_en": "Finisher medal",
       "image": null
     }
   ],
-  "venue_name_ja": null,
-  "venue_name_en": null,
-  "venue_address": null,
+  "venue_name_ja": "大通公園（大通西4丁目）",
+  "venue_name_en": "Odori Park (Odori West 4-chome)",
+  "venue_address": "北海道札幌市中央区大通西4丁目",
   "start_lat": null,
   "start_lng": null
 }

--- a/src/data/races/kanazawa-marathon-2026.json
+++ b/src/data/races/kanazawa-marathon-2026.json
@@ -18,8 +18,8 @@
   "entry_start_date": "2026-04-10",
   "entry_end_date": "2026-05-20",
   "reception_type": "pre_day",
-  "reception_note_ja": "",
-  "reception_note_en": "",
+  "reception_note_ja": "ランナー受付：10月23日(金) 13:30～20:30、10月24日(土) 9:30～19:30。大会当日の受付は行いません。代理受付不可。",
+  "reception_note_en": "Runner check-in: Oct 23 (Fri) 13:30–20:30, Oct 24 (Sat) 9:30–19:30. No race-day check-in. No proxy check-in.",
   "tags": [
     "ご当地エイド充実",
     "城下町",
@@ -32,7 +32,11 @@
     "min_elevation_m": null,
     "elevation_diff_m": null,
     "surface": "road",
-    "certification": [],
+    "certification": [
+      "JAAF",
+      "WA",
+      "AIMS"
+    ],
     "highlights_ja": "兼六園、金沢城、ひがし茶屋街付近",
     "highlights_en": "Kenroku-en Garden, Kanazawa Castle, Higashi Chaya District area",
     "notes_ja": null,
@@ -60,7 +64,19 @@
   ],
   "aid_stations": [],
   "checkpoints": [],
-  "access_points": [],
+  "access_points": [
+    {
+      "station_name_ja": "金沢駅",
+      "station_name_en": "Kanazawa Station",
+      "station_code": "",
+      "transport_to_venue_ja": "徒歩約20分（スタート会場）／シャトルバス有料（スタート会場行き）・無料（フィニッシュ会場行き）",
+      "transport_to_venue_en": "Approx. 20 min walk to start venue / Paid shuttle bus to start venue / Free shuttle bus to finish venue",
+      "latitude": 0,
+      "longitude": 0,
+      "walk_minutes": 20,
+      "is_primary": true
+    }
+  ],
   "nearby_spots": [
     {
       "type": "観光地",
@@ -110,15 +126,16 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-05-30T06:36:53.964Z",
+  "updated_at": "2026-07-31T14:32:03.226Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
       "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
       "秋冬大会の日程は例年パターンからの推定を含む。正式発表後に要更新",
-      "2026-05-30: 自動クロールで更新"
+      "2026-05-30: 自動クロールで更新",
+      "2026-07-31: 自動クロールで更新"
     ],
-    "last_verified": "2026-05-30",
+    "last_verified": "2026-07-31",
     "detail_level": "medium"
   },
   "entry_periods": [
@@ -175,8 +192,8 @@
       "image": null
     }
   ],
-  "venue_name_ja": null,
-  "venue_name_en": null,
+  "venue_name_ja": "石川県西部緑地公園（産業展示館4号館前）",
+  "venue_name_en": "Ishikawa Prefecture Seibu Green Park (in front of Industrial Exhibition Hall Bldg. 4)",
   "venue_address": null,
   "start_lat": null,
   "start_lng": null

--- a/src/data/races/kochi-ryoma-marathon-2027.json
+++ b/src/data/races/kochi-ryoma-marathon-2027.json
@@ -58,7 +58,19 @@
   ],
   "aid_stations": [],
   "checkpoints": [],
-  "access_points": [],
+  "access_points": [
+    {
+      "station_name_ja": "高知駅",
+      "station_name_en": "Kochi Station",
+      "station_code": "",
+      "transport_to_venue_ja": "徒歩約15分（高知県庁スタート地点）",
+      "transport_to_venue_en": "15 min walk to start (Kochi Prefectural Office)",
+      "latitude": 0,
+      "longitude": 0,
+      "walk_minutes": 15,
+      "is_primary": true
+    }
+  ],
   "nearby_spots": [
     {
       "type": "観光地",
@@ -96,13 +108,14 @@
   ],
   "result": null,
   "created_at": "2026-06-29T14:13:35.752Z",
-  "updated_at": "2026-06-29T14:13:35.752Z",
+  "updated_at": "2026-07-31T14:32:35.280Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
-      "2026-06-29: 自動クロールで kochi-ryoma-marathon-2026 を元に2027年大会ファイルを新規作成"
+      "2026-06-29: 自動クロールで kochi-ryoma-marathon-2026 を元に2027年大会ファイルを新規作成",
+      "2026-07-31: 自動クロールで更新"
     ],
-    "last_verified": "2026-06-29",
+    "last_verified": "2026-07-31",
     "detail_level": "medium"
   },
   "entry_periods": [
@@ -114,6 +127,15 @@
       "entry_fee": 13000,
       "category_id": null,
       "sort_order": 0
+    },
+    {
+      "label_ja": "新宿シティ連携協定枠",
+      "label_en": "Shinjuku City Partnership Entry",
+      "start_date": "2026-08-22",
+      "end_date": "2026-10-20",
+      "entry_fee": 26000,
+      "category_id": null,
+      "sort_order": 1
     }
   ],
   "motif": "坂本龍馬",
@@ -179,9 +201,9 @@
       "image": null
     }
   ],
-  "venue_name_ja": null,
-  "venue_name_en": null,
-  "venue_address": null,
+  "venue_name_ja": "高知県庁前（スタート）／高知県立春野総合運動公園（フィニッシュ）",
+  "venue_name_en": "Kochi Prefectural Office (Start) / Haruno Sogo Undo Koen (Finish)",
+  "venue_address": "高知県高知市丸ノ内1-2-20",
   "start_lat": null,
   "start_lng": null
 }

--- a/src/data/races/mie-matsusaka-marathon-2026.json
+++ b/src/data/races/mie-matsusaka-marathon-2026.json
@@ -18,8 +18,8 @@
   "entry_start_date": "2026-05-24",
   "entry_end_date": "2026-07-31",
   "reception_type": "pre_mail",
-  "reception_note_ja": "ナンバーカード・計測チップ等は12月上旬頃、登録住所へ事前郵送",
-  "reception_note_en": "Race bib, timing chip, etc. will be mailed to your registered address in early December",
+  "reception_note_ja": "12月上旬頃、登録住所へ大会プログラム・ビブス（ナンバーカード）・記録計測用チップ等を発送予定（健康ウオークの部を除く）",
+  "reception_note_en": "Race program, bib (race number), timing chip, etc. will be mailed to your registered address in early December (excluding Health Walk participants)",
   "tags": [
     "ご当地グルメ"
   ],
@@ -83,7 +83,7 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-07-27T14:22:17.267Z",
+  "updated_at": "2026-07-31T14:33:07.527Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
@@ -91,9 +91,10 @@
       "秋冬大会の日程は例年パターンからの推定を含む。正式発表後に要更新",
       "2026-05-30: 自動クロールで更新",
       "2026-06-22: 自動クロールで更新",
-      "2026-07-27: 自動クロールで更新"
+      "2026-07-27: 自動クロールで更新",
+      "2026-07-31: 自動クロールで更新"
     ],
-    "last_verified": "2026-07-27",
+    "last_verified": "2026-07-31",
     "detail_level": "medium"
   },
   "entry_periods": [

--- a/src/data/races/mtfuji-climb-run-2026.json
+++ b/src/data/races/mtfuji-climb-run-2026.json
@@ -45,11 +45,23 @@
   ],
   "aid_stations": [],
   "checkpoints": [],
-  "access_points": [],
+  "access_points": [
+    {
+      "station_name_ja": "富士山駅（富士急行線）",
+      "station_name_en": "Fujisan Station (Fujikyu Railway)",
+      "station_code": "",
+      "transport_to_venue_ja": "タクシーで10〜15分。大会当日（9/13）は無料シャトルバス運行（富士山駅発7:30・8:00・8:30）",
+      "transport_to_venue_en": "10-15 min by taxi. Free shuttle bus on race day (Sep 13) departs Fujisan Station at 7:30, 8:00, and 8:30 AM",
+      "latitude": 0,
+      "longitude": 0,
+      "walk_minutes": 0,
+      "is_primary": true
+    }
+  ],
   "nearby_spots": [],
   "result": null,
   "created_at": "2026-04-28T13:53:53.451Z",
-  "updated_at": "2026-07-27T14:23:20.144Z",
+  "updated_at": "2026-07-31T14:33:27.699Z",
   "entry_periods": [
     {
       "start_date": "2026-04-24",
@@ -104,10 +116,11 @@
     }
   ],
   "_metadata": {
-    "last_verified": "2026-07-27",
+    "last_verified": "2026-07-31",
     "data_accuracy_notes": [
       "2026-05-30: 自動クロールで更新",
-      "2026-07-27: 自動クロールで更新"
+      "2026-07-27: 自動クロールで更新",
+      "2026-07-31: 自動クロールで更新"
     ]
   },
   "venue_name_ja": "富士北麓公園 富士山GXスタジアム",

--- a/src/data/races/osaka-yodo-river-citizens-marathon-2026.json
+++ b/src/data/races/osaka-yodo-river-citizens-marathon-2026.json
@@ -30,8 +30,8 @@
     "certification": [],
     "highlights_ja": "淀川河川公園の河川敷のみを走るフラットコース。通常は通行できない淀川大堰を渡れる特徴がある。フルマラソン9:00・ハーフマラソン8:30・10km 13:00スタート。給水所7地点、救護所4地点設置。",
     "highlights_en": "A flat course running entirely along the Yodo River riverbank park. Runners can cross the Yodo River Weir, normally closed to the public. Full marathon starts at 9:00, half at 8:30, 10km at 13:00. 7 water stations and 4 first-aid stations.",
-    "notes_ja": null,
-    "notes_en": null
+    "notes_ja": "救護所設置予定地点：スタート・ゴール地点、赤川地区、西中島地区、塚本地区。",
+    "notes_en": "Planned first-aid station locations: Start/Finish area, Akagawa district, Nishinakajima district, and Tsukamoto district."
   },
   "categories": [
     {
@@ -65,7 +65,7 @@
   "nearby_spots": [],
   "result": null,
   "created_at": "2026-04-11T14:42:59.225Z",
-  "updated_at": "2026-06-27T13:32:25.650Z",
+  "updated_at": "2026-07-31T14:34:51.766Z",
   "entry_periods": [
     {
       "label_ja": "一般エントリー",
@@ -82,7 +82,7 @@
         "towel"
       ],
       "description_ja": "【フル・ハーフ】\n参加賞：Ｔシャツ（フリーサイズ）\n完走証：タオル\n【10km】\n参加賞：タオル",
-      "description_en": "",
+      "description_en": "[Full / Half]\nParticipation gift: T-shirt (free size)\nFinisher certificate: Towel\n[10km]\nParticipation gift: Towel",
       "image": null
     }
   ],
@@ -121,10 +121,11 @@
     }
   ],
   "_metadata": {
-    "last_verified": "2026-06-27",
+    "last_verified": "2026-07-31",
     "data_accuracy_notes": [
       "2026-06-08: 自動クロールで更新",
-      "2026-06-27: 自動クロールで更新"
+      "2026-06-27: 自動クロールで更新",
+      "2026-07-31: 自動クロールで更新"
     ]
   },
   "venue_name_ja": null,

--- a/src/data/races/sapporo-marathon-2026.json
+++ b/src/data/races/sapporo-marathon-2026.json
@@ -69,7 +69,7 @@
   "nearby_spots": [],
   "result": null,
   "created_at": "2026-05-15T14:40:14.753Z",
-  "updated_at": "2026-07-27T14:31:28.827Z",
+  "updated_at": "2026-07-31T14:36:22.238Z",
   "entry_periods": [
     {
       "label_ja": "JPHS優先エントリー",
@@ -167,16 +167,17 @@
     }
   ],
   "_metadata": {
-    "last_verified": "2026-07-27",
+    "last_verified": "2026-07-31",
     "data_accuracy_notes": [
       "2026-05-30: 自動クロールで更新",
       "2026-06-08: 自動クロールで更新",
-      "2026-07-27: 自動クロールで更新"
+      "2026-07-27: 自動クロールで更新",
+      "2026-07-31: 自動クロールで更新"
     ]
   },
   "venue_name_ja": "真駒内セキスイハイムスタジアム",
   "venue_name_en": "Makomanai Sekisui Heim Stadium",
-  "venue_address": null,
+  "venue_address": "札幌市南区真駒内公園3番1号",
   "start_lat": null,
   "start_lng": null
 }

--- a/src/data/races/toyama-marathon-2026.json
+++ b/src/data/races/toyama-marathon-2026.json
@@ -33,8 +33,8 @@
     "certification": [
       "JAAF"
     ],
-    "highlights_ja": "立山連峰、新湊大橋、富山湾",
-    "highlights_en": "Tateyama Mountains, Shinminato Bridge, Toyama Bay",
+    "highlights_ja": "高岡古城公園、高岡大仏、山町筋、新湊漁港、新湊大橋、海王丸パーク、立山連峰、富岩運河環水公園",
+    "highlights_en": "Takaoka Kojyo Park, Takaoka Daibutsu, Yamachosuji, Shinminato Port, Shinminato Bridge, Kaiomaru Park, Tateyama Mountains, Fugan Canal Kansui Park",
     "notes_ja": null,
     "notes_en": null
   },
@@ -95,16 +95,17 @@
   ],
   "result": null,
   "created_at": "2026-03-15T00:00:00Z",
-  "updated_at": "2026-06-08T14:41:11.626Z",
+  "updated_at": "2026-07-31T14:37:23.223Z",
   "_metadata": {
     "data_source": "公式サイト等の公開情報から転記",
     "data_accuracy_notes": [
       "ライト版：基本情報のみ。エイド、周辺スポット、気象データ等は未入力",
       "秋冬大会の日程は例年パターンからの推定を含む。正式発表後に要更新",
       "2026-05-30: 自動クロールで更新",
-      "2026-06-08: 自動クロールで更新"
+      "2026-06-08: 自動クロールで更新",
+      "2026-07-31: 自動クロールで更新"
     ],
-    "last_verified": "2026-06-08",
+    "last_verified": "2026-07-31",
     "detail_level": "medium"
   },
   "entry_periods": [

--- a/tools/crawl/checksums.json
+++ b/tools/crawl/checksums.json
@@ -1,22 +1,22 @@
 {
   "https://www.abashiri-marathon.jp/outline/": {
     "hash": "91fff2f513a6e920e41faf6bbdc1ea92c4f4af653b9c9493d4e761aab15d8406",
-    "last_checked": "2026-07-27T14:04:20.279Z",
+    "last_checked": "2026-07-31T14:24:56.702Z",
     "race_id": "abashiri-marathon-2026"
   },
   "https://www.abashiri-marathon.jp/entry/": {
     "hash": "518f61990bfb00fe5fc1484e38f4110cbf1d5ff8f592485b672561a3afb91626",
-    "last_checked": "2026-07-27T14:04:20.361Z",
+    "last_checked": "2026-07-31T14:24:56.779Z",
     "race_id": "abashiri-marathon-2026"
   },
   "https://www.abashiri-marathon.jp/course/": {
     "hash": "524bf485c0c884ea094a068dfbd0f17da14038d6ced4f63fbdb4b8138a70692f",
-    "last_checked": "2026-07-27T14:04:20.461Z",
+    "last_checked": "2026-07-31T14:24:56.854Z",
     "race_id": "abashiri-marathon-2026"
   },
   "https://www.abashiri-marathon.jp/contact/": {
     "hash": "4d85fecfd42c89832ba9116770d13e6f2c613ae42a7c6a0365b195e6aa50420c",
-    "last_checked": "2026-07-27T14:04:20.557Z",
+    "last_checked": "2026-07-31T14:24:56.928Z",
     "race_id": "abashiri-marathon-2026"
   },
   "https://www.abashiri-marathon.jp/feed/": {
@@ -26,83 +26,83 @@
   },
   "https://aomori-sakuramarathon.com/category/infomation/": {
     "hash": "eb29c381bf5f8d09ffce5efc1f5918d5c887645c09c01263876aa1a415ee0bc6",
-    "last_checked": "2026-07-27T14:04:21.334Z",
+    "last_checked": "2026-07-31T14:24:57.689Z",
     "race_id": "aomori-sakura-marathon-2026"
   },
   "https://aomori-sakuramarathon.com/guide/": {
     "hash": "093ed21ce726044fc2160fe1048ea20ec4267a8616694d0afd659b8afc268293",
-    "last_checked": "2026-07-27T14:04:22.063Z",
+    "last_checked": "2026-07-31T14:24:58.398Z",
     "race_id": "aomori-sakura-marathon-2026"
   },
   "https://aomori-sakuramarathon.com/entry/": {
     "hash": "929ce7eb0a216882ab359c6db23a056c0aeb3f681fcc2c7870f8a3642f919103",
-    "last_checked": "2026-07-27T14:04:22.418Z",
+    "last_checked": "2026-07-31T14:24:58.751Z",
     "race_id": "aomori-sakura-marathon-2026"
   },
   "https://aomori-sakuramarathon.com/course/": {
     "hash": "639ad9395ee64db3c98e74fcf39e63bc77d66d8b1342e329f6874b0faa5d8ea4",
-    "last_checked": "2026-07-27T14:04:22.817Z",
+    "last_checked": "2026-07-31T14:24:59.321Z",
     "race_id": "aomori-sakura-marathon-2026"
   },
   "https://aomori-sakuramarathon.com/qa/": {
     "hash": "db8dc87ba474fc8a19674133ab384c8e9f5cbb1623c94113659b53e2e0d08b04",
-    "last_checked": "2026-07-27T14:04:23.197Z",
+    "last_checked": "2026-07-31T14:24:59.829Z",
     "race_id": "aomori-sakura-marathon-2026"
   },
   "https://www.asahikawa-half-marathon.jp/outline/": {
     "hash": "47bf70698f75e9773f0d62dd66104d2a62d6c0a46dbbd5e5432a31e5cb2f067c",
-    "last_checked": "2026-07-27T14:04:23.599Z",
+    "last_checked": "2026-07-31T14:25:00.680Z",
     "race_id": "asahikawa-half-marathon-2026"
   },
   "https://www.asahikawa-half-marathon.jp/course/": {
     "hash": "ac5b1580e8a0f3746e06825503c72d4483e3644da174851c7744325029488c0c",
-    "last_checked": "2026-07-27T14:04:23.769Z",
+    "last_checked": "2026-07-31T14:25:00.817Z",
     "race_id": "asahikawa-half-marathon-2026"
   },
   "https://www.asahikawa-half-marathon.jp/entry/": {
     "hash": "0bb52c00d86a87e10a0156c3afa929892e2ce9f518b4bc6a1a0bf04e1ad4dae0",
-    "last_checked": "2026-07-27T14:04:23.896Z",
+    "last_checked": "2026-07-31T14:25:00.982Z",
     "race_id": "asahikawa-half-marathon-2026"
   },
   "https://www.betsudai.com/outline/": {
     "hash": "ba5d06d6001a87b52a3f6b3acb26014122145b0be3df21e6b3df2a812b746b3e",
-    "last_checked": "2026-07-27T14:04:24.078Z",
+    "last_checked": "2026-07-31T14:25:01.252Z",
     "race_id": "beppu-oita-marathon-2026"
   },
   "https://www.betsudai.com/outline/flow/": {
     "hash": "1afe6f26ac5ba16f3fa4511026e2f719b7b728678809ec3aaeaac655755f2fac",
-    "last_checked": "2026-07-27T14:04:24.153Z",
+    "last_checked": "2026-07-31T14:25:01.321Z",
     "race_id": "beppu-oita-marathon-2026"
   },
   "https://www.betsudai.com/outline/course/": {
     "hash": "12eb3ac0b00f41b4f4ded05771e9ea319459feb86f44c0c506bac38e2f6eed6d",
-    "last_checked": "2026-07-27T14:04:24.227Z",
+    "last_checked": "2026-07-31T14:25:01.386Z",
     "race_id": "beppu-oita-marathon-2026"
   },
   "https://www.betsudai.com/question/": {
     "hash": "83398aaeaa0331deab4c6d4db6335e4176b73779ec67c8735939e27dd6778cc1",
-    "last_checked": "2026-07-27T14:04:24.310Z",
+    "last_checked": "2026-07-31T14:25:01.465Z",
     "race_id": "beppu-oita-marathon-2026"
   },
   "https://biwako-marathon.com/outline-marathon/": {
     "hash": "28c3e030661d101838c5dece3b768beab803a471139fcdc6f4cf4040c434e583",
-    "last_checked": "2026-07-27T14:04:24.543Z",
-    "race_id": "biwako-marathon-2026"
+    "last_checked": "2026-07-31T14:25:01.785Z",
+    "race_id": "biwako-marathon-2027"
   },
   "https://biwako-marathon.com/entry/": {
-    "hash": "a8b521716253c2b651d0f4b85199f2edd68aad893b697cb47c67a5dfedfd1a9b",
-    "last_checked": "2026-07-27T14:04:24.603Z",
-    "race_id": "biwako-marathon-2026"
+    "hash": "cbde0ce3c7a1721359bdbceb923ccf614d7498eaec56c8b93e869bf7b9c97fff",
+    "last_checked": "2026-07-31T14:25:01.841Z",
+    "race_id": "biwako-marathon-2027"
   },
   "https://biwako-marathon.com/course/": {
     "hash": "08a3d399588da42875e32de00d299714044e1923ba39631dd671701970302000",
-    "last_checked": "2026-07-27T14:04:24.666Z",
-    "race_id": "biwako-marathon-2026"
+    "last_checked": "2026-07-31T14:25:01.904Z",
+    "race_id": "biwako-marathon-2027"
   },
   "https://biwako-marathon.com/traffic_regulation/": {
     "hash": "4a001a8cdbc4e182b0e0778ce63f1b015b8eb24054358f9e685dcd62710a818b",
-    "last_checked": "2026-07-27T14:04:24.724Z",
-    "race_id": "biwako-marathon-2026"
+    "last_checked": "2026-07-31T14:25:01.958Z",
+    "race_id": "biwako-marathon-2027"
   },
   "https://biwako-marathon.com/feed/": {
     "hash": "24ed0c8b1dcb0c81925e2feb04b25f0e4c51df6f310a769ed3e53677e1e9cdff",
@@ -111,127 +111,127 @@
   },
   "https://www.r-wellness.com/fuji5/participant-info/": {
     "hash": "266eb373d5f7dee2aa4866a58e0b49cab963a90fd068d98f05097b59f1d8c13a",
-    "last_checked": "2026-07-27T14:04:25.206Z",
+    "last_checked": "2026-07-31T14:25:02.193Z",
     "race_id": "challenge-fuji5lakes-2026"
   },
   "https://www.r-wellness.com/fuji5/course/": {
     "hash": "fdbb2054b500145a2e7f1894e6298d5bd901dd4095ea0a2d2f4349b94818465e",
-    "last_checked": "2026-07-27T14:04:25.573Z",
+    "last_checked": "2026-07-31T14:25:02.292Z",
     "race_id": "challenge-fuji5lakes-2026"
   },
   "https://www.r-wellness.com/fuji5/access/": {
     "hash": "bdb641d9f83202ae9a56b3534d94684c59238edee36f647a7ad843941a5e122f",
-    "last_checked": "2026-07-27T14:04:25.925Z",
+    "last_checked": "2026-07-31T14:25:02.378Z",
     "race_id": "challenge-fuji5lakes-2026"
   },
   "https://www.r-wellness.com/fuji5/entry/": {
     "hash": "d026e418928b077798ff62a960290b19fbd9d7af5960c9fa3968b4d6e24524e4",
-    "last_checked": "2026-07-27T14:04:26.289Z",
+    "last_checked": "2026-07-31T14:25:02.461Z",
     "race_id": "challenge-fuji5lakes-2026"
   },
   "https://www.r-wellness.com/fuji5/faq/": {
     "hash": "3c2f0764c3a9a0e03adde57da20e67aafa5445a5fc15097d671e9ea5da6ecbaa",
-    "last_checked": "2026-07-27T14:04:26.656Z",
+    "last_checked": "2026-07-31T14:25:02.544Z",
     "race_id": "challenge-fuji5lakes-2026"
   },
   "https://chiba-aqualine-marathon.com/tournament/": {
-    "hash": "e4888fa1edf1cc6b42933c87bd210af06922b36c743e15637495917cd12f8ddf",
-    "last_checked": "2026-07-27T14:04:26.765Z",
+    "hash": "63295a3971c25d461effbcab851f146aea5d2121ed9df5d28fda7e9bc5abdcc0",
+    "last_checked": "2026-07-31T14:25:02.617Z",
     "race_id": "chiba-aqualine-marathon-2026"
   },
   "https://ehimemarathon.jp/outline/": {
     "hash": "d797f04351ec973a15074d4e37582edb5d2141c41d2592ce26840b68d60d6cd2",
-    "last_checked": "2026-07-27T14:04:26.899Z",
+    "last_checked": "2026-07-31T14:25:02.731Z",
     "race_id": "ehime-marathon-2027"
   },
   "https://ehimemarathon.jp/entry/": {
     "hash": "e26bdeda6bd6d73ab2c01202ba9ce4bd1f09ab7525f08a75122adc8864c2b673",
-    "last_checked": "2026-07-27T14:04:26.915Z",
+    "last_checked": "2026-07-31T14:25:02.747Z",
     "race_id": "ehime-marathon-2027"
   },
   "https://ehimemarathon.jp/about-volunteer/": {
     "hash": "6a84f86e1ab4a0d27641073d55080be64cf0e644d4c89c6b58b116497cbc4ac9",
-    "last_checked": "2026-07-27T14:04:27.596Z",
+    "last_checked": "2026-07-31T14:25:03.591Z",
     "race_id": "ehime-marathon-2027"
   },
   "https://ehimemarathon.jp/course/": {
     "hash": "c2b90178678cb34f373f3d2c3245fdf68cf9f258077ad94e54298280b5eee2b4",
-    "last_checked": "2026-07-27T14:04:28.255Z",
+    "last_checked": "2026-07-31T14:25:03.604Z",
     "race_id": "ehime-marathon-2027"
   },
   "https://ehimemarathon.jp/access/": {
     "hash": "7214b55e111e1df3e7aaadeaafe8fc9a9f237a9310afd79579664f75fe62e38e",
-    "last_checked": "2026-07-27T14:04:29.156Z",
+    "last_checked": "2026-07-31T14:25:04.453Z",
     "race_id": "ehime-marathon-2027"
   },
   "https://fujimountainrace.city.fujiyoshida.yamanashi.jp/outline/": {
     "hash": "11b53a19485dc6b3a6f369aa82950c125dbfcb78c3161a84e1b1295af5bc65eb",
-    "last_checked": "2026-07-27T14:04:29.318Z",
+    "last_checked": "2026-07-31T14:25:04.584Z",
     "race_id": "fuji-mountain-race-2026"
   },
   "https://fujimountainrace.city.fujiyoshida.yamanashi.jp/entry/": {
     "hash": "663102edbfa4b982ffff2cd10e17a1c96373b8ffadb9b98378a7639d0b81e348",
-    "last_checked": "2026-07-27T14:04:29.370Z",
+    "last_checked": "2026-07-31T14:25:04.653Z",
     "race_id": "fuji-mountain-race-2026"
   },
   "https://fujimountainrace.city.fujiyoshida.yamanashi.jp/course/": {
     "hash": "6eee351362ff3e9e79355b794fb2828af2f525ca2ca74d2c0210f01385292d69",
-    "last_checked": "2026-07-27T14:04:29.425Z",
+    "last_checked": "2026-07-31T14:25:04.669Z",
     "race_id": "fuji-mountain-race-2026"
   },
   "https://fujimountainrace.city.fujiyoshida.yamanashi.jp/access/": {
     "hash": "f1ad26062f183f3c2d0b62cd7b3071e545a1d776415f86cd73db8b9b40bd86e4",
-    "last_checked": "2026-07-27T14:04:29.478Z",
+    "last_checked": "2026-07-31T14:25:04.726Z",
     "race_id": "fuji-mountain-race-2026"
   },
   "https://fujimountainrace.city.fujiyoshida.yamanashi.jp/2026/wp-content/uploads/2026/04/info-sponsors.pdf": {
     "hash": "9c68961564530716e0c619e88a9e9026cf86635e36c3c79f4969a5672f39d048",
-    "last_checked": "2026-07-27T14:04:29.672Z",
+    "last_checked": "2026-07-31T14:25:04.904Z",
     "race_id": "fuji-mountain-race-2026"
   },
   "https://mtfujimarathon.com/info/": {
-    "hash": "380d0e66124b1168733e80b62cdfba4a4a1ecdd0c3567c4bd5d35a621a7d1304",
-    "last_checked": "2026-07-27T14:04:29.972Z",
+    "hash": "6f21395d5e6fc7cbfd38032769403e3e8c2f92c72249f122b4885c0d09bfd827",
+    "last_checked": "2026-07-31T14:25:05.119Z",
     "race_id": "fujisan-marathon-2026"
   },
   "https://mtfujimarathon.com/entry-front/": {
-    "hash": "6963b577e0591f62d1c41081e72cabcbbd6744b6170edfadcd9160016331492b",
-    "last_checked": "2026-07-27T14:04:30.035Z",
+    "hash": "d12fb362f7b9bec0190151f6cc905949c0af2955edb049bb8d51e4e9faf3c770",
+    "last_checked": "2026-07-31T14:25:05.193Z",
     "race_id": "fujisan-marathon-2026"
   },
   "https://mtfujimarathon.com/outline/": {
     "hash": "9798446b2dfd1740a550b16aa37fa0e52d8e7cf86d22b86d6f86a56c5ffd0825",
-    "last_checked": "2026-07-27T14:04:30.115Z",
+    "last_checked": "2026-07-31T14:25:05.269Z",
     "race_id": "fujisan-marathon-2026"
   },
   "https://mtfujimarathon.com/course/": {
     "hash": "24e42984514c3e8a3482555b5746b2e315590c3b93a0fd54d6b2885888a7d88c",
-    "last_checked": "2026-07-27T14:04:30.177Z",
+    "last_checked": "2026-07-31T14:25:05.351Z",
     "race_id": "fujisan-marathon-2026"
   },
   "https://mtfujimarathon.com/access/": {
     "hash": "1a0d4147dd56d54a67ef214b84f4b935a28c7b5aa161375facd9d3faf60f9a96",
-    "last_checked": "2026-07-27T14:04:30.243Z",
+    "last_checked": "2026-07-31T14:25:05.425Z",
     "race_id": "fujisan-marathon-2026"
   },
   "https://fukuchiyama-marathon.com/outline/": {
     "hash": "57bca7f54c92f90fd9a23a149b312bcd7907ba8e285d8260f6b80786c480dd49",
-    "last_checked": "2026-07-27T14:04:31.192Z",
+    "last_checked": "2026-07-31T14:25:05.720Z",
     "race_id": "fukuchiyama-marathon-2026"
   },
   "https://fukuchiyama-marathon.com/course-map/": {
     "hash": "03b933782faa6d560c4b63671dbac6c82ee05ec276d8bac8d444e37c3be1ec0d",
-    "last_checked": "2026-07-27T14:04:31.677Z",
+    "last_checked": "2026-07-31T14:25:05.905Z",
     "race_id": "fukuchiyama-marathon-2026"
   },
   "https://fukuchiyama-marathon.com/entry/": {
     "hash": "557a5f678405f936737d195f1e1ae4624379f513b8741173c3b863ff02a4a697",
-    "last_checked": "2026-07-27T14:04:31.872Z",
+    "last_checked": "2026-07-31T14:25:06.078Z",
     "race_id": "fukuchiyama-marathon-2026"
   },
   "https://fukuchiyama-marathon.com/access/": {
     "hash": "359b8b1745a5775b1b572207e5d03b8127530377548a1c346843036ff5c24fee",
-    "last_checked": "2026-07-27T14:04:32.202Z",
+    "last_checked": "2026-07-31T14:25:06.339Z",
     "race_id": "fukuchiyama-marathon-2026"
   },
   "https://www.fukui-sakura-marathon.jp/about/": {
@@ -251,7 +251,7 @@
   },
   "https://www.fukui-sakura-marathon.jp/runner/": {
     "hash": "5130ece3bcc12b9415a8fa2287933f4683cdaa96515ca5a507ff74e53ab46ba2",
-    "last_checked": "2026-07-27T14:04:36.117Z",
+    "last_checked": "2026-07-31T14:25:10.021Z",
     "race_id": "fukui-sakura-marathon-2026"
   },
   "https://www.fukui-sakura-marathon.jp/stay/": {
@@ -261,12 +261,12 @@
   },
   "https://www.fukuoka-international-marathon.jp/": {
     "hash": "61ea9d3931b6c26eca48c10ca530f8101cc0921d3bdbecfad972526dd471d05a",
-    "last_checked": "2026-07-27T14:04:37.346Z",
+    "last_checked": "2026-07-31T14:25:11.289Z",
     "race_id": "fukuoka-international-marathon-2026"
   },
   "https://www.f-marathon.jp/about/": {
     "hash": "93dd1bb948adba7fd9c604109183d3758c174e0e62f952fff401824435690078",
-    "last_checked": "2026-07-27T14:04:37.645Z",
+    "last_checked": "2026-07-31T14:25:11.432Z",
     "race_id": "fukuoka-marathon-2026"
   },
   "https://www.f-marathon.jp/about/course.php/": {
@@ -286,117 +286,117 @@
   },
   "https://www.f-marathon.jp/traffic/": {
     "hash": "d833b5db1ed84d1e9dd337962b7fea6f8be2838c05b06d0ccc798272b6a47394",
-    "last_checked": "2026-07-27T14:04:37.754Z",
+    "last_checked": "2026-07-31T14:25:11.526Z",
     "race_id": "fukuoka-marathon-2026"
   },
   "https://www.g-marathon.com/about-guide/": {
-    "hash": "3b6c272575cf3299ec240bbf5172d0209bb3671e7c530944706ca8dccd8fbdb3",
-    "last_checked": "2026-07-27T14:04:37.878Z",
+    "hash": "249b69f7152bbbaf6f336f53d6187cfa392ca25226e0c83810f4ea46d4f3502d",
+    "last_checked": "2026-07-31T14:25:12.403Z",
     "race_id": "gunma-marathon-2026"
   },
   "https://www.g-marathon.com/course-full/": {
     "hash": "4d6a0b3e45226f859614450f34d4b9d33ad4e425b2a0bfe854df26a67de457ff",
-    "last_checked": "2026-07-27T14:04:38.706Z",
+    "last_checked": "2026-07-31T14:25:13.264Z",
     "race_id": "gunma-marathon-2026"
   },
   "https://www.kumagera.ne.jp/a100km/course.html": {
     "hash": "0400379c8d34d45b491e7e99362434403713d8af8276834a2611a90cd40bbf36",
-    "last_checked": "2026-07-27T14:04:20.650Z",
+    "last_checked": "2026-07-31T14:24:57.022Z",
     "race_id": "akita-nairiku-ultra-2026"
   },
   "https://www.kumagera.ne.jp/a100km/entry.html": {
     "hash": "ac8655485bf895ddc9ac210fdf6b854b673e9d141fde3ee973b547bbab8f7422",
-    "last_checked": "2026-07-27T14:04:20.668Z",
+    "last_checked": "2026-07-31T14:24:57.043Z",
     "race_id": "akita-nairiku-ultra-2026"
   },
   "https://www.kumagera.ne.jp/a100km/essentia-point.html": {
     "hash": "85867aa1f1ca55f12cd112adabd2af0d5fa5272678c75a46a6d8efbe8ee0a45b",
-    "last_checked": "2026-07-27T14:04:20.687Z",
+    "last_checked": "2026-07-31T14:24:57.062Z",
     "race_id": "akita-nairiku-ultra-2026"
   },
   "https://www.kumagera.ne.jp/a100km/access.html": {
     "hash": "76fe52037b53f163dcfb97d86fb19e2b7e45986c3a598c8d14d500161b1559dc",
-    "last_checked": "2026-07-27T14:04:20.705Z",
+    "last_checked": "2026-07-31T14:24:57.081Z",
     "race_id": "akita-nairiku-ultra-2026"
   },
   "https://www.kumagera.ne.jp/a100km/question.html": {
     "hash": "51387e4c0186c96d06ecce0c4f9155d1e8234d09da0b82e31dc989d539ae0b13",
-    "last_checked": "2026-07-27T14:04:20.726Z",
+    "last_checked": "2026-07-31T14:24:57.103Z",
     "race_id": "akita-nairiku-ultra-2026"
   },
   "https://www.betsudai.com/wp-content/themes/betsudai/pdf/74/kou.pdf": {
     "hash": "f81fd537033822b64e8d4a11cc1e6c3ce2dbb2b44c607fb0330ac2b37bbc04e2",
-    "last_checked": "2026-07-27T14:04:24.419Z",
+    "last_checked": "2026-07-31T14:25:01.671Z",
     "race_id": "beppu-oita-marathon-2026"
   },
   "https://chiba-aqualine-marathon.com/tournament/course.html": {
-    "hash": "6f2f1666cb43e454e0ba64b54415582e07efe415bfb5eadb0cf5aa0ecc99b04c",
-    "last_checked": "2026-07-27T14:04:26.781Z",
+    "hash": "9b7b63b2dd224fff5559e10312f1704c2a34b936fd2c3d3b248c128e1e662ec8",
+    "last_checked": "2026-07-31T14:25:02.633Z",
     "race_id": "chiba-aqualine-marathon-2026"
   },
   "https://chiba-aqualine-marathon.com/runner/entry.html": {
-    "hash": "ec03674bff039c953ab1b2a7f0af72c60a0bb5da85d0e21e53577e7aff3f70ce",
-    "last_checked": "2026-07-27T14:04:26.797Z",
+    "hash": "ee47cd0afb3e6b4361ef882a5cf3e2293eebafc42de2eb2a03f1a15305148418",
+    "last_checked": "2026-07-31T14:25:02.650Z",
     "race_id": "chiba-aqualine-marathon-2026"
   },
   "https://chiba-aqualine-marathon.com/runner/guidelines.html": {
-    "hash": "ad13c50923e6de39b279faf881d47af98fe175576be148fa75c61ef39d056878",
-    "last_checked": "2026-07-27T14:04:26.815Z",
+    "hash": "e115c26591f32f5fbe452c25badfbca2e44dbed6373265a6578864168cc943f2",
+    "last_checked": "2026-07-31T14:25:02.667Z",
     "race_id": "chiba-aqualine-marathon-2026"
   },
   "https://www.f-marathon.jp/about/course.php": {
     "hash": "b7a336b284744c0735810b9a5410dd72789431f2eee7c92fb4d8cc4d369bd4d7",
-    "last_checked": "2026-07-27T14:04:37.672Z",
+    "last_checked": "2026-07-31T14:25:11.456Z",
     "race_id": "fukuoka-marathon-2026"
   },
   "https://www.f-marathon.jp/about/logo.php": {
     "hash": "efa854cbcba8f0fec1402cf8fc2bcb28e733a2d51f83c0347f17fde209d27746",
-    "last_checked": "2026-07-27T14:04:37.701Z",
+    "last_checked": "2026-07-31T14:25:11.479Z",
     "race_id": "fukuoka-marathon-2026"
   },
   "https://www.f-marathon.jp/runner/apply.php": {
     "hash": "e1d2b947543a46223f5c545650c95b3f288dc3926deb771c837e6b0b403bb85e",
-    "last_checked": "2026-07-27T14:04:37.727Z",
+    "last_checked": "2026-07-31T14:25:11.502Z",
     "race_id": "fukuoka-marathon-2026"
   },
   "https://www.g-marathon.com/access/": {
     "hash": "ce82fdecda2f4a42974c310137af637b3a407d4d4b08817842770792694f4f71",
-    "last_checked": "2026-07-27T14:04:39.391Z",
+    "last_checked": "2026-07-31T14:25:13.289Z",
     "race_id": "gunma-marathon-2026"
   },
   "https://www.g-marathon.com/faq_runner/": {
     "hash": "0e400128b4c88af4237c2c970761ee28c4dc08ce8f5b639eaaeac60b805bc44f",
-    "last_checked": "2026-07-27T14:04:39.410Z",
+    "last_checked": "2026-07-31T14:25:13.689Z",
     "race_id": "gunma-marathon-2026"
   },
   "https://www.g-marathon.com/info/": {
-    "hash": "4cb26155dfa0c4ebc98778fb8c90df0ff4ed3bf95ff3fa5ffc7cd19bb35c3806",
-    "last_checked": "2026-07-27T14:04:39.425Z",
+    "hash": "77b9b34fa55f7d4d6b22ecbab9771cfb624326dc254d4ad506f27e0de7bf0dc5",
+    "last_checked": "2026-07-31T14:25:14.530Z",
     "race_id": "gunma-marathon-2026"
   },
   "https://www.sakuranbo-m.jp/overview/": {
     "hash": "6bff5b397d9836fe8f6aca4ce74d28d672d822f9dbc82198ee15f1b3959fe869",
-    "last_checked": "2026-07-27T14:04:40.368Z",
+    "last_checked": "2026-07-31T14:25:15.195Z",
     "race_id": "higashine-sakuranbo-marathon-2026"
   },
   "https://www.sakuranbo-m.jp/course/": {
     "hash": "53feebaff16b36b31512acb795d83c6af843ea87a1e8d284b5b5ffbd05332a4c",
-    "last_checked": "2026-07-27T14:04:40.851Z",
+    "last_checked": "2026-07-31T14:25:15.849Z",
     "race_id": "higashine-sakuranbo-marathon-2026"
   },
   "https://www.sakuranbo-m.jp/access/": {
     "hash": "6282e51d84fd5905d5f3c0580e55068efcee2a1394e641dc21e79e82bcb80099",
-    "last_checked": "2026-07-27T14:04:41.283Z",
+    "last_checked": "2026-07-31T14:25:16.276Z",
     "race_id": "higashine-sakuranbo-marathon-2026"
   },
   "https://www.sakuranbo-m.jp/archives/2173/": {
     "hash": "aa765f38237b6086ebd7555c1def65589fb856cd17285d3250afb582bcf9a09f",
-    "last_checked": "2026-07-27T14:04:41.670Z",
+    "last_checked": "2026-07-31T14:25:16.681Z",
     "race_id": "higashine-sakuranbo-marathon-2026"
   },
   "https://www.sakuranbo-m.jp/qa/": {
     "hash": "8d23bfe85adfaeb122ceeb88c24f6d56dbb083986fc2764ac08d10cd4eabd38c",
-    "last_checked": "2026-07-27T14:04:42.090Z",
+    "last_checked": "2026-07-31T14:25:17.137Z",
     "race_id": "higashine-sakuranbo-marathon-2026"
   },
   "https://www.runningkanagawa.com/faq/": {
@@ -411,147 +411,147 @@
   },
   "https://www.himeji-marathon.jp/outline/index.html": {
     "hash": "f4265f62438cef80de0b6d9fd7d6db52669dcb138161eab099a69e239cd8f3c8",
-    "last_checked": "2026-07-27T14:04:42.611Z",
+    "last_checked": "2026-07-31T14:25:17.598Z",
     "race_id": "himeji-castle-marathon-2026"
   },
   "https://www.himeji-marathon.jp/course/index.html": {
     "hash": "99b79419961cc1b2ce864e8352c1cf43d0e386517caabdc69e701998ede72777",
-    "last_checked": "2026-07-27T14:04:42.631Z",
+    "last_checked": "2026-07-31T14:25:17.614Z",
     "race_id": "himeji-castle-marathon-2026"
   },
   "https://www.himeji-marathon.jp/access/index.html": {
     "hash": "20b518940c53f9845c33d60ddbcb5921785c0a4b3c0389d8e0a51224a4dbab91",
-    "last_checked": "2026-07-27T14:04:42.647Z",
+    "last_checked": "2026-07-31T14:25:17.631Z",
     "race_id": "himeji-castle-marathon-2026"
   },
   "https://www.himeji-marathon.jp/application/index.html": {
     "hash": "325abeb65e34f714433391b5013286ef730bb78e021ddef73ccd3036b3302be0",
-    "last_checked": "2026-07-27T14:04:42.666Z",
+    "last_checked": "2026-07-31T14:25:17.648Z",
     "race_id": "himeji-castle-marathon-2026"
   },
   "https://www.himeji-marathon.jp/participation/index.html": {
     "hash": "94472310f81f82d3051e646768bf4417949a75f5ed690c3fd54ffdc9a4c35e43",
-    "last_checked": "2026-07-27T14:04:42.684Z",
+    "last_checked": "2026-07-31T14:25:17.667Z",
     "race_id": "himeji-castle-marathon-2026"
   },
   "https://hitachi-marathon.jp/outline/": {
     "hash": "1774273bb3e5340439db1d09e4a6b7cc611aa8f8cf348872a347adae1d07c953",
-    "last_checked": "2026-07-27T14:04:42.963Z",
+    "last_checked": "2026-07-31T14:25:17.880Z",
     "race_id": "hitachi-seaside-marathon-2026"
   },
   "https://hitachi-marathon.jp/entry/": {
     "hash": "05abd320046072b14a51de9711b6b07c1f001d28e4457feb131770a5c188bbe1",
-    "last_checked": "2026-07-27T14:04:43.017Z",
+    "last_checked": "2026-07-31T14:25:17.936Z",
     "race_id": "hitachi-seaside-marathon-2026"
   },
   "https://hitachi-marathon.jp/2026/feature/": {
     "hash": "da852adc32ccda828d0677cfb5cd717cb7f7ec9c11bf5e981c5d7a6e15b8128d",
-    "last_checked": "2026-07-27T14:04:43.167Z",
+    "last_checked": "2026-07-31T14:25:18.065Z",
     "race_id": "hitachi-seaside-marathon-2026"
   },
   "https://hitachi-marathon.jp/2025/wp-content/uploads/2025/08/roadclosure2025.pdf": {
     "hash": "d6ddb860e55b36cf6d22086e51a9c87e2dc0aa7611109770a5866f8fabb00cc6",
-    "last_checked": "2026-07-27T14:04:43.243Z",
+    "last_checked": "2026-07-31T14:25:18.132Z",
     "race_id": "hitachi-seaside-marathon-2026"
   },
   "https://hofu-yomiuri.jp/outline/": {
     "hash": "a9fd67f396e15d2fc3bd562f42df1f854b3e79a3a0ad8b21acdadba3c19b295f",
-    "last_checked": "2026-07-27T14:04:43.365Z",
+    "last_checked": "2026-07-31T14:25:18.201Z",
     "race_id": "hofu-yomiuri-marathon-2026"
   },
   "https://hofu-yomiuri.jp/course/": {
     "hash": "e52d706e1aac18439d899797106514f31c36f7535598389a855e7d579d8a408a",
-    "last_checked": "2026-07-27T14:04:44.762Z",
+    "last_checked": "2026-07-31T14:25:18.227Z",
     "race_id": "hofu-yomiuri-marathon-2026"
   },
   "https://hokkaido-marathon.com/overview/": {
-    "hash": "44cc416db69ac08b226f6966e6cc7f5fb8126c137039be54f6612d433777ffdf",
-    "last_checked": "2026-07-27T14:04:44.852Z",
+    "hash": "ad6a0efb8162ef948c89e476988af8147485819a3dd2a255e7cbcb62c434a104",
+    "last_checked": "2026-07-31T14:25:18.314Z",
     "race_id": "hokkaido-marathon-2026"
   },
   "https://hokkaido-marathon.com/course/": {
-    "hash": "f0ee1fa16937f8792de0249d4b0073486281889f74cbed871107f097851ceb32",
-    "last_checked": "2026-07-27T14:04:44.862Z",
+    "hash": "06a617195de0e50e9de1f0671cca79ce15f3860f66c2524512435abdd6f59a93",
+    "last_checked": "2026-07-31T14:25:18.325Z",
     "race_id": "hokkaido-marathon-2026"
   },
   "https://hokkaido-marathon.com/entry/": {
-    "hash": "b417c91bbb538f4167e4b6e5b5f8ee12263098d95492417782ada6a784e04f6b",
-    "last_checked": "2026-07-27T14:04:44.875Z",
+    "hash": "6e5114b5e9ce536fe66c165aa5ec6de12c5d560b42316822bd91eafb097f08b4",
+    "last_checked": "2026-07-31T14:25:18.336Z",
     "race_id": "hokkaido-marathon-2026"
   },
   "https://hokkaido-marathon.com/faq/": {
-    "hash": "d4238d7093a865f3f88d9823a45a3d00350a4a7ecd5ae938451f94e910a58d7e",
-    "last_checked": "2026-07-27T14:04:45.526Z",
+    "hash": "f8cc62004666f4253511b6900aa7d8279acbc5169939809f12bae8ce61960439",
+    "last_checked": "2026-07-31T14:25:19.004Z",
     "race_id": "hokkaido-marathon-2026"
   },
   "https://hokkaido-marathon.com/info/12731/": {
-    "hash": "f11ca26bcb79f151308efb301a8bb26cd7d3d6fbb25abab6d3f810df89fa2f32",
-    "last_checked": "2026-07-27T14:04:46.198Z",
+    "hash": "266e55fafbfdb32b2db3dabbc7a2d7ebe963784087f3bb0f8ee7a6974a61109f",
+    "last_checked": "2026-07-31T14:25:19.675Z",
     "race_id": "hokkaido-marathon-2026"
   },
   "https://ibusuki-nanohana.com/overview/": {
     "hash": "a9bcbc69b928f5bc8703b44c77c0a414548cac5a68b03a0e5d304f6be4f122d1",
-    "last_checked": "2026-07-27T14:04:46.456Z",
+    "last_checked": "2026-07-31T14:25:20.286Z",
     "race_id": "ibusuki-nanohana-2026"
   },
   "https://ibusuki-nanohana.com/essentials/": {
     "hash": "c23a39a9d7c370a14594255e4f3341bb263187da4e212298f21f7ebf0adf46bf",
-    "last_checked": "2026-07-27T14:04:46.558Z",
+    "last_checked": "2026-07-31T14:25:20.381Z",
     "race_id": "ibusuki-nanohana-2026"
   },
   "https://ibusuki-nanohana.com/question/": {
     "hash": "80bdd3f8a23f353529cadd5dc3f6e1610fe09fb305659e5f0a2288537a842fec",
-    "last_checked": "2026-07-27T14:04:46.647Z",
+    "last_checked": "2026-07-31T14:25:20.494Z",
     "race_id": "ibusuki-nanohana-2026"
   },
   "https://ibusuki-nanohana.com/course/": {
     "hash": "07663f580a40ac4c5428ae8d5768eed5f8bb5b120377b98e96ec39eac66ed905",
-    "last_checked": "2026-07-27T14:04:46.664Z",
+    "last_checked": "2026-07-31T14:25:20.584Z",
     "race_id": "ibusuki-nanohana-2026"
   },
   "https://ibusuki-nanohana.com/entry/": {
     "hash": "4ee163b7747f569e27c1c2d1d059d58037d580aa61ef063d9356f4c5000df02b",
-    "last_checked": "2026-07-27T14:04:46.759Z",
+    "last_checked": "2026-07-31T14:25:20.677Z",
     "race_id": "ibusuki-nanohana-2026"
   },
   "https://ichinoseki-half.jp/outline/": {
     "hash": "34490b203b872973429c86fd2f26b0d44219b300c7d02312a5c0ce7011a6a74e",
-    "last_checked": "2026-07-27T14:04:46.902Z",
+    "last_checked": "2026-07-31T14:25:20.814Z",
     "race_id": "ichinoseki-half-marathon-2026"
   },
   "https://ichinoseki-half.jp/entry/": {
     "hash": "3fb3018b881a9b2a90bf94b46e8c484564288ab32f21392ad2bcd59ba8b9f7cb",
-    "last_checked": "2026-07-27T14:04:46.953Z",
+    "last_checked": "2026-07-31T14:25:20.862Z",
     "race_id": "ichinoseki-half-marathon-2026"
   },
   "https://ichinoseki-half.jp/course/": {
     "hash": "65211a2ce1e80346d8c7e9c1f0bab51a81c20e872d64f92ba2e4f37d2b0efdb8",
-    "last_checked": "2026-07-27T14:04:46.998Z",
+    "last_checked": "2026-07-31T14:25:20.918Z",
     "race_id": "ichinoseki-half-marathon-2026"
   },
   "https://iki-ultra.jp/about/": {
     "hash": "b2c74817edce1aafa651d2562121a5e6a70cdc9d1a897ac217d4839566f06782",
-    "last_checked": "2026-07-27T14:04:47.512Z",
+    "last_checked": "2026-07-31T14:25:21.442Z",
     "race_id": "iki-ultra-marathon-2026"
   },
   "https://iki-ultra.jp/qa/": {
     "hash": "2b639f644ee41e39d2ae352745dace53b49fe6887554d9d1eb0b3e320ccd0bf9",
-    "last_checked": "2026-07-27T14:04:47.607Z",
+    "last_checked": "2026-07-31T14:25:21.533Z",
     "race_id": "iki-ultra-marathon-2026"
   },
   "https://iki-ultra.jp/entry/": {
     "hash": "528ad6b5a6df859619219e0bdbe26b628cfa45bcd1e3944a6fedc2bfece96d50",
-    "last_checked": "2026-07-27T14:04:47.701Z",
+    "last_checked": "2026-07-31T14:25:21.635Z",
     "race_id": "iki-ultra-marathon-2026"
   },
   "https://iki-ultra.jp/course/": {
     "hash": "bba52a6c44494bbabcb87f774aa243042812eb0271606aff4a6f6b6c48bd695d",
-    "last_checked": "2026-07-27T14:04:47.777Z",
+    "last_checked": "2026-07-31T14:25:21.739Z",
     "race_id": "iki-ultra-marathon-2026"
   },
   "https://iki-ultra.jp/access/": {
     "hash": "3300e81c396f040ce77ab7c11468354185d2cabdca60655fd610dbe266620838",
-    "last_checked": "2026-07-27T14:04:47.854Z",
+    "last_checked": "2026-07-31T14:25:21.866Z",
     "race_id": "iki-ultra-marathon-2026"
   },
   "https://i-c-m.jp/guideline/": {
@@ -576,112 +576,112 @@
   },
   "https://iwaki-marathon.jp/outline/": {
     "hash": "18e79a78ee171d713500f23811869b7760dcb5b0dd083e124ec1dc6c88c7f218",
-    "last_checked": "2026-07-27T14:04:49.158Z",
+    "last_checked": "2026-07-31T14:25:22.710Z",
     "race_id": "iwaki-sunshine-marathon-2027"
   },
   "https://iwaki-marathon.jp/course/": {
     "hash": "74571ab36caec5ed993ea910d1a29113e8bf6375125cab6ba6aed238cfd21ef0",
-    "last_checked": "2026-07-27T14:04:49.689Z",
+    "last_checked": "2026-07-31T14:25:23.236Z",
     "race_id": "iwaki-sunshine-marathon-2027"
   },
   "https://iwaki-marathon.jp/outline/schedule/": {
     "hash": "d3b258947aee57930472f563ae60a9cd1ce31834e47f33223102e1eac4a10bd9",
-    "last_checked": "2026-07-27T14:04:51.189Z",
+    "last_checked": "2026-07-31T14:25:23.768Z",
     "race_id": "iwaki-sunshine-marathon-2027"
   },
   "https://iwaki-marathon.jp/entry/": {
     "hash": "d32b560cb185b69b42b94530945b7ccfcbceb6d456eb684f15f314fa6cd334ed",
-    "last_checked": "2026-07-27T14:04:51.711Z",
+    "last_checked": "2026-07-31T14:25:24.277Z",
     "race_id": "iwaki-sunshine-marathon-2027"
   },
   "https://iwaki-marathon.jp/access/": {
     "hash": "a5b21e2ada44765b4c5c128442f6dc70981c315207c2fe3b48718eb1b9b4b2a4",
-    "last_checked": "2026-07-27T14:04:52.225Z",
+    "last_checked": "2026-07-31T14:25:24.822Z",
     "race_id": "iwaki-sunshine-marathon-2027"
   },
   "https://iwate-morioka-city-marathon.jp/outline/": {
-    "hash": "c01474ebc36cebd404de0e0e4a14a790baebc8fe02a823b1b568ed654fcf5371",
-    "last_checked": "2026-07-27T14:04:52.441Z",
+    "hash": "c0afb9660de03cc22e6b811026a720384a2e1944baae0aa1e210d8a9bddf97c8",
+    "last_checked": "2026-07-31T14:25:24.962Z",
     "race_id": "iwate-morioka-city-marathon-2026"
   },
   "https://iwate-morioka-city-marathon.jp/concept/": {
-    "hash": "919f302b22c576c81fee45e2950b17e98c9f712b4a734607c9e72a4f1350fdf4",
-    "last_checked": "2026-07-27T14:04:52.506Z",
+    "hash": "ad3196d74e57091bb4452dba07bd47a888feaed45ff6afe4b3f5e63f2f95355e",
+    "last_checked": "2026-07-31T14:25:25.029Z",
     "race_id": "iwate-morioka-city-marathon-2026"
   },
   "https://iwate-morioka-city-marathon.jp/entry/": {
-    "hash": "a90321907aa09a5c92ed87cc123a45461750c84abc97d7ca1aa533ff03790a8e",
-    "last_checked": "2026-07-27T14:04:52.569Z",
+    "hash": "71bda06b07902db6eff4e09068d259468c66eb5126a27199af5affe6a94ceec6",
+    "last_checked": "2026-07-31T14:25:25.093Z",
     "race_id": "iwate-morioka-city-marathon-2026"
   },
   "https://iwate-morioka-city-marathon.jp/course/": {
-    "hash": "41cad32ec3d8b1214f9a3fae953dc813f74ea9e3d8c7d2519c1d065a8f552b08",
-    "last_checked": "2026-07-27T14:04:52.629Z",
+    "hash": "5f1f2ab4afb4a5ffa935a6fa429ee866357b3a015635b6894ab61167a18d3635",
+    "last_checked": "2026-07-31T14:25:25.154Z",
     "race_id": "iwate-morioka-city-marathon-2026"
   },
   "https://iwate-morioka-city-marathon.jp/faq_reception/": {
-    "hash": "3bf9f55da00590ce1ed4e6ad0ddb9c86c0a87f06a1a6e8274331d6c01c9b0c26",
-    "last_checked": "2026-07-27T14:04:52.688Z",
+    "hash": "1c4a9086548ad9bb8a76b53bf310f43d51417b3edf5c7225a45aecc3a50a67a6",
+    "last_checked": "2026-07-31T14:25:25.221Z",
     "race_id": "iwate-morioka-city-marathon-2026"
   },
   "https://oshukirameki.jp/outline/": {
     "hash": "8debce1fe793af8a48186a926514b618a5caa11a179a2516b4b85157492fb8b7",
-    "last_checked": "2026-07-27T14:04:52.960Z",
+    "last_checked": "2026-07-31T14:25:25.475Z",
     "race_id": "iwate-oshu-kirameki-marathon-2026"
   },
   "https://oshukirameki.jp/entry/": {
     "hash": "a1fce03205b6d3ee10c3479fb64c69a4555667e5ff7b8a15231b8d3224e43b4c",
-    "last_checked": "2026-07-27T14:04:53.174Z",
+    "last_checked": "2026-07-31T14:25:25.679Z",
     "race_id": "iwate-oshu-kirameki-marathon-2026"
   },
   "https://oshukirameki.jp/info/": {
     "hash": "1c2479fd83116ec2ce2e3300e96f548ca9ebac68ad18583da7f01fcd61ceb0ba",
-    "last_checked": "2026-07-27T14:04:53.390Z",
+    "last_checked": "2026-07-31T14:25:25.876Z",
     "race_id": "iwate-oshu-kirameki-marathon-2026"
   },
   "https://oshukirameki.jp/course/": {
     "hash": "5f44be2e5330715d2054b3195db180c2ed595e52988a1af8daa106bafb596542",
-    "last_checked": "2026-07-27T14:04:53.571Z",
+    "last_checked": "2026-07-31T14:25:26.042Z",
     "race_id": "iwate-oshu-kirameki-marathon-2026"
   },
   "https://kagawa-marathon.com/faq/": {
     "hash": "c8db94aa9255c144aac61813a4728375bb5c1e3182c81a565631c53e972750ea",
-    "last_checked": "2026-07-27T14:05:00.783Z",
-    "race_id": "kagawa-marathon-2026"
+    "last_checked": "2026-07-31T14:25:27.095Z",
+    "race_id": "kagawa-marathon-2027"
   },
   "https://kagawa-marathon.com/information/essentials/": {
     "hash": "cbb816890e151756843164e37bd91ec09cc763dc6a0fb68ead877b9ef522c390",
-    "last_checked": "2026-07-27T14:05:00.821Z",
-    "race_id": "kagawa-marathon-2026"
+    "last_checked": "2026-07-31T14:25:27.134Z",
+    "race_id": "kagawa-marathon-2027"
   },
   "https://kagawa-marathon.com/information/access/": {
     "hash": "2a0f067f13dbbf9be415edbfa4bedc7821c275e53d5caa7d4a0e135ff388f970",
-    "last_checked": "2026-07-27T14:05:00.860Z",
-    "race_id": "kagawa-marathon-2026"
+    "last_checked": "2026-07-31T14:25:27.172Z",
+    "race_id": "kagawa-marathon-2027"
   },
   "https://kagawa-marathon.com/information/course/": {
     "hash": "28404f59bb615bb999b8fe1c8ef39ffb4a0cf414a05a8839c91cb1acac4ed6d1",
-    "last_checked": "2026-07-27T14:05:00.898Z",
-    "race_id": "kagawa-marathon-2026"
+    "last_checked": "2026-07-31T14:25:27.228Z",
+    "race_id": "kagawa-marathon-2027"
   },
   "https://kagawa-marathon.com/information/concept/": {
     "hash": "c213f556fce13483279ae571d8fbc9f2bb2bcb92d72767a8cc436d16b3e563bc",
-    "last_checked": "2026-07-27T14:05:00.936Z",
-    "race_id": "kagawa-marathon-2026"
+    "last_checked": "2026-07-31T14:25:27.306Z",
+    "race_id": "kagawa-marathon-2027"
   },
   "https://www.kagoshima-marathon.jp/about/": {
-    "hash": "56f3fd660bc2d83dd14f2a9d051828280f0402bba0960022ceb79c5d3fc244e0",
-    "last_checked": "2026-06-29T14:10:46.116Z",
+    "hash": "018816eac77b9fb513a5277f49a6845b9660223ad72552851364b098a422e3cd",
+    "last_checked": "2026-07-31T14:25:27.661Z",
     "race_id": "kagoshima-marathon-2026"
   },
   "https://www.kagoshima-marathon.jp/about/course/course-guidelines.html": {
-    "hash": "3a4572c2ce99351475d03aaf5719d6f583d599a404e2a97a99394edbe6c4131c",
-    "last_checked": "2026-06-29T14:10:46.160Z",
+    "hash": "5d45604c60cfd995de7d8ef1823b312cca41e3ad965e636c49604f69b18f6728",
+    "last_checked": "2026-07-31T14:25:27.708Z",
     "race_id": "kagoshima-marathon-2026"
   },
   "https://www.kagoshima-marathon.jp/entry/": {
-    "hash": "0b6b63ee0e7f3bd3b42720f70f6b2b8720b46ea6ff8ba1079009579da3601333",
-    "last_checked": "2026-06-29T14:10:46.179Z",
+    "hash": "3958b62d97cf618f449e3386c880da6d247ee671cb68f7b233bfd4709b4ea0bf",
+    "last_checked": "2026-07-31T14:25:27.723Z",
     "race_id": "kagoshima-marathon-2026"
   },
   "https://www.kagoshima-marathon.jp/traffic/index-mk.html": {
@@ -690,138 +690,138 @@
     "race_id": "kagoshima-marathon-2026"
   },
   "https://www.kagoshima-marathon.jp/faq/": {
-    "hash": "3e0483f2c3667809813f13f51e7d8675fc3ba6495577ef05b58a197f22426fbc",
-    "last_checked": "2026-07-27T14:05:01.513Z",
+    "hash": "5be286ad891063a680db2b62abd919fdd91b0c35118ce8a3bce36d2540753f0a",
+    "last_checked": "2026-07-31T14:25:27.817Z",
     "race_id": "kagoshima-marathon-2026"
   },
   "https://kaikyomarathon.jp/outline/": {
     "hash": "e5fd3c2b788a85e0d5da3e437c7531a8a60c5933ba68f822bf90d2dd02525852",
-    "last_checked": "2026-07-27T14:05:02.285Z",
+    "last_checked": "2026-07-31T14:25:27.892Z",
     "race_id": "kaikyo-marathon-2026"
   },
   "https://kaikyomarathon.jp/entry/": {
     "hash": "c0a0282b24ee7039838ab3f575313786faccb9e9b0bd11c9badd61856a836fb3",
-    "last_checked": "2026-07-27T14:05:02.305Z",
+    "last_checked": "2026-07-31T14:25:27.904Z",
     "race_id": "kaikyo-marathon-2026"
   },
   "https://kaikyomarathon.jp/course/": {
     "hash": "2ded800f3383e5f19a8b0911b3ddf50d29d8ca8d637a001682880a68d237058d",
-    "last_checked": "2026-07-27T14:05:02.336Z",
+    "last_checked": "2026-07-31T14:25:28.583Z",
     "race_id": "kaikyo-marathon-2026"
   },
   "https://kaikyomarathon.jp/access/": {
     "hash": "46ce85a8af0f0397cf02b8b4bbc33f320b2b5024db430d5d54701bac65858f26",
-    "last_checked": "2026-07-27T14:05:02.369Z",
+    "last_checked": "2026-07-31T14:25:29.435Z",
     "race_id": "kaikyo-marathon-2026"
   },
   "https://kaikyomarathon.jp/qa/": {
     "hash": "3d2245dcce554aa1752f4ec1ea0736b6b5b63b3b0250c775b212f08458e78fbb",
-    "last_checked": "2026-07-27T14:05:02.396Z",
+    "last_checked": "2026-07-31T14:25:30.273Z",
     "race_id": "kaikyo-marathon-2026"
   },
   "https://www.kanazawa-marathon.jp/outline/index.html?": {
     "hash": "f5dc074da74a2bd12fff700d9fb2f12352727c5f6aa70da28ffec178dc4d2304",
-    "last_checked": "2026-07-27T14:05:02.596Z",
+    "last_checked": "2026-07-31T14:25:30.478Z",
     "race_id": "kanazawa-marathon-2026"
   },
   "https://www.kanazawa-marathon.jp/course/index.html?": {
     "hash": "dabb288991ad21d39e878c8227e134db008fc273d2c9065be1991b54788a0103",
-    "last_checked": "2026-07-27T14:05:02.719Z",
+    "last_checked": "2026-07-31T14:25:30.602Z",
     "race_id": "kanazawa-marathon-2026"
   },
   "https://www.kanazawa-marathon.jp/point/index.html?": {
     "hash": "11bb369cc76a17d1933351cedebb561179acd1f50aeaf5a889d2aca069fc850e",
-    "last_checked": "2026-07-27T14:05:02.737Z",
+    "last_checked": "2026-07-31T14:25:30.622Z",
     "race_id": "kanazawa-marathon-2026"
   },
   "https://www.kanazawa-marathon.jp/entry/index.html?": {
     "hash": "56037b0c226dfaf4c848b79e6697ace2caf00eec75dea2bb9e95c1b51e74d5a3",
-    "last_checked": "2026-07-27T14:05:02.771Z",
+    "last_checked": "2026-07-31T14:25:30.658Z",
     "race_id": "kanazawa-marathon-2026"
   },
   "https://www.kanazawa-marathon.jp/qanda/index.html?": {
-    "hash": "30aae79b340cd527232a09b090b65fb6367e59626d691999e8726eb1c36bda14",
-    "last_checked": "2026-07-27T14:05:02.821Z",
+    "hash": "e1f0f45c91c2cf4fb8f3ae2f04121a4c9340c5858388f3625cb2d2b3f97f4655",
+    "last_checked": "2026-07-31T14:25:30.711Z",
     "race_id": "kanazawa-marathon-2026"
   },
   "https://www.kasa-mara.jp/outline/": {
     "hash": "42abc55e23b4fe464c23a222a1ad5d89af874b34d8c71f9d053578837aab88b9",
-    "last_checked": "2026-07-27T14:05:03.025Z",
-    "race_id": "kasama-togeinosato-half-2025-2025"
+    "last_checked": "2026-07-31T14:25:32.138Z",
+    "race_id": "kasama-togeinosato-half-2025-2026"
   },
   "https://www.kasa-mara.jp/entry/": {
     "hash": "9ab12e070ff77e9bceebd8dac8dcaa2c16a0491b8e4053341919fd76d2ed9629",
-    "last_checked": "2026-07-27T14:05:03.130Z",
-    "race_id": "kasama-togeinosato-half-2025-2025"
+    "last_checked": "2026-07-31T14:25:32.258Z",
+    "race_id": "kasama-togeinosato-half-2025-2026"
   },
   "https://www.kasa-mara.jp/course/": {
     "hash": "ca0a4aaf52635de67eef12ad53cd9f71e754e7a033dfdfd195ba27e566a52f36",
-    "last_checked": "2026-07-27T14:05:03.252Z",
-    "race_id": "kasama-togeinosato-half-2025-2025"
+    "last_checked": "2026-07-31T14:25:32.432Z",
+    "race_id": "kasama-togeinosato-half-2025-2026"
   },
   "https://www.kasumigaura-marathon.jp/outline/": {
     "hash": "1f479d4161c530310c7d01bbb1acf2c3f147bd55a981523d0d022c167cff6131",
-    "last_checked": "2026-07-27T14:05:03.849Z",
+    "last_checked": "2026-07-31T14:25:33.220Z",
     "race_id": "kasumigaura-marathon-2026"
   },
   "https://www.kasumigaura-marathon.jp/access/": {
     "hash": "7a73df84d4d25b3c4b078ab10ed11145d094f883f3432cd4017840bc4aed10d8",
-    "last_checked": "2026-07-27T14:05:04.165Z",
+    "last_checked": "2026-07-31T14:25:33.827Z",
     "race_id": "kasumigaura-marathon-2026"
   },
   "https://www.kasumigaura-marathon.jp/course/": {
     "hash": "7a26d8bc432157870a2937a404adfc7b8863bd21094a6612f563bab8344320c8",
-    "last_checked": "2026-07-27T14:05:04.469Z",
+    "last_checked": "2026-07-31T14:25:34.433Z",
     "race_id": "kasumigaura-marathon-2026"
   },
   "https://www.kasumigaura-marathon.jp/entry/": {
     "hash": "3bb27b7b801b5bec3469eddaf3b210124709ce0abe15a8afa7a04d3f7357d6a2",
-    "last_checked": "2026-07-27T14:05:05.006Z",
+    "last_checked": "2026-07-31T14:25:34.964Z",
     "race_id": "kasumigaura-marathon-2026"
   },
   "https://www.kasumigaura-marathon.jp/faq/": {
     "hash": "ed80ca675ad7db58513e7aa64ab4e0479ad120a43615b2296e903f45c71ff0ab",
-    "last_checked": "2026-07-27T14:05:05.555Z",
+    "last_checked": "2026-07-31T14:25:35.514Z",
     "race_id": "kasumigaura-marathon-2026"
   },
   "https://katsutamarathon.jp/info/abbott/": {
     "hash": "0099aa7f010f9c4a7d3165c4de590e8b81da9b90369bb73aff492635c949dc50",
-    "last_checked": "2026-07-27T14:05:05.627Z",
+    "last_checked": "2026-07-31T14:25:36.294Z",
     "race_id": "katsuta-marathon-2026"
   },
   "https://katsutamarathon.jp/outline/": {
     "hash": "9af275615d3cfb49b64c74489a082aabb3574d7893fea486e247fe80bc8a3232",
-    "last_checked": "2026-07-27T14:05:05.643Z",
+    "last_checked": "2026-07-31T14:25:37.123Z",
     "race_id": "katsuta-marathon-2026"
   },
   "https://katsutamarathon.jp/entry/": {
     "hash": "81506c2122b5699287da98f29d042bff8b81d1502a721ebada63e6ce62114128",
-    "last_checked": "2026-07-27T14:05:05.656Z",
+    "last_checked": "2026-07-31T14:25:37.142Z",
     "race_id": "katsuta-marathon-2026"
   },
   "https://katsutamarathon.jp/course/": {
     "hash": "b6cf1944daaab596a5e80ca87718050b1cd6e003bd7df9dc77f1d2d28dbbc59f",
-    "last_checked": "2026-07-27T14:05:05.669Z",
+    "last_checked": "2026-07-31T14:25:37.183Z",
     "race_id": "katsuta-marathon-2026"
   },
   "https://kitakyushu-marathon.jp/about/": {
     "hash": "9d8f5dc185f4af5a6701a823e2b3a746e0e88565cd6ed18dacfab7332d2ebf50",
-    "last_checked": "2026-07-27T14:05:05.784Z",
+    "last_checked": "2026-07-31T14:25:37.267Z",
     "race_id": "kitakyushu-marathon-2026"
   },
   "https://kitakyushu-marathon.jp/course/": {
     "hash": "23357ccd751cfb987101de840ad1672ef089b8a8c4de62e65a8b3cabbe42f557",
-    "last_checked": "2026-07-27T14:05:06.042Z",
+    "last_checked": "2026-07-31T14:25:37.279Z",
     "race_id": "kitakyushu-marathon-2026"
   },
   "https://kitakyushu-marathon.jp/step/": {
     "hash": "c6b0a3e38ed295c3bf4989fe2b03db5d349c0137c7cb824601704eefc75efd82",
-    "last_checked": "2026-07-27T14:05:06.054Z",
+    "last_checked": "2026-07-31T14:25:37.289Z",
     "race_id": "kitakyushu-marathon-2026"
   },
   "https://kitakyushu-marathon.jp/access/": {
     "hash": "9bc7c71991d6f2bcecbcc94c3d3d4f7efb19ba373a6fe5bed510ff1e73c667f9",
-    "last_checked": "2026-07-27T14:05:06.743Z",
+    "last_checked": "2026-07-31T14:25:37.940Z",
     "race_id": "kitakyushu-marathon-2026"
   },
   "https://kitakyushu-marathon.jp/qa/": {
@@ -831,237 +831,237 @@
   },
   "http://www.senshu-marathon.jp/guidance/": {
     "hash": "5c0ac11e9602730c077fb11fd708e1e7fb499db74540e30990c529e55c98e0d0",
-    "last_checked": "2026-07-27T14:05:07.392Z",
+    "last_checked": "2026-07-31T14:25:38.711Z",
     "race_id": "kix-senshu-marathon-2026"
   },
   "http://www.senshu-marathon.jp/course/": {
     "hash": "953caa09fdead77e470b1f425b4f0f8deba73defbc34d5067b090fd2375cf53e",
-    "last_checked": "2026-07-27T14:05:07.718Z",
+    "last_checked": "2026-07-31T14:25:39.032Z",
     "race_id": "kix-senshu-marathon-2026"
   },
   "http://www.senshu-marathon.jp/access/": {
     "hash": "6f49540972eb159c0f03d6bdf1675229540632609030c81d37a24908eec04f12",
-    "last_checked": "2026-07-27T14:05:08.042Z",
+    "last_checked": "2026-07-31T14:25:39.361Z",
     "race_id": "kix-senshu-marathon-2026"
   },
   "http://www.senshu-marathon.jp/entry/": {
     "hash": "98c45e422ce4f851cf88540ddc8bdc21a9c8d2e093f00a692d83b18d59936d43",
-    "last_checked": "2026-07-27T14:05:08.380Z",
+    "last_checked": "2026-07-31T14:25:39.740Z",
     "race_id": "kix-senshu-marathon-2026"
   },
   "https://www.kobe-marathon.net/2026/faq/": {
     "hash": "18e1f914cdf221ced676c8c11cbcc1fdb357e5815bd8621ca973aa2984b90d5c",
-    "last_checked": "2026-07-27T14:05:08.506Z",
+    "last_checked": "2026-07-31T14:25:39.843Z",
     "race_id": "kobe-marathon-2026"
   },
   "https://www.kobe-marathon.net/2026/race/essentials/": {
     "hash": "0061281b6e4682889228b6260aee8e0e46c997530facd51a74d32c84e121e687",
-    "last_checked": "2026-07-27T14:05:08.583Z",
+    "last_checked": "2026-07-31T14:25:39.909Z",
     "race_id": "kobe-marathon-2026"
   },
   "https://www.kobe-marathon.net/2026/runner/entry/": {
     "hash": "7cb569bd13a44cd734a32a43db469bffef33327fd64db49df904dcbff1090b34",
-    "last_checked": "2026-07-27T14:05:08.596Z",
+    "last_checked": "2026-07-31T14:25:39.920Z",
     "race_id": "kobe-marathon-2026"
   },
   "https://www.kobe-marathon.net/2026/runner/course/": {
     "hash": "925be55f437160e4c97026a5b9dd37b1d3ea59f16ee537f3e0afc392a462a128",
-    "last_checked": "2026-07-27T14:05:08.608Z",
+    "last_checked": "2026-07-31T14:25:39.930Z",
     "race_id": "kobe-marathon-2026"
   },
   "https://www.kobe-marathon.net/2026/support/expo/expoinfo/": {
     "hash": "d756dd58f071c8c1b176a74dac7d3398eb376892f12573b1cc7250ef012e32b6",
-    "last_checked": "2026-07-27T14:05:08.619Z",
+    "last_checked": "2026-07-31T14:25:39.941Z",
     "race_id": "kobe-marathon-2026"
   },
   "https://ryoma-marathon.jp/outline/": {
     "hash": "7691cd1fba4eefcf4c01cee58439654558e6cf099dfdb3bd049b4f31071dfaad",
-    "last_checked": "2026-07-27T14:05:08.695Z",
+    "last_checked": "2026-07-31T14:25:40.682Z",
     "race_id": "kochi-ryoma-marathon-2027"
   },
   "https://ryoma-marathon.jp/entry/": {
-    "hash": "1636f9991c30603d1763425caf97781e83ef456de606122f7f40fc553979fb0e",
-    "last_checked": "2026-05-31T13:51:51.069Z",
-    "race_id": "kochi-ryoma-marathon-2026"
+    "hash": "b4986bc2904f668158812fee851aa5c46b1fc3db94e29af5c07ee14c045e7648",
+    "last_checked": "2026-07-31T14:25:40.698Z",
+    "race_id": "kochi-ryoma-marathon-2027"
   },
   "https://ryoma-marathon.jp/course/": {
     "hash": "fa136b96fdd9652da09ca1acbd2743474d7e3e7a20966894bb9d8dd30272e731",
-    "last_checked": "2026-07-27T14:05:08.744Z",
+    "last_checked": "2026-07-31T14:25:40.711Z",
     "race_id": "kochi-ryoma-marathon-2027"
   },
   "https://ryoma-marathon.jp/access/": {
     "hash": "dec69adf5b453e06521fb30ac6ab23b71d953eed0360efe7f4e29674ae3de90e",
-    "last_checked": "2026-07-27T14:05:08.757Z",
+    "last_checked": "2026-07-31T14:25:41.386Z",
     "race_id": "kochi-ryoma-marathon-2027"
   },
   "https://ryoma-marathon.jp/faq/": {
-    "hash": "f4cdec5ea4058a725228f2750d45d016422d9398637ce340b7a67cc50b374da8",
-    "last_checked": "2026-05-31T13:51:52.787Z",
-    "race_id": "kochi-ryoma-marathon-2026"
+    "hash": "ba823f98ab527684c2e18161e23ae0bd3eb6eef341d675bdba38dcf681d232e8",
+    "last_checked": "2026-07-31T14:25:41.401Z",
+    "race_id": "kochi-ryoma-marathon-2027"
   },
   "https://kumamotojyo-marathon.jp/outline.php": {
     "hash": "6a286d3e7ece314c2936cd7ee3d825435ac7bef03a6b6c0d6dcd889af29c7f8f",
-    "last_checked": "2026-07-27T14:05:08.888Z",
-    "race_id": "kumamoto-castle-marathon-2026"
+    "last_checked": "2026-07-31T14:25:41.550Z",
+    "race_id": "kumamoto-castle-marathon-2027"
   },
   "https://kumamotojyo-marathon.jp/course.php": {
     "hash": "32b2f0d3d5c2d09b641799b2275a5281623bafb6ae84f37b4b2ffb6585b4d0a2",
-    "last_checked": "2026-07-27T14:05:08.964Z",
-    "race_id": "kumamoto-castle-marathon-2026"
+    "last_checked": "2026-07-31T14:25:41.624Z",
+    "race_id": "kumamoto-castle-marathon-2027"
   },
   "https://kumamotojyo-marathon.jp/entry.php": {
     "hash": "29d9d16c03ec9ec0e701578528149f8d2aa7d2709b410046a2699efcf3d2ed98",
-    "last_checked": "2026-07-27T14:05:09.035Z",
-    "race_id": "kumamoto-castle-marathon-2026"
+    "last_checked": "2026-07-31T14:25:41.721Z",
+    "race_id": "kumamoto-castle-marathon-2027"
   },
   "https://kumamotojyo-marathon.jp/volunteer.php": {
     "hash": "14070f77d109160692163db2c92fbaa7ef20f91fda2de81637f9257eda19ae66",
-    "last_checked": "2026-07-27T14:05:09.110Z",
-    "race_id": "kumamoto-castle-marathon-2026"
+    "last_checked": "2026-07-31T14:25:41.790Z",
+    "race_id": "kumamoto-castle-marathon-2027"
   },
   "https://kumamotojyo-marathon.jp/traffic.php": {
     "hash": "053dd1c0feb6c15482bdaddc8dc41938a6724a4f0c9750f3b8efe8122c5c7772",
-    "last_checked": "2026-07-27T14:05:09.185Z",
-    "race_id": "kumamoto-castle-marathon-2026"
+    "last_checked": "2026-07-31T14:25:41.863Z",
+    "race_id": "kumamoto-castle-marathon-2027"
   },
   "https://kyoto-marathon.com/info/": {
     "hash": "63570c9ebee2a7b025cbd2f2713506720c66dabcdd3906f4027a1287483a6219",
-    "last_checked": "2026-07-27T14:05:09.355Z",
+    "last_checked": "2026-07-31T14:25:41.993Z",
     "race_id": "kyoto-marathon-2027"
   },
   "https://kyoto-marathon.com/info/course/": {
     "hash": "ba3f262a06da6733382839d1b1e183afede9922629ce4e29cccb5a2becff8a24",
-    "last_checked": "2026-07-27T14:05:09.366Z",
+    "last_checked": "2026-07-31T14:25:42.005Z",
     "race_id": "kyoto-marathon-2027"
   },
   "https://kyoto-marathon.com/info/concept/": {
     "hash": "26b48632325935d6b41ec007236943db2b72a773bb66a57160b2d2e51993b67d",
-    "last_checked": "2026-07-27T14:05:09.382Z",
+    "last_checked": "2026-07-31T14:25:42.025Z",
     "race_id": "kyoto-marathon-2027"
   },
   "https://kyoto-marathon.com/traffic/": {
     "hash": "e5050083720774363ca36f50c4e6171bf0fb9e4a128592ef125418267992e0b8",
-    "last_checked": "2026-07-27T14:05:09.393Z",
+    "last_checked": "2026-07-31T14:25:42.038Z",
     "race_id": "kyoto-marathon-2027"
   },
   "https://kyoto-marathon.com/faq/": {
     "hash": "55f6700e71ca8c3c40c33a72fc6bc25e967f8538257b8eca2dad69fcf40cea0e",
-    "last_checked": "2026-07-27T14:05:09.405Z",
+    "last_checked": "2026-07-31T14:25:42.053Z",
     "race_id": "kyoto-marathon-2027"
   },
   "https://mie-matsusaka-marathon.jp/essential/": {
-    "hash": "6e6caac9f32fb806e55ce3c54a843ab21e854b200d031fcfbde74b2e19547d64",
-    "last_checked": "2026-07-27T14:05:09.708Z",
+    "hash": "543b59e41f29438ebc7faf3f7d8d9d63eca94eec497d9c442e68004c637284a5",
+    "last_checked": "2026-07-31T14:25:42.382Z",
     "race_id": "mie-matsusaka-marathon-2026"
   },
   "https://mie-matsusaka-marathon.jp/course/": {
-    "hash": "4ec4cf6381c994a0cb9e35f72172c6c11fdd7c89911a7ae1242740c78e091612",
-    "last_checked": "2026-07-27T14:05:09.890Z",
+    "hash": "697d49e0c6aee2ec50bd0e5eb992f71b57f598a420e1bf1d60fa5b99501c2c7e",
+    "last_checked": "2026-07-31T14:25:42.845Z",
     "race_id": "mie-matsusaka-marathon-2026"
   },
   "https://mie-matsusaka-marathon.jp/charm/": {
-    "hash": "ff2ccb69c4a5511fc89aec75a0c894bf32a6506f75e726d22e4a1c1ea04151f2",
-    "last_checked": "2026-07-27T14:05:10.182Z",
+    "hash": "9a1d6e4297f46af27faad8685af8900799fbdeca0c92dda457d68d427c216910",
+    "last_checked": "2026-07-31T14:25:43.225Z",
     "race_id": "mie-matsusaka-marathon-2026"
   },
   "https://mie-matsusaka-marathon.jp/venue/": {
-    "hash": "5128576206824e06d57069b35e02538327dcab791b2703f01934985338bbe4a7",
-    "last_checked": "2026-07-27T14:05:10.419Z",
+    "hash": "9cbd7ce3cbe4031bac2716e030ce41a32eb52a46debc72f0608828176cf5f8ae",
+    "last_checked": "2026-07-31T14:25:43.558Z",
     "race_id": "mie-matsusaka-marathon-2026"
   },
   "https://mie-matsusaka-marathon.jp/runner/": {
-    "hash": "d00d0abd299fcaf5d3f8c0a1531e8b74e6a416750a61c26550f18186501c74bd",
-    "last_checked": "2026-07-27T14:05:10.659Z",
+    "hash": "6ac5e271f2c4de81fab3bc018cfa3139b1242e32c15dd88c6f1a7cb0d423b960",
+    "last_checked": "2026-07-31T14:25:43.916Z",
     "race_id": "mie-matsusaka-marathon-2026"
   },
   "https://www.mitokomon-manyu-marathon.com/about/index.html": {
     "hash": "e0322f2a516c3ee36a1c71c7d850a8db286b4201ffa7f5e0169c6dcfc0904038",
-    "last_checked": "2026-07-27T14:05:10.825Z",
+    "last_checked": "2026-07-31T14:25:44.226Z",
     "race_id": "mito-komon-manyu-marathon-2026"
   },
   "https://www.mitokomon-manyu-marathon.com/entry/index.html": {
     "hash": "2153be3ec47d479d7836d1f93143521ccb735fbcb85303fd7cb4cb4800bb98c2",
-    "last_checked": "2026-07-27T14:05:10.856Z",
+    "last_checked": "2026-07-31T14:25:44.258Z",
     "race_id": "mito-komon-manyu-marathon-2026"
   },
   "https://www.mitokomon-manyu-marathon.com/venue/index.html": {
     "hash": "138d28c4a5576c22579a728b921a407cbb925fd4eba98e14c3ed15602c1f2ee2",
-    "last_checked": "2026-07-27T14:05:10.888Z",
+    "last_checked": "2026-07-31T14:25:44.289Z",
     "race_id": "mito-komon-manyu-marathon-2026"
   },
   "https://www.mitokomon-manyu-marathon.com/venue/supply.html": {
     "hash": "9a980b43597ddd37393138e3797c82234e6d92573226a301451b6981dfc0fb16",
-    "last_checked": "2026-07-27T14:05:10.919Z",
+    "last_checked": "2026-07-31T14:25:44.319Z",
     "race_id": "mito-komon-manyu-marathon-2026"
   },
   "https://www.mitokomon-manyu-marathon.com/qa/index.html": {
     "hash": "333438ab58bb82f67f2d04386539c0e22939cadff91aa9878f1ee3a42a00b3a7",
-    "last_checked": "2026-07-27T14:05:10.950Z",
+    "last_checked": "2026-07-31T14:25:44.351Z",
     "race_id": "mito-komon-manyu-marathon-2026"
   },
   "https://mtfujiclimbrun.com/outline/": {
     "hash": "6518ef104b4ee24ff9de57698c1f26e75ae923318f74b0e90bad53b8137d3ce4",
-    "last_checked": "2026-07-27T14:05:11.102Z",
+    "last_checked": "2026-07-31T14:25:44.511Z",
     "race_id": "mtfuji-climb-run-2026"
   },
   "https://mtfujiclimbrun.com/entry/": {
     "hash": "ee412df38b1ebd4a291e6b43531599ad3ccc76af72ffc7c0974197ab55e2470a",
-    "last_checked": "2026-07-27T14:05:11.154Z",
+    "last_checked": "2026-07-31T14:25:44.559Z",
     "race_id": "mtfuji-climb-run-2026"
   },
   "https://mtfujiclimbrun.com/course/": {
     "hash": "a90c469339bb28024bfe42de49b583a7f3961a1440e278de562f9fc97fdd9aa2",
-    "last_checked": "2026-07-27T14:05:11.199Z",
+    "last_checked": "2026-07-31T14:25:44.611Z",
     "race_id": "mtfuji-climb-run-2026"
   },
   "https://mtfujiclimbrun.com/access/": {
-    "hash": "8620b12134b60c1a2a6ecb958580fb5026c1f96814fd0cd923e7ea6856eb3fb7",
-    "last_checked": "2026-07-27T14:05:11.246Z",
+    "hash": "0fcbcc81c9ec74f90a7f60a91c619879810638aecffe96d830d33bede07e454c",
+    "last_checked": "2026-07-31T14:25:44.658Z",
     "race_id": "mtfuji-climb-run-2026"
   },
   "https://mtfujiclimbrun.com/qa/": {
     "hash": "64cfec35516f89c29a8fb9491c6f662ca1d099e51115a8b0633d9f5c5c44f62f",
-    "last_checked": "2026-07-27T14:05:11.297Z",
+    "last_checked": "2026-07-31T14:25:44.707Z",
     "race_id": "mtfuji-climb-run-2026"
   },
   "https://nagai-marathon.jp/news-cat/infomartion/": {
     "hash": "c7ae0d3b85073f1c3480cb09030ab3d79f9979d0388c47de65125f7fb3d28a86",
-    "last_checked": "2026-07-27T14:05:14.971Z",
+    "last_checked": "2026-07-31T14:25:47.253Z",
     "race_id": "nagai-marathon-2026"
   },
   "https://nagai-marathon.jp/news/2026/402/": {
-    "hash": "4c03be4770b6ce370c4d401073fc3d0ea71631bcd462c8ddf25c0deef49e5bc5",
-    "last_checked": "2026-07-27T14:05:17.579Z",
+    "hash": "94b327bfce19f0c1f07198e1167807e803f881feecba96b064b18052963e8bc2",
+    "last_checked": "2026-07-31T14:25:49.228Z",
     "race_id": "nagai-marathon-2026"
   },
   "https://nagai-marathon.jp/wp/wp-content/themes/source_tcd045-child/pdf/nagaimararhon2026_yoko.pdf": {
     "hash": "1938ce85ae6df77df6ca317164b19d4e45ca2b44275d3d713d4142c93d5fbe97",
-    "last_checked": "2026-07-27T14:05:17.800Z",
+    "last_checked": "2026-07-31T14:25:49.518Z",
     "race_id": "nagai-marathon-2026"
   },
   "https://www.naganomarathon.gr.jp/information/": {
     "hash": "011e0f8077b6f9fdbec943ca44e3fe1a364faefe10fd21e2c8b97577012d37d6",
-    "last_checked": "2026-07-27T14:05:18.376Z",
+    "last_checked": "2026-07-31T14:25:49.823Z",
     "race_id": "nagano-marathon-2026"
   },
   "https://www.naganomarathon.gr.jp/information/course/": {
     "hash": "51eb789edc47152c37e9f72c6097cd696c1e186a64deaaf965192f1fe9098d70",
-    "last_checked": "2026-07-27T14:05:18.582Z",
+    "last_checked": "2026-07-31T14:25:50.019Z",
     "race_id": "nagano-marathon-2026"
   },
   "https://www.naganomarathon.gr.jp/entry/": {
     "hash": "9f131012d4a2f0b3a87abcb7dedefbf880afe3e1f038c6a31b2a88b14d240088",
-    "last_checked": "2026-07-27T14:05:18.778Z",
+    "last_checked": "2026-07-31T14:25:50.203Z",
     "race_id": "nagano-marathon-2026"
   },
   "https://www.naganomarathon.gr.jp/entrant/requirements/": {
     "hash": "a2e369f983c0009dd5bd7faa1d1c65db5792cfd0bfb1053c226f622f311497c2",
-    "last_checked": "2026-07-27T14:05:18.976Z",
+    "last_checked": "2026-07-31T14:25:50.389Z",
     "race_id": "nagano-marathon-2026"
   },
   "https://www.naganomarathon.gr.jp/stay/": {
     "hash": "303e2ad9e99c91054226adb505e792848e54f41589d1c56454eded37fd46e5f1",
-    "last_checked": "2026-07-27T14:05:19.186Z",
+    "last_checked": "2026-07-31T14:25:50.569Z",
     "race_id": "nagano-marathon-2026"
   },
   "https://womens-marathon.nagoya/en/outline/chinese1/": {
@@ -1071,202 +1071,202 @@
   },
   "https://womens-marathon.nagoya/outline/": {
     "hash": "e0f08e6c15e843aa30a84c1f34dea11fee94e04799dcfdf688e3e27ff033a805",
-    "last_checked": "2026-07-27T14:05:19.333Z",
+    "last_checked": "2026-07-31T14:25:50.781Z",
     "race_id": "nagoya-womens-marathon-2026"
   },
   "https://womens-marathon.nagoya/faq/": {
     "hash": "32eb96d8162ccb2c1d2b233daec0acd24939c1ec672be83e76160c705b76dd37",
-    "last_checked": "2026-07-27T14:05:19.385Z",
+    "last_checked": "2026-07-31T14:25:50.792Z",
     "race_id": "nagoya-womens-marathon-2026"
   },
   "https://womens-marathon.nagoya/entry/": {
     "hash": "5c9b14fade6516dc88977592530d082d7274aad92a8f18da0e355d8ad08bdc6a",
-    "last_checked": "2026-07-27T14:05:19.397Z",
+    "last_checked": "2026-07-31T14:25:50.800Z",
     "race_id": "nagoya-womens-marathon-2026"
   },
   "https://womens-marathon.nagoya/course/": {
     "hash": "74c6d4a7f398071ea8df5d631fc0e18eb30d3b94b38666b8f647b0e0d84ecb25",
-    "last_checked": "2026-07-27T14:05:19.408Z",
+    "last_checked": "2026-07-31T14:25:50.811Z",
     "race_id": "nagoya-womens-marathon-2026"
   },
   "https://naha-marathon.jp/info/": {
     "hash": "728dcbc98df2fd39c335adab52c465a8f36277c89018cb7c9fe253f5414f3cd0",
-    "last_checked": "2026-07-27T14:05:19.634Z",
+    "last_checked": "2026-07-31T14:25:51.050Z",
     "race_id": "naha-marathon-2026"
   },
   "https://naha-marathon.jp/entry/": {
     "hash": "847e130fbc4506e1f2e76536a2891f48b566cb57ebd1c0e0da7d71fba550c1fa",
-    "last_checked": "2026-07-27T14:05:19.739Z",
+    "last_checked": "2026-07-31T14:25:51.153Z",
     "race_id": "naha-marathon-2026"
   },
   "https://naha-marathon.jp/course/": {
     "hash": "6c6218cb3c09f3d0640d77ef37bf627557410df0e937f49fa71658fad3a6b07b",
-    "last_checked": "2026-07-27T14:05:19.846Z",
+    "last_checked": "2026-07-31T14:25:51.264Z",
     "race_id": "naha-marathon-2026"
   },
   "https://naha-marathon.jp/contact/": {
     "hash": "4b7c7d1da18e4d63f837fb8c2ed4c3cd3b4968f16d15abfecd5594c160abd106",
-    "last_checked": "2026-07-27T14:05:19.961Z",
+    "last_checked": "2026-07-31T14:25:51.393Z",
     "race_id": "naha-marathon-2026"
   },
   "https://www.nara-marathon.jp/guidelines.html": {
     "hash": "639981d71104f951d903254fdfb3b2e7c6d33d9643067385adf0d49968f89f6d",
-    "last_checked": "2026-07-27T14:05:20.033Z",
+    "last_checked": "2026-07-31T14:25:51.525Z",
     "race_id": "nara-marathon-2026"
   },
   "https://www.nara-marathon.jp/course.html": {
     "hash": "18715391d55e7960109b8e817586a32904b7057268ac4d304b05b97d1d12a575",
-    "last_checked": "2026-07-27T14:05:20.046Z",
+    "last_checked": "2026-07-31T14:25:51.541Z",
     "race_id": "nara-marathon-2026"
   },
   "https://www.nara-marathon.jp/access.html": {
     "hash": "d3d27945bd2d1fe70c0067be35254434f17fb73225da0ce07eeccd1f59204d44",
-    "last_checked": "2026-07-27T14:05:20.058Z",
+    "last_checked": "2026-07-31T14:25:51.553Z",
     "race_id": "nara-marathon-2026"
   },
   "https://www.nara-marathon.jp/qa.html": {
     "hash": "d8d7cca92aab32a54f80d72cf0de5af4f5b4113ccc7d8373a97d8ab2f81e259a",
-    "last_checked": "2026-07-27T14:05:20.076Z",
+    "last_checked": "2026-07-31T14:25:51.598Z",
     "race_id": "nara-marathon-2026"
   },
   "https://www.nara-marathon.jp/entry.html": {
     "hash": "029c7c662cec32f45062f6e57049e35300df032c71eeefa85184e2493a2c4b3c",
-    "last_checked": "2026-07-27T14:05:20.088Z",
+    "last_checked": "2026-07-31T14:25:51.609Z",
     "race_id": "nara-marathon-2026"
   },
   "https://runfes-niigata.com/requirements/": {
     "hash": "7402b1518c9dd8f527f93314aaae32a4ba2accbb8ebba6844f01e0784a26f7c4",
-    "last_checked": "2026-07-27T14:05:20.233Z",
+    "last_checked": "2026-07-31T14:25:51.792Z",
     "race_id": "niigata-city-marathon-2026"
   },
   "https://runfes-niigata.com/2026/05/19/%e3%80%8c%e3%83%95%e3%82%a1%e3%83%b3%e3%83%a9%e3%83%b3%e3%80%8d%e3%82%a8%e3%83%b3%e3%83%88%e3%83%aa%e3%83%bc%e7%b7%a0%e3%82%81%e5%88%87%e3%82%8a%e3%81%ae%e3%81%8a%e7%9f%a5%e3%82%89%e3%81%9b/": {
-    "hash": "b7cbbf5b72e26bfab6df4670c9477e6e582ee9f072be75c5e6cf852dc7feb0db",
-    "last_checked": "2026-07-27T14:05:20.302Z",
+    "hash": "bae0b4d1cfdfc8a96f76de6ab55cd449b2a2caadb3b251a88bf1b73d94f27d29",
+    "last_checked": "2026-07-31T14:25:51.914Z",
     "race_id": "niigata-city-marathon-2026"
   },
   "https://nishio-marathon.jp": {
     "hash": "38705db2cbcc286280f5f5404e8c43a8cee82eb7fb8cda08c180245c47198e73",
-    "last_checked": "2026-07-27T14:05:20.510Z",
+    "last_checked": "2026-07-31T14:25:53.507Z",
     "race_id": "nishio-marathon-2026"
   },
   "https://www.okayamamarathon.jp/event-information/guideline/": {
     "hash": "b7b43bc47a42b1f697c50cc7b9de44181d4fc0e3a13a1b440c97042571acff72",
-    "last_checked": "2026-07-27T14:05:21.688Z",
+    "last_checked": "2026-07-31T14:25:55.225Z",
     "race_id": "okayama-marathon-2026"
   },
   "https://www.okayamamarathon.jp/event-information/access/": {
     "hash": "e04f86583236b8e65ead3d551e60d5af0adbd466c45a7ef2a707bc4c7b764ed2",
-    "last_checked": "2026-07-27T14:05:21.853Z",
+    "last_checked": "2026-07-31T14:25:55.254Z",
     "race_id": "okayama-marathon-2026"
   },
   "https://www.okayamamarathon.jp/event-information/course/": {
     "hash": "0f96802ce83e8c512661d8fc007a578b65a4e9153256d54890e23c646c1d32ce",
-    "last_checked": "2026-07-27T14:05:21.878Z",
+    "last_checked": "2026-07-31T14:25:55.281Z",
     "race_id": "okayama-marathon-2026"
   },
   "https://www.okayamamarathon.jp/runner/entry/": {
     "hash": "0190e131022cd819a36386eef2ad9d532f0519c94b2d7beddd868b1236014c5c",
-    "last_checked": "2026-07-27T14:05:21.905Z",
+    "last_checked": "2026-07-31T14:25:55.333Z",
     "race_id": "okayama-marathon-2026"
   },
   "https://www.okayamamarathon.jp/faq/": {
     "hash": "7b738bd83f92dc94d4b2e3f4b8cc463d2d2483bb10bd2cbfbe895e3be9171bf2",
-    "last_checked": "2026-07-27T14:05:22.098Z",
+    "last_checked": "2026-07-31T14:25:55.521Z",
     "race_id": "okayama-marathon-2026"
   },
   "https://okushinano100.com/concept/": {
     "hash": "e0d258d0323d91a33bd17f27b12dea6c9c793b3e0ffcf9fb7e34f013ee072bf4",
-    "last_checked": "2026-07-27T14:05:22.177Z",
+    "last_checked": "2026-07-31T14:25:55.662Z",
     "race_id": "okushinano100-2026"
   },
   "https://okushinano100.com/coursemap/": {
     "hash": "bf765055dda4034652be0700f76372cea55129dd7741b941046cedfe0ab18e1b",
-    "last_checked": "2026-07-27T14:05:22.218Z",
+    "last_checked": "2026-07-31T14:25:55.702Z",
     "race_id": "okushinano100-2026"
   },
   "https://okushinano100.com/access/": {
     "hash": "9808349de7f90e60a8a45bf536f18a1c7b167571f0f99d08417e84bc77e9d16c",
-    "last_checked": "2026-07-27T14:05:22.236Z",
+    "last_checked": "2026-07-31T14:25:55.725Z",
     "race_id": "okushinano100-2026"
   },
   "https://okushinano100.com/faq/": {
     "hash": "481cb1770f91bf5e19bf8eebc41744d24f8908d8ae993606e01049c56694d20b",
-    "last_checked": "2026-07-27T14:05:22.258Z",
+    "last_checked": "2026-07-31T14:25:55.917Z",
     "race_id": "okushinano100-2026"
   },
   "https://okushinano100.com/entry/": {
     "hash": "3184fb076fe86d7bad5411f975ff36f7ab06a68736287163e3f3314a22ecee26",
-    "last_checked": "2026-07-27T14:05:22.502Z",
+    "last_checked": "2026-07-31T14:25:55.942Z",
     "race_id": "okushinano100-2026"
   },
   "https://www.osaka-marathon.com/2026/info/gist/": {
     "hash": "33f0001647e867edaf5b93c99654db3c28a1c05ed83c02e9439f5510ef35cee7",
-    "last_checked": "2026-07-27T14:05:22.673Z",
+    "last_checked": "2026-07-31T14:25:56.133Z",
     "race_id": "osaka-marathon-2026"
   },
   "https://www.osaka-marathon.com/2026/info/sponsor/": {
     "hash": "e771e0f5a2d27646b9cafcdd64a8a1086e12ef14a98b56f25962085e6f298e13",
-    "last_checked": "2026-07-27T14:05:22.792Z",
+    "last_checked": "2026-07-31T14:25:56.230Z",
     "race_id": "osaka-marathon-2026"
   },
   "https://www.osaka-marathon.com/2026/info/course/": {
     "hash": "a0a91f8f6cb5bc88fc6976abf5cc16e4041b31420c92cfbd4f9002e0742dba19",
-    "last_checked": "2026-07-27T14:05:22.851Z",
+    "last_checked": "2026-07-31T14:25:56.286Z",
     "race_id": "osaka-marathon-2026"
   },
   "https://www.osaka-marathon.com/2026/runner/entry/": {
     "hash": "97588ad876f3bf2facf4d2329e03d8e04d4039624ae2be792776d2e791a90f88",
-    "last_checked": "2026-07-27T14:05:22.923Z",
+    "last_checked": "2026-07-31T14:25:56.366Z",
     "race_id": "osaka-marathon-2026"
   },
   "https://www.osaka-marathon.com/2026/expo/outline/": {
     "hash": "4d1bb8d513d5d668ea2b2910f59160635e29239a7e16170023d0875f666e53fd",
-    "last_checked": "2026-07-27T14:05:22.988Z",
+    "last_checked": "2026-07-31T14:25:56.475Z",
     "race_id": "osaka-marathon-2026"
   },
   "https://www.osaka42195.com/category/info/": {
-    "hash": "91f08e96c7f86e8b5b851509ef9f0741e665f1e8c50683a8ae1e779f4a557b94",
-    "last_checked": "2026-07-27T14:05:23.153Z",
+    "hash": "1ebe09bfed0215b89479ed30f3a26b93009821bb5abd3129287241168144af34",
+    "last_checked": "2026-07-31T14:25:57.428Z",
     "race_id": "osaka-yodo-river-citizens-marathon-2026"
   },
   "https://www.osaka42195.com/category/traffic/": {
-    "hash": "f6a0792ca248e2db60ee52031b8a654413e8dcaecc5db570643a4ffee79a8c7c",
-    "last_checked": "2026-07-27T14:05:23.258Z",
+    "hash": "229d524b19d59511682a20fb881b57a015263d077a62f5dcd959bac6b4b4d5a0",
+    "last_checked": "2026-07-31T14:25:57.694Z",
     "race_id": "osaka-yodo-river-citizens-marathon-2026"
   },
   "https://www.osaka42195.com/event/about/": {
-    "hash": "3be2bed66a0b5afd8ed0fcac63f20c399edf4f19b285f6e05d9a486d9c13d67b",
-    "last_checked": "2026-07-27T14:05:23.402Z",
+    "hash": "f65b5f3de61be3f78833de14dcc7d65f27d96ea7d197b2cc529829cb158324d9",
+    "last_checked": "2026-07-31T14:25:57.868Z",
     "race_id": "osaka-yodo-river-citizens-marathon-2026"
   },
   "https://www.osaka42195.com/event/couse/": {
-    "hash": "52eef3e790714c118ac80d46111d3662bf5d40d85dbe85a23a4f5022b335bd30",
-    "last_checked": "2026-07-27T14:05:23.454Z",
+    "hash": "8281a91db69f91219b8a8342ce5a6d4546f4808615cfb58c33a5f4f7d224ade2",
+    "last_checked": "2026-07-31T14:25:58.955Z",
     "race_id": "osaka-yodo-river-citizens-marathon-2026"
   },
   "https://www.osaka42195.com/runner/entry/": {
-    "hash": "8958915183f9d91f079eefcc380c29417cedd96dfd91509f39d4dbf793dd9046",
-    "last_checked": "2026-07-27T14:05:23.498Z",
+    "hash": "f8ee595b560df191f01244459082cb5fd133589cde1dedfcace6dc0af3a4b1d2",
+    "last_checked": "2026-07-31T14:25:59.019Z",
     "race_id": "osaka-yodo-river-citizens-marathon-2026"
   },
   "https://www.outdoorsportsjapan.com/trail/ontake100/race-ontake100/": {
     "hash": "9a30051c859ffdd00c78dc0fc3c3544e145da49167b3822fbe3bb50ea48aa91e",
-    "last_checked": "2026-07-27T14:05:24.083Z",
+    "last_checked": "2026-07-31T14:25:59.649Z",
     "race_id": "osj-ontake100-2026"
   },
   "https://www.outdoorsportsjapan.com/trail/ontake100/course-ontake100/": {
     "hash": "25828d62485dd28e48a8b394179196b316302793b9a9dc9dedaea3ad3de52f74",
-    "last_checked": "2026-07-27T14:05:24.543Z",
+    "last_checked": "2026-07-31T14:26:00.121Z",
     "race_id": "osj-ontake100-2026"
   },
   "https://www.outdoorsportsjapan.com/trail/ontake100/access-ontake100/": {
     "hash": "6acf0fff17076e98028d5752d4744daa0b8f90b161c80e993aa1dbf23252a90b",
-    "last_checked": "2026-07-27T14:05:25.035Z",
+    "last_checked": "2026-07-31T14:26:00.648Z",
     "race_id": "osj-ontake100-2026"
   },
   "https://www.outdoorsportsjapan.com/trail/ontake100/entry-list-ontake100/": {
     "hash": "ae75fc2d7b4794e50af145477c3d6dec7ec31ff98f04c632a30ee12f37ebaabc",
-    "last_checked": "2026-07-27T14:05:25.562Z",
+    "last_checked": "2026-07-31T14:26:01.172Z",
     "race_id": "osj-ontake100-2026"
   },
   "https://sagasakura-marathon.jp/outline/": {
@@ -1295,33 +1295,33 @@
     "race_id": "saga-sakura-marathon-2026"
   },
   "https://saitama-marathon.jp/about/": {
-    "hash": "27726560d6f8c8d95481b41de22ad0ffe0a0a392805d560fe8bbc0d8a3bde08b",
-    "last_checked": "2026-07-27T14:05:28.393Z",
+    "hash": "256748b114dfa275e8a7958c6e49d19731ae6eeb8de8dc75c9c2fd6be431eb91",
+    "last_checked": "2026-07-31T14:26:03.465Z",
     "race_id": "saitama-marathon-2027"
   },
   "https://saitama-marathon.jp/about/guest/": {
-    "hash": "a7345acce3c4ba85a6c7eb2d63e3d7674b3b405daeb2a591c15a669fb86ecd2e",
-    "last_checked": "2026-07-27T14:05:29.149Z",
+    "hash": "aabb057f9fb59e408ae9e6db66fa4c891d18b913675454989fc16889184824d6",
+    "last_checked": "2026-07-31T14:26:04.100Z",
     "race_id": "saitama-marathon-2027"
   },
   "https://saitama-marathon.jp/about/map/": {
-    "hash": "ce3a450002490728ba13af1fef9c0cdfba12574e2f2ff0ab750f88b16f0089c1",
-    "last_checked": "2026-07-27T14:05:29.903Z",
+    "hash": "024832cfef0a6b213dfbc7e52889d8e5a7cdca3411462f4a8ffb5cd15c5cf6d6",
+    "last_checked": "2026-07-31T14:26:04.713Z",
     "race_id": "saitama-marathon-2027"
   },
   "https://saitama-marathon.jp/entry/": {
-    "hash": "ed33837417fb92a663afbc34f21ce4ca773a138b22d7a6a7cefcfb136ac2108b",
-    "last_checked": "2026-07-27T14:05:30.634Z",
+    "hash": "233a2192c36e85734582573613426110d3653eb589da04db2c94ec128c3846b7",
+    "last_checked": "2026-07-31T14:26:05.370Z",
     "race_id": "saitama-marathon-2027"
   },
   "https://satumara.sapporo-sport.jp/outline.html": {
-    "hash": "1f9cb65fe7f32caaf31f037a1a451c7b05585591b66930d4f7a906c07248c5d9",
-    "last_checked": "2026-07-27T14:05:30.728Z",
+    "hash": "86fb9c628327c6280f031c047d0118c704e5759acd039d6c17ed015e793b6cb5",
+    "last_checked": "2026-07-31T14:26:05.587Z",
     "race_id": "sapporo-marathon-2026"
   },
   "https://satumara.sapporo-sport.jp/entry.html": {
     "hash": "3650c27ba3eac6c5e0209faaa237f82b441544c2f2a9514b47f14c3071a68111",
-    "last_checked": "2026-07-27T14:05:30.743Z",
+    "last_checked": "2026-07-31T14:26:05.637Z",
     "race_id": "sapporo-marathon-2026"
   },
   "https://satumara.sapporo-sport.jp/course.html": {
@@ -1331,72 +1331,72 @@
   },
   "https://satumara.sapporo-sport.jp/access.html": {
     "hash": "035282e4c28ede9ddd982bf845a42f5c3125cf0312d970b900a99a19f7baa6bc",
-    "last_checked": "2026-07-27T14:05:30.767Z",
+    "last_checked": "2026-07-31T14:26:05.738Z",
     "race_id": "sapporo-marathon-2026"
   },
   "https://satumara.sapporo-sport.jp/faq.html": {
     "hash": "374aa96105fce77eea7dad6e7ae4c6a7f6dc28f580a9493e3199e1382a4282b9",
-    "last_checked": "2026-07-27T14:05:30.780Z",
+    "last_checked": "2026-07-31T14:26:05.807Z",
     "race_id": "sapporo-marathon-2026"
   },
   "https://www.nature-scene.net/shiga100/concept/": {
     "hash": "f7dd772c5571530f47c34ed1a1b9d6c952ba62439cd9712ac63c808f535817bd",
-    "last_checked": "2026-07-27T14:05:30.896Z",
+    "last_checked": "2026-07-31T14:26:05.924Z",
     "race_id": "shiga-kogen100-2026"
   },
   "https://www.nature-scene.net/shiga100/coursemap/": {
     "hash": "83f928cdf86915803f809c2d0567a8c3c7c7b0454b3a652496956b0008f81569",
-    "last_checked": "2026-07-27T14:05:30.984Z",
+    "last_checked": "2026-07-31T14:26:06.012Z",
     "race_id": "shiga-kogen100-2026"
   },
   "https://www.nature-scene.net/shiga100/entry/": {
     "hash": "1e00b8f07e512288ab4996657aabcd90ab1ce3f4f8ec3e406b3f78fa8042b308",
-    "last_checked": "2026-07-27T14:05:31.031Z",
+    "last_checked": "2026-07-31T14:26:06.080Z",
     "race_id": "shiga-kogen100-2026"
   },
   "https://www.shimada-marathon.jp/m-information/course.html": {
     "hash": "0d6e07f07d44d95f920dc9cc12682dfefebb7e9b63d283498cc49eb00aa45ad5",
-    "last_checked": "2026-07-27T14:05:31.155Z",
+    "last_checked": "2026-07-31T14:26:06.251Z",
     "race_id": "shimada-oigawa-marathon-2026"
   },
   "https://www.shimada-marathon.jp/entry.html": {
     "hash": "637c5c2648b98a41ae3caedc1c4e8803bc4cea45ea5e776585b12462aa441c3e",
-    "last_checked": "2026-07-27T14:05:31.191Z",
+    "last_checked": "2026-07-31T14:26:06.282Z",
     "race_id": "shimada-oigawa-marathon-2026"
   },
   "https://www.shimada-marathon.jp/access.html": {
     "hash": "85f00455b40002189ca89bc14c43b7c14e81a30097ed4d4c79a3aabbd05f98db",
-    "last_checked": "2026-07-27T14:05:31.223Z",
+    "last_checked": "2026-07-31T14:26:06.412Z",
     "race_id": "shimada-oigawa-marathon-2026"
   },
   "https://www.shimada-marathon.jp/faq.html": {
     "hash": "ba844b07d52e1fd2815868a03d975b56f3a758ad2a32c695253eacc9109f893f",
-    "last_checked": "2026-07-27T14:05:31.259Z",
+    "last_checked": "2026-07-31T14:26:06.549Z",
     "race_id": "shimada-oigawa-marathon-2026"
   },
   "https://sfmt100.com/about-shinetsu/": {
     "hash": "125298f93fed9cef622f2b9a008e1d3b2d87f2b3f97b5eb68cc5807f64cf67b3",
-    "last_checked": "2026-07-27T14:05:31.461Z",
+    "last_checked": "2026-07-31T14:26:06.813Z",
     "race_id": "shinetsu5mountains-trail-100-2026"
   },
   "https://sfmt100.com/access/": {
     "hash": "3a13709290275e8f8034142e919ce7411f5b25f8c8b693017b185455f4a42492",
-    "last_checked": "2026-07-27T14:05:31.565Z",
+    "last_checked": "2026-07-31T14:26:06.911Z",
     "race_id": "shinetsu5mountains-trail-100-2026"
   },
   "https://sfmt100.com/about/outline/": {
     "hash": "5469a2c13a3d33651eee0a167782ded8d690929f688b99649883d8ce5c0c71bb",
-    "last_checked": "2026-07-27T14:05:31.676Z",
+    "last_checked": "2026-07-31T14:26:07.023Z",
     "race_id": "shinetsu5mountains-trail-100-2026"
   },
   "https://sfmt100.com/about/entry/": {
     "hash": "631d49b450599cf5b61f174dfd3d583ed3120027e6285b7f16c7cda2548d47df",
-    "last_checked": "2026-07-27T14:05:31.781Z",
+    "last_checked": "2026-07-31T14:26:07.128Z",
     "race_id": "shinetsu5mountains-trail-100-2026"
   },
   "https://sfmt100.com/map/": {
     "hash": "7a156309f239ef68a43c53fbdeafef3850815a71b23b963053dc5ac463dbe28c",
-    "last_checked": "2026-07-27T14:05:31.882Z",
+    "last_checked": "2026-07-31T14:26:07.230Z",
     "race_id": "shinetsu5mountains-trail-100-2026"
   },
   "https://www.shizuoka-marathon.com/2026/info": {
@@ -1426,53 +1426,53 @@
   },
   "https://www.shonan-kokusai.jp/entry/": {
     "hash": "8d36a2bac25f94c1c7abcd98c8abb17d424070dda03fe01a058ff3751f3c12d8",
-    "last_checked": "2026-07-27T14:05:33.087Z",
+    "last_checked": "2026-07-31T14:26:08.665Z",
     "race_id": "shonan-international-marathon-2026"
   },
   "https://www.shonan-kokusai.jp/outline/": {
     "hash": "461673a685fd113295168a1e00b684ddec524688fef0eec0647bdc9ff6dc4e77",
-    "last_checked": "2026-07-27T14:05:33.144Z",
+    "last_checked": "2026-07-31T14:26:08.825Z",
     "race_id": "shonan-international-marathon-2026"
   },
   "https://www.shonan-kokusai.jp/access/": {
     "hash": "4607b5daf6aa08310112a60cb497ea2c41aefc497dacabbf5bd13eb173d3263c",
-    "last_checked": "2026-07-27T14:05:33.287Z",
+    "last_checked": "2026-07-31T14:26:08.998Z",
     "race_id": "shonan-international-marathon-2026"
   },
   "https://www.shonan-kokusai.jp/course/": {
     "hash": "4460657d8b5ae89194704de42d8097200590e327114554394293fffa03d56b5d",
-    "last_checked": "2026-07-27T14:05:33.457Z",
+    "last_checked": "2026-07-31T14:26:09.019Z",
     "race_id": "shonan-international-marathon-2026"
   },
   "https://www.shonan-kokusai.jp/faq/": {
     "hash": "875c7780a6dddea6cdca5e91366b4a68d1906e274ae16416df64e5c14072bae5",
-    "last_checked": "2026-07-27T14:05:33.573Z",
+    "last_checked": "2026-07-31T14:26:09.131Z",
     "race_id": "shonan-international-marathon-2026"
   },
   "https://soja-kibijimarathon.jp/wp/event-details/": {
     "hash": "19fb9e58ac07a6b0a282633ac1538774c3e9dca236789763bb3c9553a55da15b",
-    "last_checked": "2026-07-27T14:05:34.114Z",
-    "race_id": "soja-kibiji-marathon-2026"
+    "last_checked": "2026-07-31T14:26:09.595Z",
+    "race_id": "soja-kibiji-marathon-2027"
   },
   "https://soja-kibijimarathon.jp/wp/course/": {
     "hash": "f33fe5dcebf4414c781a11775b175d980ba9fe263d495f79062bfdfcb48b28a0",
-    "last_checked": "2026-07-27T14:05:34.675Z",
-    "race_id": "soja-kibiji-marathon-2026"
+    "last_checked": "2026-07-31T14:26:10.043Z",
+    "race_id": "soja-kibiji-marathon-2027"
   },
   "https://soja-kibijimarathon.jp/wp/entry/": {
     "hash": "f33fe5dcebf4414c781a11775b175d980ba9fe263d495f79062bfdfcb48b28a0",
-    "last_checked": "2026-07-27T14:05:35.162Z",
-    "race_id": "soja-kibiji-marathon-2026"
+    "last_checked": "2026-07-31T14:26:10.496Z",
+    "race_id": "soja-kibiji-marathon-2027"
   },
   "https://soja-kibijimarathon.jp/wp/qa/": {
     "hash": "4c8a0adf65a13ce781b66b72144f86df4830f5e2ff8a59e291e4fc5d736da3ec",
-    "last_checked": "2026-07-27T14:05:35.553Z",
-    "race_id": "soja-kibiji-marathon-2026"
+    "last_checked": "2026-07-31T14:26:10.859Z",
+    "race_id": "soja-kibiji-marathon-2027"
   },
   "https://soja-kibijimarathon.jp/wp/access/": {
     "hash": "27e07e45811ec9d55055e9f56161a9a0f15964fc272dcdbb6034f236a82d5ad1",
-    "last_checked": "2026-07-27T14:05:35.940Z",
-    "race_id": "soja-kibiji-marathon-2026"
+    "last_checked": "2026-07-31T14:26:11.211Z",
+    "race_id": "soja-kibiji-marathon-2027"
   },
   "https://tambasasayama-abc-marathon.jp/outline/": {
     "hash": "176947ebdda404c3c18c74d58c1440cef1bf4aeeb5a71a4bea5b2dce5e97db81",
@@ -1496,197 +1496,197 @@
   },
   "https://tateyama-wakasio.jp/outline/": {
     "hash": "fe46356565add6c88c181cb01d5124f0cef5a0a62de81a76139f7019a9630eea",
-    "last_checked": "2026-07-27T14:05:36.935Z",
+    "last_checked": "2026-07-31T14:26:12.525Z",
     "race_id": "tateyama-wakashio-2026"
   },
   "https://tateyama-wakasio.jp/course/": {
     "hash": "d8fd69ddb615417018e88d0c195189c2d43491a1c9fe21608122ef84f8cf96fb",
-    "last_checked": "2026-07-27T14:05:36.985Z",
+    "last_checked": "2026-07-31T14:26:12.585Z",
     "race_id": "tateyama-wakashio-2026"
   },
   "https://tateyama-wakasio.jp/entry/": {
     "hash": "2e1051f06670c87d065281490fad61ebd5e0a7291e0e71d93ff20d5c255ac1c9",
-    "last_checked": "2026-07-27T14:05:37.036Z",
+    "last_checked": "2026-07-31T14:26:12.635Z",
     "race_id": "tateyama-wakashio-2026"
   },
   "https://tateyama-wakasio.jp/faq/": {
     "hash": "d39b8637a06a2f2b012cf05895161da7e95d00abd68c30514f1be37e3b809d7a",
-    "last_checked": "2026-07-27T14:05:37.087Z",
+    "last_checked": "2026-07-31T14:26:12.686Z",
     "race_id": "tateyama-wakashio-2026"
   },
   "https://tazawako-marathon.com/info/": {
     "hash": "5c6a64a767f3531f93c9d5dbf51f0a06df5011d2c0b414ee168be054b41cee88",
-    "last_checked": "2026-07-27T14:05:37.196Z",
+    "last_checked": "2026-07-31T14:26:12.831Z",
     "race_id": "tazawako-marathon-2026"
   },
   "https://tazawako-marathon.com/track/": {
     "hash": "fbf506f30667799be4fc0e92a164fe27204480daf0bcb54833273ad8513d1875",
-    "last_checked": "2026-07-27T14:05:37.213Z",
+    "last_checked": "2026-07-31T14:26:12.850Z",
     "race_id": "tazawako-marathon-2026"
   },
   "https://tazawako-marathon.com/concept/": {
     "hash": "2e211f42f118de4effc53d67d99ed041791997d1d51c369b8c5cea79910e2b03",
-    "last_checked": "2026-07-27T14:05:37.228Z",
+    "last_checked": "2026-07-31T14:26:12.868Z",
     "race_id": "tazawako-marathon-2026"
   },
   "https://tazawako-marathon.com/question/": {
     "hash": "a4b671289ae3e557936a1390cf51c4fbda1a47dc35ac125543e07d1196437914",
-    "last_checked": "2026-07-27T14:05:37.247Z",
+    "last_checked": "2026-07-31T14:26:12.886Z",
     "race_id": "tazawako-marathon-2026"
   },
   "https://tazawako-marathon.com/entry/": {
     "hash": "2b45223e6ea89491a9d9da8f14c2087fb29c18c761cda60818c06cc6f40fd54d",
-    "last_checked": "2026-07-27T14:05:37.264Z",
+    "last_checked": "2026-07-31T14:26:12.903Z",
     "race_id": "tazawako-marathon-2026"
   },
   "https://www.tokushima-marathon.jp/info/": {
     "hash": "d640a96739f16d8cccca5d8c44043383bc2cf21a1815f4828993de79bac0563a",
-    "last_checked": "2026-07-27T14:05:37.377Z",
+    "last_checked": "2026-07-31T14:26:13.021Z",
     "race_id": "tokushima-marathon-2026"
   },
   "https://www.tokushima-marathon.jp/info/course.html": {
     "hash": "bfb8da0d0b20b069626904436e7cd902ac4cf1b4ca0c384def7786bedc293515",
-    "last_checked": "2026-07-27T14:05:37.681Z",
+    "last_checked": "2026-07-31T14:26:13.251Z",
     "race_id": "tokushima-marathon-2026"
   },
   "https://www.tokushima-marathon.jp/info/guest.html": {
     "hash": "30d2f36d9315c9aee93e5f58bbc0c77724a4ebb53e78c8416ea9d3436870b51d",
-    "last_checked": "2026-07-27T14:05:37.734Z",
+    "last_checked": "2026-07-31T14:26:13.313Z",
     "race_id": "tokushima-marathon-2026"
   },
   "https://www.tokushima-marathon.jp/join/entry.html": {
     "hash": "c029dbde773166f9a203f6d840954b00968014d70ecdddbd6f2a067d2238469e",
-    "last_checked": "2026-07-27T14:05:37.913Z",
+    "last_checked": "2026-07-31T14:26:13.520Z",
     "race_id": "tokushima-marathon-2026"
   },
   "https://www.tokushima-marathon.jp/regulation/": {
     "hash": "c5fdd6254250c413c38c0800b8e47fecf586b5b2360e87783048446520cad58c",
-    "last_checked": "2026-07-27T14:05:37.963Z",
+    "last_checked": "2026-07-31T14:26:13.573Z",
     "race_id": "tokushima-marathon-2026"
   },
   "https://legacyhalf.tokyo/volunteer/index.html": {
     "hash": "33f2a4ddc1f1ff5dd654a5503652560a37f2e346069293c27ebd7e3c55481f6f",
-    "last_checked": "2026-07-27T14:05:38.063Z",
+    "last_checked": "2026-07-31T14:26:13.774Z",
     "race_id": "tokyo-legacy-half-2026"
   },
   "https://legacyhalf.tokyo/about/main-visual/index.html": {
     "hash": "610f81fc7778168608f815de743bc5168feb39be160869a4b0bfeafdd9c49749",
-    "last_checked": "2026-07-27T14:05:38.150Z",
+    "last_checked": "2026-07-31T14:26:13.846Z",
     "race_id": "tokyo-legacy-half-2026"
   },
   "https://legacyhalf.tokyo/news/detail/news_0248.html": {
     "hash": "9e837ebdb5a88cf1cbef114c3fcaeb7d0cc47d1f7a5849e17eb7d18470839d5d",
-    "last_checked": "2026-07-27T14:05:38.228Z",
+    "last_checked": "2026-07-31T14:26:13.936Z",
     "race_id": "tokyo-legacy-half-2026"
   },
   "https://www.marathon.tokyo/volunteer/about/": {
-    "hash": "5571631b82ff8f559ea381761dadcae113437fced4d1b86fc49385b7e9821aca",
-    "last_checked": "2026-07-27T14:05:38.442Z",
+    "hash": "3c0602c0f5bc747ecc4aa00108413770081a6ccab2756b8c56b2edb7fdfe5bbd",
+    "last_checked": "2026-07-31T14:26:14.027Z",
     "race_id": "tokyo-marathon-2027"
   },
   "https://www.marathon.tokyo/faq/": {
-    "hash": "314a443e94248e91cd20743cb1e8ba4e2ece9dfa57c4a3bdd67aced6b8513acc",
-    "last_checked": "2026-07-27T14:05:38.460Z",
+    "hash": "31127d4f1b4b1cad04b62adc3d8be63f7e1605ab2b0c20293cc504b3768f3fa5",
+    "last_checked": "2026-07-31T14:26:14.042Z",
     "race_id": "tokyo-marathon-2027"
   },
   "https://www.marathon.tokyo/about/outline/": {
-    "hash": "8e56697169dca51df03d3fd60696fca58ecbde090d32e594da74f49151fa749e",
-    "last_checked": "2026-07-27T14:05:38.473Z",
+    "hash": "32994e45c9993234fd14c657f6548568efe62939f826c9648cc0e1b1132e8a42",
+    "last_checked": "2026-07-31T14:26:14.054Z",
     "race_id": "tokyo-marathon-2027"
   },
   "https://www.marathon.tokyo/about/course/": {
-    "hash": "6ca5cdb2b851c13454c05f8f094c84503c75d4102d3c31a4c3d3ffd2d4093468",
-    "last_checked": "2026-07-27T14:05:38.486Z",
+    "hash": "f7230084d03c3f48ba8ee5490df35df791764f154ab6af973f2036b954e944e1",
+    "last_checked": "2026-07-31T14:26:14.068Z",
     "race_id": "tokyo-marathon-2027"
   },
   "https://www.marathon.tokyo/participants/": {
-    "hash": "aa03e818b0c057bfe4e69b157e40d0ae21635fd4ee83a8c77db2d4cf82aab460",
-    "last_checked": "2026-07-27T14:05:38.498Z",
+    "hash": "37b4b88ad341cb5486dbdb7f3b3dbd4da7f95498fd1e89fb0cbb0c70395e857a",
+    "last_checked": "2026-07-31T14:26:14.080Z",
     "race_id": "tokyo-marathon-2027"
   },
   "https://tomisato-suikaroad.jp/outline/": {
     "hash": "ace1081f6b732f8b70248db8c24f8a87a97dc9b425400b05ad41ee81e2b7f35c",
-    "last_checked": "2026-07-27T14:05:39.055Z",
+    "last_checked": "2026-07-31T14:26:14.629Z",
     "race_id": "tomisato-suikaroad-2026"
   },
   "https://tomisato-suikaroad.jp/course/": {
     "hash": "3715b631ace36e417111c8bb11fec39cae0179e8c40f41d639717c7f7cd86a81",
-    "last_checked": "2026-07-27T14:05:39.211Z",
+    "last_checked": "2026-07-31T14:26:15.026Z",
     "race_id": "tomisato-suikaroad-2026"
   },
   "https://tomisato-suikaroad.jp/entry/": {
     "hash": "a328785bc60851de83bc7368253a0482812561a7b0488a9f54e82094d9bc5fe6",
-    "last_checked": "2026-07-27T14:05:39.356Z",
+    "last_checked": "2026-07-31T14:26:15.207Z",
     "race_id": "tomisato-suikaroad-2026"
   },
   "https://tomisato-suikaroad.jp/mycapinfo/": {
     "hash": "d9f1421e8005e87e25b59fe4646f94b72a4d1bbad099f474de63f343b5fb8dff",
-    "last_checked": "2026-07-27T14:05:39.504Z",
+    "last_checked": "2026-07-31T14:26:15.359Z",
     "race_id": "tomisato-suikaroad-2026"
   },
   "https://tomisato-suikaroad.jp/archives/770/": {
     "hash": "aa947394b75f598257c81fc9061f8bcac8b9bd904498f665a7613a1facb713d1",
-    "last_checked": "2026-07-27T14:05:39.651Z",
+    "last_checked": "2026-07-31T14:26:15.536Z",
     "race_id": "tomisato-suikaroad-2026"
   },
   "https://tottori-marathon.jp/about/": {
     "hash": "422987f6177a0c01e7f54bf6c37a1e753d6a859eeeb6171764f1ed813ed94ba2",
-    "last_checked": "2026-07-27T14:05:39.879Z",
+    "last_checked": "2026-07-31T14:26:15.745Z",
     "race_id": "tottori-marathon-2026"
   },
   "https://tottori-marathon.jp/course/": {
     "hash": "128018a29b74c3a846d065276e9ecc4b8606abce9ee747ff25ab853675ab1409",
-    "last_checked": "2026-07-27T14:05:40.041Z",
+    "last_checked": "2026-07-31T14:26:15.921Z",
     "race_id": "tottori-marathon-2026"
   },
   "https://tottori-marathon.jp/access/": {
     "hash": "b08bee856b5be4eb9100542912c4bc087d74d65e8e1204041a41ee08e6760e7a",
-    "last_checked": "2026-07-27T14:05:40.166Z",
+    "last_checked": "2026-07-31T14:26:16.037Z",
     "race_id": "tottori-marathon-2026"
   },
   "https://tottori-marathon.jp/faq/": {
     "hash": "07787ac0390148f131be079c0f150d43ba34d4fe1e9528e76b5bf302a1511f0f",
-    "last_checked": "2026-07-27T14:05:40.286Z",
+    "last_checked": "2026-07-31T14:26:16.151Z",
     "race_id": "tottori-marathon-2026"
   },
   "https://www.toyako-marathon.jp/outline/": {
     "hash": "04aae16ca12370f252f99e7fbb6f3edfa00df10c2851e891fa061f5c447a2f1c",
-    "last_checked": "2026-07-27T14:05:40.592Z",
+    "last_checked": "2026-07-31T14:26:16.406Z",
     "race_id": "toyako-marathon-2026"
   },
   "https://www.toyako-marathon.jp/entry/": {
     "hash": "8a251f00105de0a7168106bb47c8993ef20cab5d49eb74c0bfc81e5af5193ee5",
-    "last_checked": "2026-07-27T14:05:40.850Z",
+    "last_checked": "2026-07-31T14:26:16.597Z",
     "race_id": "toyako-marathon-2026"
   },
   "https://www.toyako-marathon.jp/course/": {
     "hash": "5aff71c01fbc2b0dd9d81f816c006d68582e525068d28040fbf07e151c07f561",
-    "last_checked": "2026-07-27T14:05:41.069Z",
+    "last_checked": "2026-07-31T14:26:16.758Z",
     "race_id": "toyako-marathon-2026"
   },
   "https://www.toyamamarathon.com/about/": {
     "hash": "cb9462ef4ece5ecb9856e62a28f50ffbf820045abd19136fcef1243181b8b2e9",
-    "last_checked": "2026-07-27T14:05:41.403Z",
+    "last_checked": "2026-07-31T14:26:16.960Z",
     "race_id": "toyama-marathon-2026"
   },
   "https://www.toyamamarathon.com/about/course/": {
-    "hash": "3c18113d9a0f3b60e20350944989c77cb4eada9d7bb19a15171ee9f4c96070f2",
-    "last_checked": "2026-07-27T14:05:41.535Z",
+    "hash": "e75c9f1d7a85a3fe6197d0508f6e18746c7ad374d56512bfa72226e804bc71fa",
+    "last_checked": "2026-07-31T14:26:17.106Z",
     "race_id": "toyama-marathon-2026"
   },
   "https://www.toyamamarathon.com/runner/stayplan/": {
     "hash": "f3abdbe5c647a4747b7f15aacc1cf5cb6438b48e686942670a86f00aceb78ed8",
-    "last_checked": "2026-07-27T14:05:41.686Z",
+    "last_checked": "2026-07-31T14:26:17.227Z",
     "race_id": "toyama-marathon-2026"
   },
   "https://www.toyamamarathon.com/traffic/": {
     "hash": "ab9b7973ce01818f671e0bc4ada0b722ef0dab8ca3367b430d82c6a5955d294c",
-    "last_checked": "2026-07-27T14:05:41.821Z",
+    "last_checked": "2026-07-31T14:26:17.358Z",
     "race_id": "toyama-marathon-2026"
   },
   "https://www.toyamamarathon.com/faq/": {
     "hash": "b23a5107addd316d8d0c716e043cf991d941791dfe2cf25df48a489a7abd1b6d",
-    "last_checked": "2026-07-27T14:05:41.952Z",
+    "last_checked": "2026-07-31T14:26:17.476Z",
     "race_id": "toyama-marathon-2026"
   },
   "https://www.tsukuba-marathon.com/page/dir000007.html": {
@@ -1696,107 +1696,107 @@
   },
   "https://www.tsukuba-marathon.com/faq.php": {
     "hash": "65524ba36bb60fc7d724f43b20a95152b20ed2c8e66759b5aceaa72ea28c5e9f",
-    "last_checked": "2026-07-27T14:05:42.286Z",
+    "last_checked": "2026-07-31T14:26:17.656Z",
     "race_id": "tsukuba-marathon-2026"
   },
   "https://www.tsukuba-marathon.com/page/page000280.html": {
     "hash": "6c2f8519a88761a574373882ea94799a81922a2830ee617784e0150e89465b2e",
-    "last_checked": "2026-07-27T14:05:42.302Z",
+    "last_checked": "2026-07-31T14:26:17.672Z",
     "race_id": "tsukuba-marathon-2026"
   },
   "https://www.tsukuba-marathon.com/page/page000276.html": {
     "hash": "0c04b04971c9a39c815751e532f23fa1da3c880bb68afacb334986acb779948a",
-    "last_checked": "2026-07-27T14:05:42.316Z",
+    "last_checked": "2026-07-31T14:26:17.689Z",
     "race_id": "tsukuba-marathon-2026"
   },
   "https://www.tsukuba-marathon.com/sitemap.php": {
     "hash": "6a25290d0fc5df89f2570db0f3423f17f8c9a4c759c03bc37f3cd1352f3d18f5",
-    "last_checked": "2026-07-27T14:05:42.855Z",
+    "last_checked": "2026-07-31T14:26:17.756Z",
     "race_id": "tsukuba-marathon-2026"
   },
   "https://wakkanai-marathon.jp/outline/": {
     "hash": "059aa7367199eb98d28771738753fe9f367e2f3efe4fe6b6e0369890589b2638",
-    "last_checked": "2026-07-27T14:05:43.104Z",
+    "last_checked": "2026-07-31T14:26:18.009Z",
     "race_id": "wakkanai-peace-marathon-2026"
   },
   "https://wakkanai-marathon.jp/entry/": {
     "hash": "7472d8abd68e3a252d7a3b3c31170772b89a8a732958e4301fda629645e0891d",
-    "last_checked": "2026-07-27T14:05:43.313Z",
+    "last_checked": "2026-07-31T14:26:18.236Z",
     "race_id": "wakkanai-peace-marathon-2026"
   },
   "https://wakkanai-marathon.jp/course/": {
     "hash": "eb9901f04f6362ba9e0d34a7896c897581291ed27bde884605fc5a14af50b02a",
-    "last_checked": "2026-07-27T14:05:43.486Z",
+    "last_checked": "2026-07-31T14:26:18.402Z",
     "race_id": "wakkanai-peace-marathon-2026"
   },
   "https://yokohamamarathon.jp/outline/": {
-    "hash": "a120b533ff925775c8008f4bbbc11692690e2dbcf9757c9144521a57a0763995",
-    "last_checked": "2026-07-27T14:05:44.318Z",
+    "hash": "e457b69a88f3e7e4cf4d8b777f4e7d4d050097785e817b10a5b30807e2dd9769",
+    "last_checked": "2026-07-31T14:26:19.237Z",
     "race_id": "yokohama-marathon-2026"
   },
   "https://yokohamamarathon.jp/entrystart/": {
-    "hash": "d232b8a70414739e03f25a8d29a767edd3dab634ff17bd3240cab56e298854a7",
-    "last_checked": "2026-07-27T14:05:45.100Z",
+    "hash": "15398cf96cbe9bbda3e2a2ecd7d9ffdb957acec4d246c860c455daf56c5ce02b",
+    "last_checked": "2026-07-31T14:26:20.081Z",
     "race_id": "yokohama-marathon-2026"
   },
   "https://yokohamamarathon.jp/volunteerqa/": {
-    "hash": "3243a17167a3aa785179189ce06efc275137e3253d64edd63ace8050ea1f2f8a",
-    "last_checked": "2026-07-27T14:05:45.932Z",
+    "hash": "259cea89cb5a3775c8064977882d207a5650046d8327acf9fea19c1359466ef0",
+    "last_checked": "2026-07-31T14:26:20.877Z",
     "race_id": "yokohama-marathon-2026"
   },
   "https://www.shining-foundation.org/izu-oshima-outline": {
     "hash": "fd0b7c193363c052a6cb54f16dee5df463d8cdc7a1f3f81ea257698ecef2a33a",
-    "last_checked": "2026-06-29T14:10:44.118Z",
+    "last_checked": "2026-07-31T14:25:26.402Z",
     "race_id": "izu-oshima-2026"
   },
   "https://www.shining-foundation.org/izu-oshima-entry": {
     "hash": "ff819e85fcbba14fed2915d5c1416a68ce9008a8dc23d7d2ad2b66bf1c67d539",
-    "last_checked": "2026-07-27T14:04:59.645Z",
+    "last_checked": "2026-07-31T14:25:26.544Z",
     "race_id": "izu-oshima-2026"
   },
   "https://www.shining-foundation.org/izu-oshima-special": {
     "hash": "3f1ca84e43fe318ca32cc3ce452d463be545d361c6b8c6384202fe6eea97a117",
-    "last_checked": "2026-07-27T14:04:59.935Z",
+    "last_checked": "2026-07-31T14:25:26.697Z",
     "race_id": "izu-oshima-2026"
   },
   "https://www.shining-foundation.org/izu-oshima-couse": {
     "hash": "6ba2beb1ac10dc8ba8178fccdb4035d98e8cbfed33fb7d79d87397193654566f",
-    "last_checked": "2026-07-27T14:05:00.301Z",
+    "last_checked": "2026-07-31T14:25:26.838Z",
     "race_id": "izu-oshima-2026"
   },
   "https://www.shining-foundation.org/izu-oshima-access": {
     "hash": "841dd0995b2a02e2f9e06c42f1ffeb91934e14bb1e9133d4bead55f9984055d4",
-    "last_checked": "2026-07-27T14:05:00.616Z",
+    "last_checked": "2026-07-31T14:25:26.990Z",
     "race_id": "izu-oshima-2026"
   },
   "https://www.ohtawara-marathon.com/outline/": {
     "hash": "33139783bf6c5819cbf533cf79eb791ea58f51fe8df11af1704ab0b05eb84bb5",
-    "last_checked": "2026-07-27T14:05:20.772Z",
+    "last_checked": "2026-07-31T14:25:53.840Z",
     "race_id": "ohtawara-marathon-2026"
   },
   "https://www.ohtawara-marathon.com/feature/": {
     "hash": "2f8b23a0cb5bd6b9d769214352b425d44a49dd314b4a7a517d535eef9800a752",
-    "last_checked": "2026-07-27T14:05:20.995Z",
+    "last_checked": "2026-07-31T14:25:54.115Z",
     "race_id": "ohtawara-marathon-2026"
   },
   "https://www.ohtawara-marathon.com/entry/": {
     "hash": "75b01156c62347a3eb45f37f1a421271a09e617a0285c87e5113088b1a4f4343",
-    "last_checked": "2026-07-27T14:05:21.175Z",
+    "last_checked": "2026-07-31T14:25:54.332Z",
     "race_id": "ohtawara-marathon-2026"
   },
   "https://www.ohtawara-marathon.com/course/": {
     "hash": "137c1002895f577f5bd12e094442786c8f28fe27230b9253cd28944ddb93731e",
-    "last_checked": "2026-07-27T14:05:21.353Z",
+    "last_checked": "2026-07-31T14:25:54.651Z",
     "race_id": "ohtawara-marathon-2026"
   },
   "https://www.ohtawara-marathon.com/contact/": {
     "hash": "77bdf134c3fcbdb49b5405c8e8ecabb611717db72d7868106bd4080144ae7624",
-    "last_checked": "2026-07-27T14:05:21.552Z",
+    "last_checked": "2026-07-31T14:25:54.881Z",
     "race_id": "ohtawara-marathon-2026"
   },
   "https://hofu-yomiuri.jp/entry/": {
     "hash": "29ac7136e860bd64a46ace5b81068310e26ac067da8c2466d49f9a2a6c3d0a7f",
-    "last_checked": "2026-07-27T14:04:44.062Z",
+    "last_checked": "2026-07-31T14:25:18.214Z",
     "race_id": "hofu-yomiuri-marathon-2026"
   }
 }

--- a/tools/crawl/extractor.js
+++ b/tools/crawl/extractor.js
@@ -100,6 +100,8 @@ ${pages}
 - motif_color は #RRGGBB 形式
 - nearby_spots の lat/lng が不明な場合は 0 を使用
 - participation_gifts と completion_gifts は別々に設定すること（完走賞・メダルは completion_gifts）
+- 複数種目（フルマラソン・ジョギング・10km等）でエントリー締切が異なる場合は、種目ごとに個別の entry_periods エントリーを作成すること（まとめて1件にしない）
+- 既存の entry_periods が複数件設定されている場合は、その種目構造を維持して更新すること
 - start_lat / start_lng は出力禁止（座標はジオコーディングスクリプトで別途処理する）
 - reception_type は "pre_day" / "race_day" / "both" / "pre_mail" / "none" のいずれか。判別不能なら出力しない
   - 前日と当日の両方の受付記載あり → "both"

--- a/tools/crawl/extractor.test.js
+++ b/tools/crawl/extractor.test.js
@@ -86,6 +86,29 @@ describe('buildExtractionPrompt', () => {
     assert.ok(prompt.includes('motif'));
     assert.ok(prompt.includes('富士山'));
   });
+
+  test('複数種目でエントリー期間が異なる場合の指示をプロンプトに含む', () => {
+    const prompt = buildExtractionPrompt(race, pageTexts);
+    assert.ok(
+      prompt.includes('複数種目') || prompt.includes('種目ごと'),
+      '複数種目のエントリー期間を個別に扱う指示が含まれる'
+    );
+  });
+
+  test('既存のentry_periodsが複数件の場合に件数を維持する指示をプロンプトに含む', () => {
+    const raceWithMultiplePeriods = {
+      ...race,
+      entry_periods: [
+        { label_ja: 'フルマラソン', label_en: 'Full Marathon', start_date: '2025-08-01', end_date: '2025-10-31', entry_fee: 16200, category_id: null, sort_order: 0 },
+        { label_ja: 'ジョギング（10km）', label_en: 'Jogging (10km)', start_date: '2025-08-01', end_date: '2025-12-01', entry_fee: 8000, category_id: null, sort_order: 1 },
+      ],
+    };
+    const prompt = buildExtractionPrompt(raceWithMultiplePeriods, pageTexts);
+    // 既存entry_periodsが2件であることがプロンプトに反映される
+    assert.ok(prompt.includes('entry_periods'));
+    assert.ok(prompt.includes('フルマラソン'));
+    assert.ok(prompt.includes('ジョギング'));
+  });
 });
 
 // ── parseClaudeResponse ───────────────────────────────────────────


### PR DESCRIPTION
## 問題

クロールが毎回ぐんまマラソンを誤更新していた。

- フルマラソン（一般エントリー）の締切は **5/13**
- ジョギング（10km）の締切は **8/17**

にもかかわらず `entry_periods` が1件（ラベル「一般エントリー」、締切8/17）だったため、LLMがジョギングの締切をフルマラソンの締切として抽出し続けていた。

## 変更内容

### `src/data/races/gunma-marathon-2026.json`
- `entry_periods` を2件に分割
  - フルマラソン: start=2026-04-09, **end=2026-05-13**, fee=13,500円
  - ジョギング（10km）: start=2026-04-09, **end=2026-08-17**, fee=6,500円

### `tools/crawl/extractor.js`
- `buildExtractionPrompt` に指示を追加
  - 複数種目でエントリー締切が異なる場合は種目ごとに個別の entry_periods を作成すること
  - 既存の entry_periods が複数件の場合はその構造を維持すること

### `tools/crawl/extractor.test.js`
- 上記プロンプト変更のテスト2件追加

### `migrations/seed-races-all.sql`
- シード再生成

## テスト

- `node --test tools/crawl/extractor.test.js` → **70/70 pass**