### PR TITLE
feat: レース装備リスト機能（Issue #124）

### DIFF
--- a/docs/update-history.md
+++ b/docs/update-history.md
@@ -900,3 +900,21 @@ APIの調査中にGoogle Routes API v2がTRANSITモードで日本に非対応�
   - アクセス：JR貴生川駅からバス35分
   - 参加賞：オリジナルTシャツ
 - `migrations/seed-races-all.sql`：シード再生成
+
+## 2026-08-05 Issue #124: レース装備リスト実装
+
+- `src/lib/race-gear-validation.ts`（新規）: `validatePutBody` / `validatePatchBody` バリデーション関数
+- `src/lib/__tests__/race-gear-validation.test.ts`（新規）: バリデーション単体テスト 27件
+- `src/app/api/user/races/[raceId]/gear/route.ts`（新規）: GET / PUT / PATCH APIルート
+  - GET: レース装備リスト取得、`?source=candidates` でコピー元候補一覧
+  - PUT: 装備リスト全置換（gear_id所有者確認、used/note引き継ぎ）
+  - PATCH: 個別使用記録更新（used / used_quantity / note）
+- `src/app/api/user/races/[raceId]/gear/__tests__/route.test.ts`（新規）: APIルートテスト 18件
+- `src/components/mypage/RaceGearSection.tsx`（新規）: レース装備セクションUIコンポーネント
+  - レース前: マイギアから追加、前のレースからコピー、数量編集、保存（PUT）
+  - レース後: 使用/未使用/未記録トグル、使用数入力、メモ入力（PATCH）
+  - マイギア0件時: ギア登録リンクを表示
+- `src/components/mypage/__tests__/RaceGearSection.test.tsx`（新規）: UIコンポーネントテスト 17件
+- `src/components/mypage/UserRaceList.tsx`（変更）: 各レース行に `RaceGearSection` を追加
+- `src/components/mypage/__tests__/UserRaceList.test.tsx`（変更）: `next-intl` モックを追加
+- `src/messages/ja.json` / `src/messages/en.json`（変更）: `gear` 名前空間に raceGear* キーを追加

--- a/src/app/api/user/races/[raceId]/gear/__tests__/route.test.ts
+++ b/src/app/api/user/races/[raceId]/gear/__tests__/route.test.ts
@@ -1,0 +1,369 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ─── モック定義 ────────────────────────────────────────────────────────────
+const {
+  mockGetSession,
+  mockSelectRows,
+  mockInsertValues,
+  mockUpdateWhere,
+  mockDeleteWhere,
+} = vi.hoisted(() => {
+  const mockSelectRows = vi.fn<[], Promise<unknown[]>>().mockResolvedValue([]);
+  const mockInsertValues = vi.fn().mockResolvedValue(undefined);
+  const mockUpdateWhere = vi.fn().mockResolvedValue(undefined);
+  const mockDeleteWhere = vi.fn().mockResolvedValue(undefined);
+  return {
+    mockGetSession: vi.fn(),
+    mockSelectRows,
+    mockInsertValues,
+    mockUpdateWhere,
+    mockDeleteWhere,
+  };
+});
+
+vi.mock('@opennextjs/cloudflare', () => ({
+  getCloudflareContext: vi.fn(() => ({ env: { DB: {} } })),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  createAuth: vi.fn(() => ({
+    api: { getSession: mockGetSession },
+  })),
+}));
+
+vi.mock('drizzle-orm/d1', () => ({
+  drizzle: vi.fn(() => {
+    const makeChain = () => {
+      const chain: Record<string, unknown> = {};
+      const terminal = () => {
+        const p = mockSelectRows();
+        return Object.assign(p, {
+          orderBy: vi.fn(() => p),
+          limit: vi.fn((n: number) => p.then((rows: unknown[]) => rows.slice(0, n))),
+        });
+      };
+      chain.from = vi.fn(() => chain);
+      chain.innerJoin = vi.fn(() => chain);
+      chain.where = vi.fn(terminal);
+      chain.orderBy = vi.fn(terminal);
+      return chain;
+    };
+
+    return {
+      select: vi.fn(makeChain),
+      insert: vi.fn(() => ({ values: mockInsertValues })),
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({ where: mockUpdateWhere })),
+      })),
+      delete: vi.fn(() => ({ where: mockDeleteWhere })),
+    };
+  }),
+}));
+
+vi.mock('drizzle-orm', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('drizzle-orm')>();
+  return {
+    ...actual,
+    eq: vi.fn((_field: unknown, val: unknown) => val),
+    ne: vi.fn((_field: unknown, val: unknown) => val),
+    and: vi.fn((...args: unknown[]) => args),
+    asc: vi.fn((col: unknown) => col),
+    desc: vi.fn((col: unknown) => col),
+    inArray: vi.fn((_field: unknown, vals: unknown) => vals),
+  };
+});
+
+import { GET, PUT, PATCH } from '../route';
+
+// ─── テストデータ ──────────────────────────────────────────────────────────
+const MOCK_USER = { id: 'user-1', name: 'テスト', email: 'test@example.com' };
+const RACE_ID = 'gunma-marathon-2026';
+const USER_RACE_ID = 'ur-uuid-1';
+
+const MOCK_USER_RACE = {
+  id: USER_RACE_ID,
+  user_id: 'user-1',
+  race_id: RACE_ID,
+  is_planning: true,
+  planning_category_id: null,
+  entry_reminder_period_ids: '[]',
+  gear_is_public: false,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+};
+
+const MOCK_GEAR_ITEM = {
+  gear_id: 'gear-1',
+  quantity: 1,
+  used: null,
+  used_quantity: null,
+  note: '',
+  sort_order: 0,
+  name: 'テストシューズ',
+  brand: 'Nike',
+  category: 'shoes',
+  asin: null,
+  amazon_url: null,
+};
+
+function makeRequest(method: string, body?: unknown, search = ''): Request {
+  return new Request(`http://localhost/api/user/races/${RACE_ID}/gear${search}`, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+function makeParams(raceId = RACE_ID) {
+  return { params: Promise.resolve({ raceId }) };
+}
+
+// ─── GET /api/user/races/[raceId]/gear ────────────────────────────────────
+describe('GET /api/user/races/[raceId]/gear', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('未認証: 401', async () => {
+    mockGetSession.mockResolvedValue(null);
+    const res = await GET(makeRequest('GET'), makeParams());
+    expect(res.status).toBe(401);
+  });
+
+  it('user_race が存在しない: 404', async () => {
+    mockGetSession.mockResolvedValue({ user: MOCK_USER });
+    mockSelectRows.mockResolvedValue([]); // user_races lookup → not found
+    const res = await GET(makeRequest('GET'), makeParams());
+    expect(res.status).toBe(404);
+  });
+
+  it('装備リストを返す', async () => {
+    mockGetSession.mockResolvedValue({ user: MOCK_USER });
+    mockSelectRows
+      .mockResolvedValueOnce([MOCK_USER_RACE])   // user_races lookup
+      .mockResolvedValueOnce([MOCK_GEAR_ITEM]);  // gear items
+    const res = await GET(makeRequest('GET'), makeParams());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].gear_id).toBe('gear-1');
+  });
+
+  it('装備リストが空なら空配列を返す', async () => {
+    mockGetSession.mockResolvedValue({ user: MOCK_USER });
+    mockSelectRows
+      .mockResolvedValueOnce([MOCK_USER_RACE])
+      .mockResolvedValueOnce([]);
+    const res = await GET(makeRequest('GET'), makeParams());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual([]);
+  });
+});
+
+// ─── GET ?source=candidates ────────────────────────────────────────────────
+describe('GET /api/user/races/[raceId]/gear?source=candidates', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('未認証: 401', async () => {
+    mockGetSession.mockResolvedValue(null);
+    const res = await GET(makeRequest('GET', undefined, '?source=candidates'), makeParams());
+    expect(res.status).toBe(401);
+  });
+
+  it('コピー元候補を返す', async () => {
+    mockGetSession.mockResolvedValue({ user: MOCK_USER });
+    // user_race_gear + user_races join → [{user_race_id, race_id}...]
+    mockSelectRows.mockResolvedValue([
+      { user_race_id: 'ur-other', race_id: 'tokyo-marathon-2026' },
+      { user_race_id: 'ur-other', race_id: 'tokyo-marathon-2026' }, // duplicate = 2 gear items
+    ]);
+    const res = await GET(makeRequest('GET', undefined, '?source=candidates'), makeParams());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].race_id).toBe('tokyo-marathon-2026');
+    expect(body[0].gear_count).toBe(2);
+  });
+
+  it('候補がない場合は空配列', async () => {
+    mockGetSession.mockResolvedValue({ user: MOCK_USER });
+    mockSelectRows.mockResolvedValue([]);
+    const res = await GET(makeRequest('GET', undefined, '?source=candidates'), makeParams());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual([]);
+  });
+});
+
+// ─── PUT /api/user/races/[raceId]/gear ────────────────────────────────────
+describe('PUT /api/user/races/[raceId]/gear', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('未認証: 401', async () => {
+    mockGetSession.mockResolvedValue(null);
+    const res = await PUT(makeRequest('PUT', { items: [] }), makeParams());
+    expect(res.status).toBe(401);
+  });
+
+  it('user_race が存在しない: 404', async () => {
+    mockGetSession.mockResolvedValue({ user: MOCK_USER });
+    mockSelectRows.mockResolvedValue([]);
+    const res = await PUT(makeRequest('PUT', { items: [] }), makeParams());
+    expect(res.status).toBe(404);
+  });
+
+  it('body が不正: 400', async () => {
+    mockGetSession.mockResolvedValue({ user: MOCK_USER });
+    mockSelectRows.mockResolvedValue([MOCK_USER_RACE]);
+    const res = await PUT(makeRequest('PUT', { items: 'invalid' }), makeParams());
+    expect(res.status).toBe(400);
+  });
+
+  it('他人の gear_id を含む: 400', async () => {
+    mockGetSession.mockResolvedValue({ user: MOCK_USER });
+    mockSelectRows
+      .mockResolvedValueOnce([MOCK_USER_RACE])  // user_races lookup
+      .mockResolvedValueOnce([]);                // 自分のgear → 0件（無効なgear_id）
+    const res = await PUT(
+      makeRequest('PUT', { items: [{ gear_id: 'other-users-gear', quantity: 1, sort_order: 0 }] }),
+      makeParams(),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('正常: リストを保存して返す', async () => {
+    mockGetSession.mockResolvedValue({ user: MOCK_USER });
+    mockSelectRows
+      .mockResolvedValueOnce([MOCK_USER_RACE])           // user_races lookup
+      .mockResolvedValueOnce([{ id: 'gear-1' }])        // gear ownership check
+      .mockResolvedValueOnce([])                          // existing gear items
+      .mockResolvedValueOnce([MOCK_GEAR_ITEM]);          // updated list
+    const res = await PUT(
+      makeRequest('PUT', { items: [{ gear_id: 'gear-1', quantity: 1, sort_order: 0 }] }),
+      makeParams(),
+    );
+    expect(res.status).toBe(200);
+    expect(mockInsertValues).toHaveBeenCalledOnce();
+  });
+
+  it('空リストでも正常（既存を全削除）', async () => {
+    mockGetSession.mockResolvedValue({ user: MOCK_USER });
+    mockSelectRows
+      .mockResolvedValueOnce([MOCK_USER_RACE])
+      .mockResolvedValueOnce([])   // existing gear items
+      .mockResolvedValueOnce([]);  // updated list
+    const res = await PUT(makeRequest('PUT', { items: [] }), makeParams());
+    expect(res.status).toBe(200);
+    expect(mockDeleteWhere).toHaveBeenCalledOnce();
+    expect(mockInsertValues).not.toHaveBeenCalled();
+  });
+
+  it('PUT で used/note が保持される（同一 gear_id が残る場合）', async () => {
+    mockGetSession.mockResolvedValue({ user: MOCK_USER });
+    const existingWithRecord = {
+      gear_id: 'gear-1',
+      user_race_id: USER_RACE_ID,
+      quantity: 1,
+      sort_order: 0,
+      used: true,
+      used_quantity: 1,
+      note: 'とても良かった',
+    };
+    mockSelectRows
+      .mockResolvedValueOnce([MOCK_USER_RACE])
+      .mockResolvedValueOnce([{ id: 'gear-1' }])       // ownership check
+      .mockResolvedValueOnce([existingWithRecord])       // existing items
+      .mockResolvedValueOnce([MOCK_GEAR_ITEM]);         // updated list
+    await PUT(
+      makeRequest('PUT', { items: [{ gear_id: 'gear-1', quantity: 2, sort_order: 0 }] }),
+      makeParams(),
+    );
+    const insertCall = mockInsertValues.mock.calls[0][0];
+    expect(insertCall.used).toBe(true);
+    expect(insertCall.note).toBe('とても良かった');
+  });
+
+  it('PUT で新規 gear_id は used=null, note="" で挿入される', async () => {
+    mockGetSession.mockResolvedValue({ user: MOCK_USER });
+    mockSelectRows
+      .mockResolvedValueOnce([MOCK_USER_RACE])
+      .mockResolvedValueOnce([{ id: 'gear-new' }])  // ownership check
+      .mockResolvedValueOnce([])                      // existing items（既存なし）
+      .mockResolvedValueOnce([MOCK_GEAR_ITEM]);
+    await PUT(
+      makeRequest('PUT', { items: [{ gear_id: 'gear-new', quantity: 1, sort_order: 0 }] }),
+      makeParams(),
+    );
+    const insertCall = mockInsertValues.mock.calls[0][0];
+    expect(insertCall.used).toBeNull();
+    expect(insertCall.note).toBe('');
+  });
+});
+
+// ─── PATCH /api/user/races/[raceId]/gear ──────────────────────────────────
+describe('PATCH /api/user/races/[raceId]/gear', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('未認証: 401', async () => {
+    mockGetSession.mockResolvedValue(null);
+    const res = await PATCH(makeRequest('PATCH', { gear_id: 'g1', used: true }), makeParams());
+    expect(res.status).toBe(401);
+  });
+
+  it('user_race が存在しない: 404', async () => {
+    mockGetSession.mockResolvedValue({ user: MOCK_USER });
+    mockSelectRows.mockResolvedValue([]);
+    const res = await PATCH(makeRequest('PATCH', { gear_id: 'g1', used: true }), makeParams());
+    expect(res.status).toBe(404);
+  });
+
+  it('body が不正: 400', async () => {
+    mockGetSession.mockResolvedValue({ user: MOCK_USER });
+    mockSelectRows.mockResolvedValue([MOCK_USER_RACE]);
+    const res = await PATCH(makeRequest('PATCH', { gear_id: 'g1' }), makeParams());
+    expect(res.status).toBe(400);
+  });
+
+  it('gear_id がリスト内に存在しない: 404', async () => {
+    mockGetSession.mockResolvedValue({ user: MOCK_USER });
+    mockSelectRows
+      .mockResolvedValueOnce([MOCK_USER_RACE])
+      .mockResolvedValueOnce([]);  // gear item not found
+    const res = await PATCH(makeRequest('PATCH', { gear_id: 'nonexistent', used: true }), makeParams());
+    expect(res.status).toBe(404);
+  });
+
+  it('使用記録を更新して返す', async () => {
+    mockGetSession.mockResolvedValue({ user: MOCK_USER });
+    const existingItem = { ...MOCK_GEAR_ITEM, user_race_id: USER_RACE_ID };
+    const updatedItem = { ...existingItem, used: true, note: 'good' };
+    mockSelectRows
+      .mockResolvedValueOnce([MOCK_USER_RACE])
+      .mockResolvedValueOnce([existingItem])   // gear item found
+      .mockResolvedValueOnce([updatedItem]);   // after update
+    const res = await PATCH(
+      makeRequest('PATCH', { gear_id: 'gear-1', used: true, note: 'good' }),
+      makeParams(),
+    );
+    expect(res.status).toBe(200);
+    expect(mockUpdateWhere).toHaveBeenCalledOnce();
+    const body = await res.json();
+    expect(body.used).toBe(true);
+  });
+
+  it('used=null でリセットできる', async () => {
+    mockGetSession.mockResolvedValue({ user: MOCK_USER });
+    const existingItem = { ...MOCK_GEAR_ITEM, user_race_id: USER_RACE_ID, used: true };
+    const resetItem = { ...existingItem, used: null };
+    mockSelectRows
+      .mockResolvedValueOnce([MOCK_USER_RACE])
+      .mockResolvedValueOnce([existingItem])
+      .mockResolvedValueOnce([resetItem]);
+    const res = await PATCH(
+      makeRequest('PATCH', { gear_id: 'gear-1', used: null }),
+      makeParams(),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.used).toBeNull();
+  });
+});

--- a/src/app/api/user/races/[raceId]/gear/__tests__/route.test.ts
+++ b/src/app/api/user/races/[raceId]/gear/__tests__/route.test.ts
@@ -8,7 +8,7 @@ const {
   mockUpdateWhere,
   mockDeleteWhere,
 } = vi.hoisted(() => {
-  const mockSelectRows = vi.fn<[], Promise<unknown[]>>().mockResolvedValue([]);
+  const mockSelectRows = vi.fn<() => Promise<unknown[]>>().mockResolvedValue([]);
   const mockInsertValues = vi.fn().mockResolvedValue(undefined);
   const mockUpdateWhere = vi.fn().mockResolvedValue(undefined);
   const mockDeleteWhere = vi.fn().mockResolvedValue(undefined);
@@ -56,6 +56,7 @@ vi.mock('drizzle-orm/d1', () => ({
         set: vi.fn(() => ({ where: mockUpdateWhere })),
       })),
       delete: vi.fn(() => ({ where: mockDeleteWhere })),
+      batch: vi.fn().mockResolvedValue([]),
     };
   }),
 }));

--- a/src/app/api/user/races/[raceId]/gear/route.ts
+++ b/src/app/api/user/races/[raceId]/gear/route.ts
@@ -108,7 +108,12 @@ export async function PUT(request: Request, { params }: Params) {
   const userRace = await getUserRace(db, session.user.id, raceId);
   if (!userRace) return Response.json({ error: 'Not Found' }, { status: 404 });
 
-  const body = await request.json();
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: 'リクエストボディが不正です' }, { status: 400 });
+  }
   const validation = validatePutBody(body);
   if ('error' in validation) return Response.json({ error: validation.error }, { status: 400 });
 
@@ -137,15 +142,13 @@ export async function PUT(request: Request, { params }: Params) {
 
   const existingMap = new Map(existing.map((e) => [e.gear_id, e]));
 
-  // 既存を全削除
-  await db
+  // 削除と挿入を db.batch() でまとめて原子的に実行
+  const deleteOp = db
     .delete(schema.user_race_gear)
     .where(eq(schema.user_race_gear.user_race_id, userRace.id));
-
-  // 新しいアイテムを挿入（同一 gear_id の used/note は引き継ぐ）
-  for (const item of items) {
+  const insertOps = items.map((item) => {
     const prev = existingMap.get(item.gear_id);
-    await db.insert(schema.user_race_gear).values({
+    return db.insert(schema.user_race_gear).values({
       user_race_id: userRace.id,
       gear_id: item.gear_id,
       quantity: item.quantity,
@@ -154,7 +157,9 @@ export async function PUT(request: Request, { params }: Params) {
       used_quantity: prev?.used_quantity ?? null,
       note: prev?.note ?? '',
     });
-  }
+  });
+  type BatchOp = Parameters<typeof db.batch>[0][number];
+  await db.batch([deleteOp, ...insertOps] as [BatchOp, ...BatchOp[]]);
 
   // 更新後のリストを返す
   const updated = await db
@@ -190,7 +195,12 @@ export async function PATCH(request: Request, { params }: Params) {
   const userRace = await getUserRace(db, session.user.id, raceId);
   if (!userRace) return Response.json({ error: 'Not Found' }, { status: 404 });
 
-  const body = await request.json();
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: 'リクエストボディが不正です' }, { status: 400 });
+  }
   const validation = validatePatchBody(body);
   if ('error' in validation) return Response.json({ error: validation.error }, { status: 400 });
 

--- a/src/app/api/user/races/[raceId]/gear/route.ts
+++ b/src/app/api/user/races/[raceId]/gear/route.ts
@@ -1,0 +1,224 @@
+/**
+ * GET   /api/user/races/[raceId]/gear                 — 装備リスト取得
+ * GET   /api/user/races/[raceId]/gear?source=candidates — コピー元候補
+ * PUT   /api/user/races/[raceId]/gear                 — リスト全置換
+ * PATCH /api/user/races/[raceId]/gear                 — 個別使用記録更新
+ */
+import { getCloudflareContext } from '@opennextjs/cloudflare';
+import { createAuth } from '@/lib/auth';
+import { drizzle } from 'drizzle-orm/d1';
+import { eq, and, ne, asc, inArray } from 'drizzle-orm';
+import * as schema from '@/lib/db/schema';
+import { validatePutBody, validatePatchBody } from '@/lib/race-gear-validation';
+
+type Params = { params: Promise<{ raceId: string }> };
+
+async function getContext(request: Request) {
+  const { env } = getCloudflareContext();
+  const auth = createAuth(env.DB);
+  const session = await auth.api.getSession({ headers: request.headers });
+  const db = drizzle(env.DB, { schema });
+  return { session, db };
+}
+
+async function getUserRace(
+  db: ReturnType<typeof drizzle>,
+  userId: string,
+  raceId: string,
+) {
+  const [row] = await db
+    .select()
+    .from(schema.user_races)
+    .where(and(eq(schema.user_races.user_id, userId), eq(schema.user_races.race_id, raceId)))
+    .limit(1);
+  return row ?? null;
+}
+
+// ─── GET ───────────────────────────────────────────────────────────────────
+
+export async function GET(request: Request, { params }: Params) {
+  const { raceId } = await params;
+  const { session, db } = await getContext(request);
+
+  if (!session) return Response.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const url = new URL(request.url);
+
+  // コピー元候補モード
+  if (url.searchParams.get('source') === 'candidates') {
+    const rows = await db
+      .select({
+        user_race_id: schema.user_race_gear.user_race_id,
+        race_id: schema.user_races.race_id,
+      })
+      .from(schema.user_race_gear)
+      .innerJoin(schema.user_races, eq(schema.user_race_gear.user_race_id, schema.user_races.id))
+      .where(and(eq(schema.user_races.user_id, session.user.id), ne(schema.user_races.race_id, raceId)));
+
+    // JS側でdeduplicateしてgear_countを集計
+    const countMap = new Map<string, { race_id: string; gear_count: number }>();
+    for (const row of rows) {
+      const entry = countMap.get(row.user_race_id);
+      if (entry) {
+        entry.gear_count++;
+      } else {
+        countMap.set(row.user_race_id, { race_id: row.race_id, gear_count: 1 });
+      }
+    }
+
+    return Response.json(
+      [...countMap.entries()].map(([user_race_id, v]) => ({ user_race_id, ...v })),
+    );
+  }
+
+  // 通常GETモード
+  const userRace = await getUserRace(db, session.user.id, raceId);
+  if (!userRace) return Response.json({ error: 'Not Found' }, { status: 404 });
+
+  const items = await db
+    .select({
+      gear_id: schema.user_race_gear.gear_id,
+      quantity: schema.user_race_gear.quantity,
+      used: schema.user_race_gear.used,
+      used_quantity: schema.user_race_gear.used_quantity,
+      note: schema.user_race_gear.note,
+      sort_order: schema.user_race_gear.sort_order,
+      name: schema.user_gear.name,
+      brand: schema.user_gear.brand,
+      category: schema.user_gear.category,
+      asin: schema.user_gear.asin,
+      amazon_url: schema.user_gear.amazon_url,
+    })
+    .from(schema.user_race_gear)
+    .innerJoin(schema.user_gear, eq(schema.user_race_gear.gear_id, schema.user_gear.id))
+    .where(eq(schema.user_race_gear.user_race_id, userRace.id))
+    .orderBy(asc(schema.user_race_gear.sort_order));
+
+  return Response.json(items);
+}
+
+// ─── PUT ───────────────────────────────────────────────────────────────────
+
+export async function PUT(request: Request, { params }: Params) {
+  const { raceId } = await params;
+  const { session, db } = await getContext(request);
+
+  if (!session) return Response.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const userRace = await getUserRace(db, session.user.id, raceId);
+  if (!userRace) return Response.json({ error: 'Not Found' }, { status: 404 });
+
+  const body = await request.json();
+  const validation = validatePutBody(body);
+  if ('error' in validation) return Response.json({ error: validation.error }, { status: 400 });
+
+  const { items } = validation.data;
+
+  // gear_id の所有者確認
+  if (items.length > 0) {
+    const gearIds = items.map((i) => i.gear_id);
+    const ownedGear = await db
+      .select({ id: schema.user_gear.id })
+      .from(schema.user_gear)
+      .where(and(eq(schema.user_gear.user_id, session.user.id), inArray(schema.user_gear.id, gearIds)));
+
+    const ownedIds = new Set(ownedGear.map((g) => g.id));
+    const invalid = gearIds.find((id) => !ownedIds.has(id));
+    if (invalid) {
+      return Response.json({ error: `gear_id ${invalid} はあなたのギアではありません` }, { status: 400 });
+    }
+  }
+
+  // 既存の used/note を保持するため取得
+  const existing = await db
+    .select()
+    .from(schema.user_race_gear)
+    .where(eq(schema.user_race_gear.user_race_id, userRace.id));
+
+  const existingMap = new Map(existing.map((e) => [e.gear_id, e]));
+
+  // 既存を全削除
+  await db
+    .delete(schema.user_race_gear)
+    .where(eq(schema.user_race_gear.user_race_id, userRace.id));
+
+  // 新しいアイテムを挿入（同一 gear_id の used/note は引き継ぐ）
+  for (const item of items) {
+    const prev = existingMap.get(item.gear_id);
+    await db.insert(schema.user_race_gear).values({
+      user_race_id: userRace.id,
+      gear_id: item.gear_id,
+      quantity: item.quantity,
+      sort_order: item.sort_order,
+      used: prev?.used ?? null,
+      used_quantity: prev?.used_quantity ?? null,
+      note: prev?.note ?? '',
+    });
+  }
+
+  // 更新後のリストを返す
+  const updated = await db
+    .select({
+      gear_id: schema.user_race_gear.gear_id,
+      quantity: schema.user_race_gear.quantity,
+      used: schema.user_race_gear.used,
+      used_quantity: schema.user_race_gear.used_quantity,
+      note: schema.user_race_gear.note,
+      sort_order: schema.user_race_gear.sort_order,
+      name: schema.user_gear.name,
+      brand: schema.user_gear.brand,
+      category: schema.user_gear.category,
+      asin: schema.user_gear.asin,
+      amazon_url: schema.user_gear.amazon_url,
+    })
+    .from(schema.user_race_gear)
+    .innerJoin(schema.user_gear, eq(schema.user_race_gear.gear_id, schema.user_gear.id))
+    .where(eq(schema.user_race_gear.user_race_id, userRace.id))
+    .orderBy(asc(schema.user_race_gear.sort_order));
+
+  return Response.json(updated);
+}
+
+// ─── PATCH ─────────────────────────────────────────────────────────────────
+
+export async function PATCH(request: Request, { params }: Params) {
+  const { raceId } = await params;
+  const { session, db } = await getContext(request);
+
+  if (!session) return Response.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const userRace = await getUserRace(db, session.user.id, raceId);
+  if (!userRace) return Response.json({ error: 'Not Found' }, { status: 404 });
+
+  const body = await request.json();
+  const validation = validatePatchBody(body);
+  if ('error' in validation) return Response.json({ error: validation.error }, { status: 400 });
+
+  const { gear_id, used, used_quantity, note } = validation.data;
+
+  // そのレースのリストに gear_id が存在するか確認
+  const [existingItem] = await db
+    .select()
+    .from(schema.user_race_gear)
+    .where(and(eq(schema.user_race_gear.user_race_id, userRace.id), eq(schema.user_race_gear.gear_id, gear_id)))
+    .limit(1);
+
+  if (!existingItem) return Response.json({ error: 'Not Found' }, { status: 404 });
+
+  const updateData: Record<string, unknown> = { used };
+  if (used_quantity !== undefined) updateData.used_quantity = used_quantity;
+  if (note !== undefined) updateData.note = note;
+
+  await db
+    .update(schema.user_race_gear)
+    .set(updateData)
+    .where(and(eq(schema.user_race_gear.user_race_id, userRace.id), eq(schema.user_race_gear.gear_id, gear_id)));
+
+  const [updated] = await db
+    .select()
+    .from(schema.user_race_gear)
+    .where(and(eq(schema.user_race_gear.user_race_id, userRace.id), eq(schema.user_race_gear.gear_id, gear_id)))
+    .limit(1);
+
+  return Response.json(updated);
+}

--- a/src/components/mypage/RaceGearSection.tsx
+++ b/src/components/mypage/RaceGearSection.tsx
@@ -1,0 +1,567 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useTranslations } from 'next-intl';
+import { Link } from '@/i18n/navigation';
+import { type UserGear } from '@/lib/types';
+
+// ─── 型 ────────────────────────────────────────────────────────────────────
+
+interface RaceGearRow {
+  gear_id: string;
+  quantity: number;
+  used: boolean | null;
+  used_quantity: number | null;
+  note: string;
+  sort_order: number;
+  name: string;
+  brand: string | null;
+  category: string;
+  asin: string | null;
+  amazon_url: string | null;
+}
+
+interface Candidate {
+  user_race_id: string;
+  race_id: string;
+  gear_count: number;
+}
+
+interface DraftItem {
+  gear_id: string;
+  quantity: number;
+  sort_order: number;
+}
+
+// ─── Props ─────────────────────────────────────────────────────────────────
+
+interface Props {
+  raceId: string;
+  raceDate: string; // YYYY-MM-DD
+}
+
+// ─── Component ─────────────────────────────────────────────────────────────
+
+export default function RaceGearSection({ raceId, raceDate }: Props) {
+  const t = useTranslations('gear');
+
+  const [open, setOpen] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [raceGear, setRaceGear] = useState<RaceGearRow[]>([]);
+  const [myGear, setMyGear] = useState<UserGear[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [showAddPanel, setShowAddPanel] = useState(false);
+  const [showCopyPanel, setShowCopyPanel] = useState(false);
+  const [candidates, setCandidates] = useState<Candidate[]>([]);
+  const [selectedCandidateRaceId, setSelectedCandidateRaceId] = useState('');
+  const [draft, setDraft] = useState<DraftItem[]>([]);
+  const [addSelected, setAddSelected] = useState<Set<string>>(new Set());
+
+  const today = new Date().toISOString().slice(0, 10);
+  const isPostRace = raceDate < today;
+
+  // ─── Load ───────────────────────────────────────────────────────────────
+
+  const load = useCallback(async () => {
+    try {
+      const [gearRes, raceGearRes] = await Promise.all([
+        fetch('/api/user/gear'),
+        fetch(`/api/user/races/${raceId}/gear`),
+      ]);
+      const myGearData: UserGear[] = gearRes.ok ? await gearRes.json() : [];
+      const raceGearData: RaceGearRow[] = raceGearRes.ok ? await raceGearRes.json() : [];
+      const active = myGearData.filter((g) => !g.is_retired);
+      setMyGear(active);
+      setRaceGear(raceGearData);
+      setDraft(raceGearData.map((item, i) => ({
+        gear_id: item.gear_id,
+        quantity: item.quantity,
+        sort_order: i,
+      })));
+    } catch {
+      // ignore
+    } finally {
+      setLoaded(true);
+    }
+  }, [raceId]);
+
+  useEffect(() => {
+    if (open && !loaded) {
+      load();
+    }
+  }, [open, loaded, load]);
+
+  // ─── Helpers ────────────────────────────────────────────────────────────
+
+  function getDraftLabel(d: DraftItem): string {
+    const fromGear = myGear.find((g) => g.id === d.gear_id);
+    if (fromGear) {
+      return fromGear.brand ? `${fromGear.brand} ${fromGear.name}` : fromGear.name;
+    }
+    const fromRace = raceGear.find((g) => g.gear_id === d.gear_id);
+    if (fromRace) {
+      return fromRace.brand ? `${fromRace.brand} ${fromRace.name}` : fromRace.name;
+    }
+    return d.gear_id;
+  }
+
+  function getRaceGearLabel(item: RaceGearRow): string {
+    return item.brand ? `${item.brand} ${item.name}` : item.name;
+  }
+
+  // ─── PUT (save pre-race list) ───────────────────────────────────────────
+
+  const handleSave = async () => {
+    setSaving(true);
+    setSaved(false);
+    try {
+      const res = await fetch(`/api/user/races/${raceId}/gear`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ items: draft }),
+      });
+      if (res.ok) {
+        const updated: RaceGearRow[] = await res.json();
+        setRaceGear(updated);
+        setDraft(updated.map((item, i) => ({
+          gear_id: item.gear_id,
+          quantity: item.quantity,
+          sort_order: i,
+        })));
+        setSaved(true);
+        setTimeout(() => setSaved(false), 2000);
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // ─── PATCH (post-race usage update) ────────────────────────────────────
+
+  const handlePatch = async (
+    gearId: string,
+    patch: { used: boolean | null; used_quantity?: number; note?: string },
+  ) => {
+    const res = await fetch(`/api/user/races/${raceId}/gear`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ gear_id: gearId, ...patch }),
+    });
+    if (res.ok) {
+      const updated = await res.json();
+      setRaceGear((prev) =>
+        prev.map((item) =>
+          item.gear_id === gearId ? { ...item, ...updated } : item,
+        ),
+      );
+    }
+  };
+
+  // ─── Add from my gear ───────────────────────────────────────────────────
+
+  const toggleAddSelect = (gearId: string) => {
+    setAddSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(gearId)) next.delete(gearId);
+      else next.add(gearId);
+      return next;
+    });
+  };
+
+  const confirmAdd = () => {
+    const currentIds = new Set(draft.map((d) => d.gear_id));
+    const toAdd = [...addSelected].filter((id) => !currentIds.has(id));
+    setDraft((prev) => [
+      ...prev,
+      ...toAdd.map((id, i) => ({
+        gear_id: id,
+        quantity: 1,
+        sort_order: prev.length + i,
+      })),
+    ]);
+    setShowAddPanel(false);
+    setAddSelected(new Set());
+  };
+
+  // ─── Copy from previous race ────────────────────────────────────────────
+
+  const handleCopyOpen = async () => {
+    const res = await fetch(`/api/user/races/${raceId}/gear?source=candidates`);
+    const data: Candidate[] = res.ok ? await res.json() : [];
+    setCandidates(data);
+    setSelectedCandidateRaceId(data[0]?.race_id ?? '');
+    setShowCopyPanel(true);
+  };
+
+  const confirmCopy = async () => {
+    if (!selectedCandidateRaceId) return;
+    const res = await fetch(`/api/user/races/${selectedCandidateRaceId}/gear`);
+    if (res.ok) {
+      const items: RaceGearRow[] = await res.json();
+      setDraft(items.map((item, i) => ({
+        gear_id: item.gear_id,
+        quantity: item.quantity,
+        sort_order: i,
+      })));
+      setShowCopyPanel(false);
+    }
+  };
+
+  // ─── Draft helpers ──────────────────────────────────────────────────────
+
+  const updateQty = (gearId: string, qty: number) => {
+    setDraft((prev) =>
+      prev.map((d) => (d.gear_id === gearId ? { ...d, quantity: qty } : d)),
+    );
+  };
+
+  const removeFromDraft = (gearId: string) => {
+    setDraft((prev) =>
+      prev
+        .filter((d) => d.gear_id !== gearId)
+        .map((d, i) => ({ ...d, sort_order: i })),
+    );
+  };
+
+  // ─── Toggle button ──────────────────────────────────────────────────────
+
+  const toggleButton = (
+    <button
+      onClick={() => setOpen((v) => !v)}
+      className="text-xs px-2 py-0.5 rounded-[3px] font-medium transition-colors"
+      style={{
+        background: open ? 'var(--color-primary)' : 'var(--color-cream)',
+        color: open ? '#fff' : 'var(--color-ink2)',
+        border: '1px solid var(--color-border)',
+      }}
+    >
+      {t('raceGearButton')}
+    </button>
+  );
+
+  // ─── Collapsed state ────────────────────────────────────────────────────
+
+  if (!open) return toggleButton;
+
+  // ─── Loading ────────────────────────────────────────────────────────────
+
+  if (!loaded) {
+    return (
+      <div className="w-full">
+        {toggleButton}
+        <div className="mt-2 animate-pulse h-12 bg-gray-100 rounded" />
+      </div>
+    );
+  }
+
+  // ─── No gear registered ─────────────────────────────────────────────────
+
+  if (myGear.length === 0) {
+    return (
+      <div className="w-full">
+        {toggleButton}
+        <div className="mt-2 text-xs" style={{ color: 'var(--color-mid)' }}>
+          {t('raceGearNoGear')}{' '}
+          <Link
+            href="/mypage/gear"
+            className="underline"
+            style={{ color: 'var(--color-primary)' }}
+          >
+            {t('raceGearGoToGear')}
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  // ─── Pre-race view ──────────────────────────────────────────────────────
+
+  if (!isPostRace) {
+    const availableToAdd = myGear.filter(
+      (g) => !draft.some((d) => d.gear_id === g.id),
+    );
+
+    return (
+      <div className="w-full">
+        {toggleButton}
+        <div
+          className="mt-2 rounded-lg p-3"
+          style={{
+            border: '1px solid var(--color-border)',
+            background: 'var(--color-cream)',
+          }}
+        >
+          {draft.length === 0 ? (
+            <p className="text-xs mb-2" style={{ color: 'var(--color-mid)' }}>
+              {t('raceGearEmpty')}
+            </p>
+          ) : (
+            <ul className="space-y-1 mb-2">
+              {draft.map((d) => (
+                <li key={d.gear_id} className="flex items-center gap-2 text-sm">
+                  <span className="flex-1 min-w-0 truncate text-xs">
+                    {getDraftLabel(d)}
+                  </span>
+                  <input
+                    type="number"
+                    min={1}
+                    max={999}
+                    value={d.quantity}
+                    onChange={(e) =>
+                      updateQty(d.gear_id, Math.max(1, parseInt(e.target.value) || 1))
+                    }
+                    className="w-12 text-center border rounded px-1 py-0.5 text-xs"
+                    style={{ borderColor: 'var(--color-border)' }}
+                    aria-label={t('raceGearQuantity')}
+                  />
+                  <button
+                    onClick={() => removeFromDraft(d.gear_id)}
+                    className="text-xs px-1.5 py-0.5 rounded"
+                    style={{ color: 'var(--color-mid)' }}
+                    aria-label="削除"
+                  >
+                    ×
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          <div className="flex flex-wrap gap-2">
+            <button
+              onClick={() => {
+                setAddSelected(new Set());
+                setShowAddPanel(true);
+              }}
+              className="text-xs px-2 py-1 rounded border"
+              style={{
+                borderColor: 'var(--color-border)',
+                color: 'var(--color-ink2)',
+                background: '#fff',
+              }}
+            >
+              {t('raceGearAddFromGear')}
+            </button>
+            <button
+              onClick={handleCopyOpen}
+              className="text-xs px-2 py-1 rounded border"
+              style={{
+                borderColor: 'var(--color-border)',
+                color: 'var(--color-ink2)',
+                background: '#fff',
+              }}
+            >
+              {t('raceGearCopyFromPrev')}
+            </button>
+            <button
+              onClick={handleSave}
+              disabled={saving}
+              className="text-xs px-2 py-1 rounded font-medium"
+              style={{ background: 'var(--color-primary)', color: '#fff' }}
+            >
+              {saving ? t('raceGearSaving') : saved ? t('raceGearSaved') : t('raceGearSave')}
+            </button>
+          </div>
+
+          {/* マイギアから追加パネル */}
+          {showAddPanel && (
+            <div
+              className="mt-3 rounded p-2"
+              style={{ border: '1px solid var(--color-border)', background: '#fff' }}
+            >
+              <p className="text-xs font-semibold mb-2">{t('raceGearAddFromGear')}</p>
+              {availableToAdd.length === 0 ? (
+                <p className="text-xs" style={{ color: 'var(--color-mid)' }}>
+                  {t('raceGearEmpty')}
+                </p>
+              ) : (
+                <ul className="space-y-1 max-h-48 overflow-y-auto mb-2">
+                  {availableToAdd.map((g) => (
+                    <li
+                      key={g.id}
+                      className="flex items-center gap-2 text-xs cursor-pointer py-0.5"
+                      onClick={() => toggleAddSelect(g.id)}
+                    >
+                      <input
+                        type="checkbox"
+                        readOnly
+                        checked={addSelected.has(g.id)}
+                        className="pointer-events-none"
+                      />
+                      <span>
+                        {g.brand ? `${g.brand} ` : ''}
+                        {g.name}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              <div className="flex gap-2">
+                <button
+                  onClick={confirmAdd}
+                  disabled={addSelected.size === 0}
+                  className="text-xs px-2 py-1 rounded font-medium"
+                  style={{ background: 'var(--color-primary)', color: '#fff' }}
+                >
+                  追加
+                </button>
+                <button
+                  onClick={() => setShowAddPanel(false)}
+                  className="text-xs px-2 py-1 rounded"
+                  style={{ color: 'var(--color-mid)' }}
+                >
+                  キャンセル
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* 前回からコピーパネル */}
+          {showCopyPanel && (
+            <div
+              className="mt-3 rounded p-2"
+              style={{ border: '1px solid var(--color-border)', background: '#fff' }}
+            >
+              <p className="text-xs font-semibold mb-2">{t('raceGearCopySelect')}</p>
+              {candidates.length === 0 ? (
+                <p className="text-xs" style={{ color: 'var(--color-mid)' }}>
+                  {t('raceGearNoCandidates')}
+                </p>
+              ) : (
+                <>
+                  <select
+                    value={selectedCandidateRaceId}
+                    onChange={(e) => setSelectedCandidateRaceId(e.target.value)}
+                    className="text-xs border rounded px-1 py-0.5 w-full mb-2"
+                    style={{ borderColor: 'var(--color-border)' }}
+                  >
+                    {candidates.map((c) => (
+                      <option key={c.user_race_id} value={c.race_id}>
+                        {c.race_id} ({c.gear_count})
+                      </option>
+                    ))}
+                  </select>
+                  <div className="flex gap-2">
+                    <button
+                      onClick={confirmCopy}
+                      className="text-xs px-2 py-1 rounded font-medium"
+                      style={{ background: 'var(--color-primary)', color: '#fff' }}
+                    >
+                      {t('raceGearCopyConfirm')}
+                    </button>
+                    <button
+                      onClick={() => setShowCopyPanel(false)}
+                      className="text-xs px-2 py-1 rounded"
+                      style={{ color: 'var(--color-mid)' }}
+                    >
+                      キャンセル
+                    </button>
+                  </div>
+                </>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // ─── Post-race view ─────────────────────────────────────────────────────
+
+  return (
+    <div className="w-full">
+      {toggleButton}
+      <div
+        className="mt-2 rounded-lg p-3"
+        style={{
+          border: '1px solid var(--color-border)',
+          background: 'var(--color-cream)',
+        }}
+      >
+        {raceGear.length === 0 ? (
+          <p className="text-xs" style={{ color: 'var(--color-mid)' }}>
+            {t('raceGearEmpty')}
+          </p>
+        ) : (
+          <ul className="space-y-3">
+            {raceGear.map((item) => (
+              <li key={item.gear_id} className="text-xs">
+                <div className="flex items-center gap-2 mb-1">
+                  <span className="flex-1 font-medium">{getRaceGearLabel(item)}</span>
+                  <span style={{ color: 'var(--color-mid)' }}>×{item.quantity}</span>
+                </div>
+                <div className="flex items-center gap-1 flex-wrap mb-1">
+                  {(
+                    [
+                      { key: 'used', value: true as boolean | null, label: t('raceGearUsed') },
+                      { key: 'not_used', value: false as boolean | null, label: t('raceGearNotUsed') },
+                      { key: 'unknown', value: null as boolean | null, label: t('raceGearUsedUnknown') },
+                    ] as const
+                  ).map(({ key, value, label }) => {
+                    const isActive =
+                      key === 'used'
+                        ? item.used === true
+                        : key === 'not_used'
+                          ? item.used === false
+                          : item.used === null;
+                    return (
+                      <button
+                        key={key}
+                        onClick={() => handlePatch(item.gear_id, { used: value })}
+                        className="px-1.5 py-0.5 rounded-[3px]"
+                        style={{
+                          background: isActive
+                            ? key === 'used'
+                              ? 'var(--color-primary)'
+                              : key === 'not_used'
+                                ? '#6b7280'
+                                : 'var(--color-border)'
+                            : 'var(--color-cream)',
+                          color:
+                            isActive && key !== 'unknown' ? '#fff' : 'var(--color-ink2)',
+                          border: '1px solid var(--color-border)',
+                        }}
+                      >
+                        {label}
+                      </button>
+                    );
+                  })}
+                  {item.used === true && (
+                    <input
+                      type="number"
+                      min={0}
+                      max={999}
+                      defaultValue={item.used_quantity ?? ''}
+                      onBlur={(e) =>
+                        handlePatch(item.gear_id, {
+                          used: true,
+                          used_quantity: parseInt(e.target.value) || 0,
+                        })
+                      }
+                      placeholder={t('raceGearUsedQuantity')}
+                      className="w-16 border rounded px-1 py-0.5"
+                      style={{ borderColor: 'var(--color-border)' }}
+                    />
+                  )}
+                </div>
+                <input
+                  type="text"
+                  defaultValue={item.note}
+                  onBlur={(e) => {
+                    if (e.target.value !== item.note) {
+                      handlePatch(item.gear_id, { used: item.used, note: e.target.value });
+                    }
+                  }}
+                  placeholder={t('raceGearNote')}
+                  className="w-full border rounded px-2 py-1"
+                  style={{ borderColor: 'var(--color-border)' }}
+                />
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/mypage/RaceGearSection.tsx
+++ b/src/components/mypage/RaceGearSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import { useTranslations } from 'next-intl';
 import { Link } from '@/i18n/navigation';
 import { type UserGear } from '@/lib/types';
@@ -57,8 +57,13 @@ export default function RaceGearSection({ raceId, raceDate }: Props) {
   const [selectedCandidateRaceId, setSelectedCandidateRaceId] = useState('');
   const [draft, setDraft] = useState<DraftItem[]>([]);
   const [addSelected, setAddSelected] = useState<Set<string>>(new Set());
+  const [patchError, setPatchError] = useState<string | null>(null);
 
-  const today = new Date().toISOString().slice(0, 10);
+  const today = new Intl.DateTimeFormat('en-CA', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(new Date());
   const isPostRace = raceDate < today;
 
   // ─── Load ───────────────────────────────────────────────────────────────
@@ -86,11 +91,13 @@ export default function RaceGearSection({ raceId, raceDate }: Props) {
     }
   }, [raceId]);
 
-  useEffect(() => {
-    if (open && !loaded) {
-      load();
-    }
-  }, [open, loaded, load]);
+  const handleToggle = () => {
+    setOpen((v) => {
+      const next = !v;
+      if (next && !loaded) void load();
+      return next;
+    });
+  };
 
   // ─── Helpers ────────────────────────────────────────────────────────────
 
@@ -143,18 +150,25 @@ export default function RaceGearSection({ raceId, raceDate }: Props) {
     gearId: string,
     patch: { used: boolean | null; used_quantity?: number; note?: string },
   ) => {
-    const res = await fetch(`/api/user/races/${raceId}/gear`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ gear_id: gearId, ...patch }),
-    });
-    if (res.ok) {
+    try {
+      setPatchError(null);
+      const res = await fetch(`/api/user/races/${raceId}/gear`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ gear_id: gearId, ...patch }),
+      });
+      if (!res.ok) {
+        setPatchError(t('raceGearPatchError'));
+        return;
+      }
       const updated = await res.json();
       setRaceGear((prev) =>
         prev.map((item) =>
           item.gear_id === gearId ? { ...item, ...updated } : item,
         ),
       );
+    } catch {
+      setPatchError(t('raceGearPatchError'));
     }
   };
 
@@ -228,7 +242,7 @@ export default function RaceGearSection({ raceId, raceDate }: Props) {
 
   const toggleButton = (
     <button
-      onClick={() => setOpen((v) => !v)}
+      onClick={handleToggle}
       className="text-xs px-2 py-0.5 rounded-[3px] font-medium transition-colors"
       style={{
         background: open ? 'var(--color-primary)' : 'var(--color-cream)',
@@ -319,7 +333,7 @@ export default function RaceGearSection({ raceId, raceDate }: Props) {
                     onClick={() => removeFromDraft(d.gear_id)}
                     className="text-xs px-1.5 py-0.5 rounded"
                     style={{ color: 'var(--color-mid)' }}
-                    aria-label="削除"
+                    aria-label={t('raceGearRemove')}
                   >
                     ×
                   </button>
@@ -404,14 +418,14 @@ export default function RaceGearSection({ raceId, raceDate }: Props) {
                   className="text-xs px-2 py-1 rounded font-medium"
                   style={{ background: 'var(--color-primary)', color: '#fff' }}
                 >
-                  追加
+                  {t('raceGearAdd')}
                 </button>
                 <button
                   onClick={() => setShowAddPanel(false)}
                   className="text-xs px-2 py-1 rounded"
                   style={{ color: 'var(--color-mid)' }}
                 >
-                  キャンセル
+                  {t('raceGearCancel')}
                 </button>
               </div>
             </div>
@@ -455,7 +469,7 @@ export default function RaceGearSection({ raceId, raceDate }: Props) {
                       className="text-xs px-2 py-1 rounded"
                       style={{ color: 'var(--color-mid)' }}
                     >
-                      キャンセル
+                      {t('raceGearCancel')}
                     </button>
                   </div>
                 </>
@@ -479,6 +493,11 @@ export default function RaceGearSection({ raceId, raceDate }: Props) {
           background: 'var(--color-cream)',
         }}
       >
+        {patchError && (
+          <p className="text-xs mb-2" style={{ color: 'var(--color-primary)' }}>
+            {patchError}
+          </p>
+        )}
         {raceGear.length === 0 ? (
           <p className="text-xs" style={{ color: 'var(--color-mid)' }}>
             {t('raceGearEmpty')}

--- a/src/components/mypage/RaceGearSection.tsx
+++ b/src/components/mypage/RaceGearSection.tsx
@@ -60,6 +60,7 @@ export default function RaceGearSection({ raceId, raceDate }: Props) {
   const [patchError, setPatchError] = useState<string | null>(null);
 
   const today = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Asia/Tokyo',
     year: 'numeric',
     month: '2-digit',
     day: '2-digit',
@@ -92,11 +93,9 @@ export default function RaceGearSection({ raceId, raceDate }: Props) {
   }, [raceId]);
 
   const handleToggle = () => {
-    setOpen((v) => {
-      const next = !v;
-      if (next && !loaded) void load();
-      return next;
-    });
+    const nextOpen = !open;
+    setOpen(nextOpen);
+    if (nextOpen && !loaded) void load();
   };
 
   // ─── Helpers ────────────────────────────────────────────────────────────

--- a/src/components/mypage/UserRaceList.tsx
+++ b/src/components/mypage/UserRaceList.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import { useSession } from '@/lib/auth-client';
 import { Link } from '@/i18n/navigation';
+import RaceGearSection from './RaceGearSection';
 
 interface UserRaceRow {
   id: string;
@@ -89,7 +90,7 @@ export default function UserRaceList() {
     );
   }
 
-  function RaceItem({ row, badge }: { row: UserRaceRow; badge?: React.ReactNode }) {
+  function RaceItem({ row }: { row: UserRaceRow }) {
     const race = raceMap.get(row.race_id);
     const name = race ? (race.full_name_ja ?? race.name_ja) : row.race_id;
 
@@ -100,40 +101,46 @@ export default function UserRaceList() {
     const reminderIds: number[] = (() => { try { return JSON.parse(row.entry_reminder_period_ids ?? '[]'); } catch { return []; } })();
 
     return (
-      <div className="flex items-center justify-between py-3 border-b border-[var(--color-border)] last:border-0">
-        <div className="flex-1 min-w-0">
-          <Link
-            href={`/races/${row.race_id}`}
-            className="text-sm font-medium no-underline hover:underline"
-            style={{ color: 'var(--color-ink)' }}
-          >
-            {name}
-          </Link>
-          <div className="flex flex-wrap items-center gap-2 mt-0.5">
-            {race && (
-              <span className="text-xs" style={{ color: 'var(--color-mid)' }}>
-                {race.date}
-              </span>
-            )}
-            {cat && row.is_planning && (
-              <span
-                className="text-xs px-2 py-0.5 rounded-[3px] font-medium"
-                style={{ background: 'var(--color-cream)', color: 'var(--color-ink2)', border: '1px solid var(--color-border)' }}
-              >
-                {getCatLabel(cat)} · {cat.distance_km}km
+      <div className="py-3 border-b border-[var(--color-border)] last:border-0">
+        <div className="flex items-center justify-between">
+          <div className="flex-1 min-w-0">
+            <Link
+              href={`/races/${row.race_id}`}
+              className="text-sm font-medium no-underline hover:underline"
+              style={{ color: 'var(--color-ink)' }}
+            >
+              {name}
+            </Link>
+            <div className="flex flex-wrap items-center gap-2 mt-0.5">
+              {race && (
+                <span className="text-xs" style={{ color: 'var(--color-mid)' }}>
+                  {race.date}
+                </span>
+              )}
+              {cat && row.is_planning && (
+                <span
+                  className="text-xs px-2 py-0.5 rounded-[3px] font-medium"
+                  style={{ background: 'var(--color-cream)', color: 'var(--color-ink2)', border: '1px solid var(--color-border)' }}
+                >
+                  {getCatLabel(cat)} · {cat.distance_km}km
+                </span>
+              )}
+            </div>
+          </div>
+          <div className="flex items-center gap-2 shrink-0 ml-4">
+            {reminderIds.length > 0 && (
+              <span className="text-xs px-2 py-0.5 rounded-[3px]"
+                style={{ background: '#fef3c7', color: '#92400e' }}>
+                🔔 リマインド{reminderIds.length > 1 ? `×${reminderIds.length}` : ''}
               </span>
             )}
           </div>
         </div>
-        <div className="flex items-center gap-2 shrink-0 ml-4">
-          {badge}
-          {reminderIds.length > 0 && (
-            <span className="text-xs px-2 py-0.5 rounded-[3px]"
-              style={{ background: '#fef3c7', color: '#92400e' }}>
-              🔔 リマインド{reminderIds.length > 1 ? `×${reminderIds.length}` : ''}
-            </span>
-          )}
-        </div>
+        {race && (
+          <div className="mt-2">
+            <RaceGearSection raceId={row.race_id} raceDate={race.date} />
+          </div>
+        )}
       </div>
     );
   }
@@ -149,6 +156,7 @@ export default function UserRaceList() {
             {planning.map((row) => (
               <RaceItem key={row.id} row={row} />
             ))}
+
           </div>
         </div>
       )}

--- a/src/components/mypage/UserRaceList.tsx
+++ b/src/components/mypage/UserRaceList.tsx
@@ -35,6 +35,64 @@ function getCatLabel(cat: CategoryInfo): string {
   return cat.name_ja ?? `${cat.distance_km}km`;
 }
 
+function RaceItem({ row, raceMap }: { row: UserRaceRow; raceMap: Map<string, RaceInfo> }) {
+  const race = raceMap.get(row.race_id);
+  const name = race ? (race.full_name_ja ?? race.name_ja) : row.race_id;
+
+  // 参加予定カテゴリ
+  const cat = race?.categories?.find((c) => c.id === row.planning_category_id);
+
+  // リマインド設定済み期間数
+  const reminderIds: number[] = (() => { try { return JSON.parse(row.entry_reminder_period_ids ?? '[]'); } catch { return []; } })();
+
+  return (
+    <div
+      className="py-3 border-b last:border-0"
+      style={{ borderColor: 'var(--color-border)' }}
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex-1 min-w-0">
+          <Link
+            href={`/races/${row.race_id}`}
+            className="text-sm font-medium no-underline hover:underline"
+            style={{ color: 'var(--color-ink)' }}
+          >
+            {name}
+          </Link>
+          <div className="flex flex-wrap items-center gap-2 mt-0.5">
+            {race && (
+              <span className="text-xs" style={{ color: 'var(--color-mid)' }}>
+                {race.date}
+              </span>
+            )}
+            {cat && row.is_planning && (
+              <span
+                className="text-xs px-2 py-0.5 rounded-[3px] font-medium"
+                style={{ background: 'var(--color-cream)', color: 'var(--color-ink2)', border: '1px solid var(--color-border)' }}
+              >
+                {getCatLabel(cat)} · {cat.distance_km}km
+              </span>
+            )}
+          </div>
+        </div>
+        <div className="flex items-center gap-2 shrink-0 ml-4">
+          {reminderIds.length > 0 && (
+            <span className="text-xs px-2 py-0.5 rounded-[3px]"
+              style={{ background: '#fef3c7', color: '#92400e' }}>
+              🔔 リマインド{reminderIds.length > 1 ? `×${reminderIds.length}` : ''}
+            </span>
+          )}
+        </div>
+      </div>
+      {race && (
+        <div className="mt-2">
+          <RaceGearSection raceId={row.race_id} raceDate={race.date} />
+        </div>
+      )}
+    </div>
+  );
+}
+
 export default function UserRaceList() {
   const { data: session } = useSession();
   const [rows, setRows] = useState<UserRaceRow[]>([]);
@@ -90,61 +148,6 @@ export default function UserRaceList() {
     );
   }
 
-  function RaceItem({ row }: { row: UserRaceRow }) {
-    const race = raceMap.get(row.race_id);
-    const name = race ? (race.full_name_ja ?? race.name_ja) : row.race_id;
-
-    // 参加予定カテゴリ
-    const cat = race?.categories?.find((c) => c.id === row.planning_category_id);
-
-    // リマインド設定済み期間数
-    const reminderIds: number[] = (() => { try { return JSON.parse(row.entry_reminder_period_ids ?? '[]'); } catch { return []; } })();
-
-    return (
-      <div className="py-3 border-b border-[var(--color-border)] last:border-0">
-        <div className="flex items-center justify-between">
-          <div className="flex-1 min-w-0">
-            <Link
-              href={`/races/${row.race_id}`}
-              className="text-sm font-medium no-underline hover:underline"
-              style={{ color: 'var(--color-ink)' }}
-            >
-              {name}
-            </Link>
-            <div className="flex flex-wrap items-center gap-2 mt-0.5">
-              {race && (
-                <span className="text-xs" style={{ color: 'var(--color-mid)' }}>
-                  {race.date}
-                </span>
-              )}
-              {cat && row.is_planning && (
-                <span
-                  className="text-xs px-2 py-0.5 rounded-[3px] font-medium"
-                  style={{ background: 'var(--color-cream)', color: 'var(--color-ink2)', border: '1px solid var(--color-border)' }}
-                >
-                  {getCatLabel(cat)} · {cat.distance_km}km
-                </span>
-              )}
-            </div>
-          </div>
-          <div className="flex items-center gap-2 shrink-0 ml-4">
-            {reminderIds.length > 0 && (
-              <span className="text-xs px-2 py-0.5 rounded-[3px]"
-                style={{ background: '#fef3c7', color: '#92400e' }}>
-                🔔 リマインド{reminderIds.length > 1 ? `×${reminderIds.length}` : ''}
-              </span>
-            )}
-          </div>
-        </div>
-        {race && (
-          <div className="mt-2">
-            <RaceGearSection raceId={row.race_id} raceDate={race.date} />
-          </div>
-        )}
-      </div>
-    );
-  }
-
   return (
     <div className="space-y-6">
       {planning.length > 0 && (
@@ -154,7 +157,7 @@ export default function UserRaceList() {
           </p>
           <div>
             {planning.map((row) => (
-              <RaceItem key={row.id} row={row} />
+              <RaceItem key={row.id} row={row} raceMap={raceMap} />
             ))}
 
           </div>
@@ -168,7 +171,7 @@ export default function UserRaceList() {
           </p>
           <div>
             {reminders.map((row) => (
-              <RaceItem key={row.id} row={row} />
+              <RaceItem key={row.id} row={row} raceMap={raceMap} />
             ))}
           </div>
         </div>

--- a/src/components/mypage/__tests__/RaceGearSection.test.tsx
+++ b/src/components/mypage/__tests__/RaceGearSection.test.tsx
@@ -24,6 +24,10 @@ const TRANSLATION_MAP: Record<string, string> = {
   raceGearUsedQuantity: '使用数',
   raceGearNote: 'メモ',
   raceGearGoToGear: 'ギアを登録する',
+  raceGearRemove: '削除',
+  raceGearAdd: '追加',
+  raceGearCancel: 'キャンセル',
+  raceGearPatchError: '保存に失敗しました',
 };
 
 vi.mock('next-intl', () => ({

--- a/src/components/mypage/__tests__/RaceGearSection.test.tsx
+++ b/src/components/mypage/__tests__/RaceGearSection.test.tsx
@@ -1,0 +1,369 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import RaceGearSection from '../RaceGearSection';
+
+// ─── モック ──────────────────────────────────────────────────────────────────
+
+const TRANSLATION_MAP: Record<string, string> = {
+  raceGearButton: '装備',
+  raceGearEmpty: '装備なし',
+  raceGearNoGear: 'ギアを登録してリストを作成',
+  raceGearAddFromGear: 'マイギアから追加',
+  raceGearCopyFromPrev: '前のレースからコピー',
+  raceGearCopySelect: 'コピー元を選択',
+  raceGearCopyConfirm: 'このリストをコピー',
+  raceGearNoCandidates: 'コピー元なし',
+  raceGearSave: '保存',
+  raceGearSaving: '保存中…',
+  raceGearSaved: '保存済み',
+  raceGearQuantity: '数量',
+  raceGearUsed: '使用',
+  raceGearNotUsed: '未使用',
+  raceGearUsedUnknown: '未記録',
+  raceGearUsedQuantity: '使用数',
+  raceGearNote: 'メモ',
+  raceGearGoToGear: 'ギアを登録する',
+};
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => TRANSLATION_MAP[key] ?? key,
+}));
+
+vi.mock('@/i18n/navigation', () => ({
+  Link: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+// ─── テストデータ ──────────────────────────────────────────────────────────────
+
+const MOCK_MY_GEAR = [
+  {
+    id: 'gear-1',
+    user_id: 'user-1',
+    category: 'shoes',
+    brand: 'Nike',
+    name: 'Vaporfly',
+    amazon_url: null,
+    asin: null,
+    usage_tag: 'race',
+    memo: '',
+    is_retired: false,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 'gear-2',
+    user_id: 'user-1',
+    category: 'tops',
+    brand: null,
+    name: 'ランニングシャツ',
+    amazon_url: null,
+    asin: null,
+    usage_tag: 'both',
+    memo: '',
+    is_retired: false,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  },
+];
+
+const MOCK_RACE_GEAR = [
+  {
+    gear_id: 'gear-1',
+    quantity: 1,
+    used: null,
+    used_quantity: null,
+    note: '',
+    sort_order: 0,
+    name: 'Vaporfly',
+    brand: 'Nike',
+    category: 'shoes',
+    asin: null,
+    amazon_url: null,
+  },
+];
+
+const MOCK_CANDIDATES = [
+  { user_race_id: 'ur-other', race_id: 'osaka-marathon-2026', gear_count: 3 },
+];
+
+function setupFetch(opts: {
+  myGear?: unknown[];
+  raceGear?: unknown[];
+  candidates?: unknown[];
+  putResponse?: unknown[];
+  patchResponse?: unknown;
+} = {}) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+      const method = init?.method ?? 'GET';
+
+      if (url === '/api/user/gear' && method === 'GET') {
+        return Promise.resolve({ ok: true, json: async () => opts.myGear ?? [] });
+      }
+      if (url.includes('/gear?source=candidates')) {
+        return Promise.resolve({ ok: true, json: async () => opts.candidates ?? [] });
+      }
+      if (url.includes('/gear') && method === 'GET') {
+        return Promise.resolve({ ok: true, json: async () => opts.raceGear ?? [] });
+      }
+      if (url.includes('/gear') && method === 'PUT') {
+        return Promise.resolve({ ok: true, json: async () => opts.putResponse ?? opts.raceGear ?? [] });
+      }
+      if (url.includes('/gear') && method === 'PATCH') {
+        return Promise.resolve({ ok: true, json: async () => opts.patchResponse ?? (opts.raceGear ?? [])[0] ?? {} });
+      }
+      return Promise.resolve({ ok: false, json: async () => ({}) });
+    }),
+  );
+}
+
+const FUTURE_DATE = '2099-12-31';
+const PAST_DATE = '2020-01-01';
+const RACE_ID = 'tokyo-marathon-2026';
+
+// ─── テスト ──────────────────────────────────────────────────────────────────
+
+describe('RaceGearSection — 初期状態', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('「装備」ボタンが表示される', () => {
+    render(<RaceGearSection raceId={RACE_ID} raceDate={FUTURE_DATE} />);
+    expect(screen.getByRole('button', { name: '装備' })).toBeInTheDocument();
+  });
+
+  it('初期状態では展開パネルは表示されない', () => {
+    render(<RaceGearSection raceId={RACE_ID} raceDate={FUTURE_DATE} />);
+    expect(screen.queryByText('マイギアから追加')).not.toBeInTheDocument();
+  });
+});
+
+describe('RaceGearSection — 展開・データ読み込み', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('ボタンクリックでデータを取得してパネルが展開される', async () => {
+    setupFetch({ myGear: MOCK_MY_GEAR, raceGear: MOCK_RACE_GEAR });
+
+    render(<RaceGearSection raceId={RACE_ID} raceDate={FUTURE_DATE} />);
+    fireEvent.click(screen.getByRole('button', { name: '装備' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('マイギアから追加')).toBeInTheDocument();
+    });
+  });
+
+  it('マイギア0件: ギア登録リンクを表示', async () => {
+    setupFetch({ myGear: [], raceGear: [] });
+
+    render(<RaceGearSection raceId={RACE_ID} raceDate={FUTURE_DATE} />);
+    fireEvent.click(screen.getByRole('button', { name: '装備' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('ギアを登録してリストを作成')).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'ギアを登録する' })).toBeInTheDocument();
+    });
+  });
+
+  it('引退済みギアはマイギアリストに含まれない', async () => {
+    const retiredGear = [
+      { ...MOCK_MY_GEAR[0], is_retired: true },
+    ];
+    setupFetch({ myGear: retiredGear, raceGear: [] });
+
+    render(<RaceGearSection raceId={RACE_ID} raceDate={FUTURE_DATE} />);
+    fireEvent.click(screen.getByRole('button', { name: '装備' }));
+
+    await waitFor(() => {
+      // 引退ギアのみ → アクティブギアなし → ギア登録リンクを表示
+      expect(screen.getByText('ギアを登録してリストを作成')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('RaceGearSection — レース前（pre-race）', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupFetch({ myGear: MOCK_MY_GEAR, raceGear: MOCK_RACE_GEAR });
+  });
+
+  it('装備アイテムを表示する', async () => {
+    render(<RaceGearSection raceId={RACE_ID} raceDate={FUTURE_DATE} />);
+    fireEvent.click(screen.getByRole('button', { name: '装備' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Nike Vaporfly')).toBeInTheDocument();
+    });
+  });
+
+  it('「マイギアから追加」「前のレースからコピー」「保存」ボタンを表示', async () => {
+    render(<RaceGearSection raceId={RACE_ID} raceDate={FUTURE_DATE} />);
+    fireEvent.click(screen.getByRole('button', { name: '装備' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'マイギアから追加' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '前のレースからコピー' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '保存' })).toBeInTheDocument();
+    });
+  });
+
+  it('装備リストが空の場合「装備なし」を表示', async () => {
+    setupFetch({ myGear: MOCK_MY_GEAR, raceGear: [] });
+
+    render(<RaceGearSection raceId={RACE_ID} raceDate={FUTURE_DATE} />);
+    fireEvent.click(screen.getByRole('button', { name: '装備' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('装備なし')).toBeInTheDocument();
+    });
+  });
+
+  it('「保存」ボタンクリックでPUT APIを呼ぶ', async () => {
+    render(<RaceGearSection raceId={RACE_ID} raceDate={FUTURE_DATE} />);
+    fireEvent.click(screen.getByRole('button', { name: '装備' }));
+
+    await waitFor(() => screen.getByRole('button', { name: '保存' }));
+    fireEvent.click(screen.getByRole('button', { name: '保存' }));
+
+    await waitFor(() => {
+      const fetchMock = vi.mocked(fetch);
+      const putCall = fetchMock.mock.calls.find(
+        ([url, init]) => String(url).includes('/gear') && (init as RequestInit)?.method === 'PUT',
+      );
+      expect(putCall).toBeDefined();
+    });
+  });
+
+  it('×ボタンでアイテムをドラフトから削除できる', async () => {
+    render(<RaceGearSection raceId={RACE_ID} raceDate={FUTURE_DATE} />);
+    fireEvent.click(screen.getByRole('button', { name: '装備' }));
+
+    await waitFor(() => screen.getByText('Nike Vaporfly'));
+
+    fireEvent.click(screen.getByRole('button', { name: '削除' }));
+
+    expect(screen.queryByText('Nike Vaporfly')).not.toBeInTheDocument();
+    expect(screen.getByText('装備なし')).toBeInTheDocument();
+  });
+});
+
+describe('RaceGearSection — レース後（post-race）', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupFetch({ myGear: MOCK_MY_GEAR, raceGear: MOCK_RACE_GEAR });
+  });
+
+  it('使用/未使用/未記録トグルを表示する', async () => {
+    render(<RaceGearSection raceId={RACE_ID} raceDate={PAST_DATE} />);
+    fireEvent.click(screen.getByRole('button', { name: '装備' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '使用' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '未使用' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '未記録' })).toBeInTheDocument();
+    });
+  });
+
+  it('「使用」ボタンクリックでPATCH APIを呼ぶ', async () => {
+    const patchedItem = { ...MOCK_RACE_GEAR[0], used: true };
+    setupFetch({ myGear: MOCK_MY_GEAR, raceGear: MOCK_RACE_GEAR, patchResponse: patchedItem });
+
+    render(<RaceGearSection raceId={RACE_ID} raceDate={PAST_DATE} />);
+    fireEvent.click(screen.getByRole('button', { name: '装備' }));
+
+    await waitFor(() => screen.getByRole('button', { name: '使用' }));
+    fireEvent.click(screen.getByRole('button', { name: '使用' }));
+
+    await waitFor(() => {
+      const fetchMock = vi.mocked(fetch);
+      const patchCall = fetchMock.mock.calls.find(
+        ([url, init]) => String(url).includes('/gear') && (init as RequestInit)?.method === 'PATCH',
+      );
+      expect(patchCall).toBeDefined();
+    });
+  });
+
+  it('レース前UIのボタン（保存・追加・コピー）が表示されない', async () => {
+    render(<RaceGearSection raceId={RACE_ID} raceDate={PAST_DATE} />);
+    fireEvent.click(screen.getByRole('button', { name: '装備' }));
+
+    await waitFor(() => screen.getByRole('button', { name: '使用' }));
+
+    expect(screen.queryByRole('button', { name: '保存' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'マイギアから追加' })).not.toBeInTheDocument();
+  });
+});
+
+describe('RaceGearSection — マイギアから追加', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupFetch({ myGear: MOCK_MY_GEAR, raceGear: [] });
+  });
+
+  it('「マイギアから追加」クリックで選択パネルを表示', async () => {
+    render(<RaceGearSection raceId={RACE_ID} raceDate={FUTURE_DATE} />);
+    fireEvent.click(screen.getByRole('button', { name: '装備' }));
+
+    await waitFor(() => screen.getByRole('button', { name: 'マイギアから追加' }));
+    fireEvent.click(screen.getByRole('button', { name: 'マイギアから追加' }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Vaporfly/)).toBeInTheDocument();
+      expect(screen.getByText('ランニングシャツ')).toBeInTheDocument();
+    });
+  });
+
+  it('ギアを選択して追加するとドラフトに追加される', async () => {
+    render(<RaceGearSection raceId={RACE_ID} raceDate={FUTURE_DATE} />);
+    fireEvent.click(screen.getByRole('button', { name: '装備' }));
+
+    await waitFor(() => screen.getByRole('button', { name: 'マイギアから追加' }));
+    fireEvent.click(screen.getByRole('button', { name: 'マイギアから追加' }));
+
+    await waitFor(() => screen.getByText(/Vaporfly/));
+    // チェックボックスをクリック
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[0]);
+
+    fireEvent.click(screen.getByRole('button', { name: '追加' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Nike Vaporfly')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('RaceGearSection — 前のレースからコピー', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('候補が0件の場合「コピー元なし」を表示', async () => {
+    setupFetch({ myGear: MOCK_MY_GEAR, raceGear: [], candidates: [] });
+
+    render(<RaceGearSection raceId={RACE_ID} raceDate={FUTURE_DATE} />);
+    fireEvent.click(screen.getByRole('button', { name: '装備' }));
+
+    await waitFor(() => screen.getByRole('button', { name: '前のレースからコピー' }));
+    fireEvent.click(screen.getByRole('button', { name: '前のレースからコピー' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('コピー元なし')).toBeInTheDocument();
+    });
+  });
+
+  it('候補が存在する場合、セレクトボックスを表示', async () => {
+    setupFetch({ myGear: MOCK_MY_GEAR, raceGear: [], candidates: MOCK_CANDIDATES });
+
+    render(<RaceGearSection raceId={RACE_ID} raceDate={FUTURE_DATE} />);
+    fireEvent.click(screen.getByRole('button', { name: '装備' }));
+
+    await waitFor(() => screen.getByRole('button', { name: '前のレースからコピー' }));
+    fireEvent.click(screen.getByRole('button', { name: '前のレースからコピー' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('combobox')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'このリストをコピー' })).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/mypage/__tests__/UserRaceList.test.tsx
+++ b/src/components/mypage/__tests__/UserRaceList.test.tsx
@@ -10,6 +10,10 @@ vi.mock('@/i18n/navigation', () => ({
   ),
 }));
 
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
 const { mockUseSession } = vi.hoisted(() => ({
   mockUseSession: vi.fn(),
 }));

--- a/src/lib/__tests__/race-gear-validation.test.ts
+++ b/src/lib/__tests__/race-gear-validation.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest';
+import { validatePutBody, validatePatchBody } from '../race-gear-validation';
+
+describe('validatePutBody', () => {
+  const validItem = { gear_id: 'gear-uuid-1', quantity: 1, sort_order: 0 };
+
+  it('正常なbodyを受け付ける', () => {
+    const result = validatePutBody({ items: [validItem] });
+    expect('data' in result).toBe(true);
+    if ('data' in result) {
+      expect(result.data.items).toHaveLength(1);
+      expect(result.data.items[0].gear_id).toBe('gear-uuid-1');
+    }
+  });
+
+  it('items が空配列でも受け付ける', () => {
+    const result = validatePutBody({ items: [] });
+    expect('data' in result).toBe(true);
+  });
+
+  it('items がない場合はエラー', () => {
+    const result = validatePutBody({});
+    expect('error' in result).toBe(true);
+  });
+
+  it('items が配列でない場合はエラー', () => {
+    const result = validatePutBody({ items: 'foo' });
+    expect('error' in result).toBe(true);
+  });
+
+  it('gear_id が空文字の場合はエラー', () => {
+    const result = validatePutBody({ items: [{ gear_id: '', quantity: 1, sort_order: 0 }] });
+    expect('error' in result).toBe(true);
+  });
+
+  it('quantity が 0 の場合はエラー（1〜999）', () => {
+    const result = validatePutBody({ items: [{ gear_id: 'x', quantity: 0, sort_order: 0 }] });
+    expect('error' in result).toBe(true);
+  });
+
+  it('quantity が 1000 の場合はエラー', () => {
+    const result = validatePutBody({ items: [{ gear_id: 'x', quantity: 1000, sort_order: 0 }] });
+    expect('error' in result).toBe(true);
+  });
+
+  it('quantity が 999 は正常', () => {
+    const result = validatePutBody({ items: [{ gear_id: 'x', quantity: 999, sort_order: 0 }] });
+    expect('data' in result).toBe(true);
+  });
+
+  it('quantity が小数の場合はエラー', () => {
+    const result = validatePutBody({ items: [{ gear_id: 'x', quantity: 1.5, sort_order: 0 }] });
+    expect('error' in result).toBe(true);
+  });
+
+  it('sort_order が負の場合はエラー', () => {
+    const result = validatePutBody({ items: [{ gear_id: 'x', quantity: 1, sort_order: -1 }] });
+    expect('error' in result).toBe(true);
+  });
+
+  it('同じ gear_id が重複する場合はエラー', () => {
+    const result = validatePutBody({
+      items: [
+        { gear_id: 'same', quantity: 1, sort_order: 0 },
+        { gear_id: 'same', quantity: 2, sort_order: 1 },
+      ],
+    });
+    expect('error' in result).toBe(true);
+  });
+
+  it('body がオブジェクトでない場合はエラー', () => {
+    expect('error' in validatePutBody(null)).toBe(true);
+    expect('error' in validatePutBody('string')).toBe(true);
+  });
+});
+
+describe('validatePatchBody', () => {
+  it('used=true の正常なbodyを受け付ける', () => {
+    const result = validatePatchBody({ gear_id: 'g1', used: true });
+    expect('data' in result).toBe(true);
+    if ('data' in result) {
+      expect(result.data.gear_id).toBe('g1');
+      expect(result.data.used).toBe(true);
+    }
+  });
+
+  it('used=false の正常なbodyを受け付ける', () => {
+    const result = validatePatchBody({ gear_id: 'g1', used: false });
+    expect('data' in result).toBe(true);
+  });
+
+  it('used=null（未記録リセット）を受け付ける', () => {
+    const result = validatePatchBody({ gear_id: 'g1', used: null });
+    expect('data' in result).toBe(true);
+    if ('data' in result) {
+      expect(result.data.used).toBeNull();
+    }
+  });
+
+  it('used_quantity=0 を受け付ける', () => {
+    const result = validatePatchBody({ gear_id: 'g1', used: true, used_quantity: 0 });
+    expect('data' in result).toBe(true);
+  });
+
+  it('used_quantity=999 を受け付ける', () => {
+    const result = validatePatchBody({ gear_id: 'g1', used: true, used_quantity: 999 });
+    expect('data' in result).toBe(true);
+  });
+
+  it('used_quantity=1000 はエラー', () => {
+    const result = validatePatchBody({ gear_id: 'g1', used: true, used_quantity: 1000 });
+    expect('error' in result).toBe(true);
+  });
+
+  it('used_quantity が負の場合はエラー', () => {
+    const result = validatePatchBody({ gear_id: 'g1', used: true, used_quantity: -1 });
+    expect('error' in result).toBe(true);
+  });
+
+  it('used_quantity が小数の場合はエラー', () => {
+    const result = validatePatchBody({ gear_id: 'g1', used: true, used_quantity: 1.5 });
+    expect('error' in result).toBe(true);
+  });
+
+  it('note が500文字以内なら受け付ける', () => {
+    const result = validatePatchBody({ gear_id: 'g1', used: true, note: 'a'.repeat(500) });
+    expect('data' in result).toBe(true);
+  });
+
+  it('note が501文字以上はエラー', () => {
+    const result = validatePatchBody({ gear_id: 'g1', used: true, note: 'a'.repeat(501) });
+    expect('error' in result).toBe(true);
+  });
+
+  it('gear_id が空文字はエラー', () => {
+    const result = validatePatchBody({ gear_id: '', used: true });
+    expect('error' in result).toBe(true);
+  });
+
+  it('gear_id がない場合はエラー', () => {
+    const result = validatePatchBody({ used: true });
+    expect('error' in result).toBe(true);
+  });
+
+  it('used がない場合はエラー', () => {
+    const result = validatePatchBody({ gear_id: 'g1' });
+    expect('error' in result).toBe(true);
+  });
+
+  it('used が boolean/null 以外はエラー', () => {
+    const result = validatePatchBody({ gear_id: 'g1', used: 'yes' });
+    expect('error' in result).toBe(true);
+  });
+
+  it('body がオブジェクトでない場合はエラー', () => {
+    expect('error' in validatePatchBody(null)).toBe(true);
+  });
+});

--- a/src/lib/race-gear-validation.ts
+++ b/src/lib/race-gear-validation.ts
@@ -1,0 +1,105 @@
+type ValidationResult<T> = { data: T } | { error: string };
+
+export interface PutGearItem {
+  gear_id: string;
+  quantity: number;
+  sort_order: number;
+}
+
+export interface PutGearBody {
+  items: PutGearItem[];
+}
+
+export interface PatchGearBody {
+  gear_id: string;
+  used: boolean | null;
+  used_quantity?: number;
+  note?: string;
+}
+
+function isInteger(n: unknown): n is number {
+  return typeof n === 'number' && Number.isInteger(n);
+}
+
+export function validatePutBody(body: unknown): ValidationResult<PutGearBody> {
+  if (body === null || typeof body !== 'object') {
+    return { error: 'リクエストボディが不正です' };
+  }
+
+  const b = body as Record<string, unknown>;
+
+  if (!Array.isArray(b.items)) {
+    return { error: 'items は配列で指定してください' };
+  }
+
+  const items: PutGearItem[] = [];
+  const seenGearIds = new Set<string>();
+
+  for (let i = 0; i < b.items.length; i++) {
+    const item = b.items[i] as Record<string, unknown>;
+
+    if (typeof item.gear_id !== 'string' || item.gear_id.trim() === '') {
+      return { error: `items[${i}].gear_id は空でない文字列で指定してください` };
+    }
+    const gear_id = item.gear_id.trim();
+
+    if (seenGearIds.has(gear_id)) {
+      return { error: `items に重複した gear_id があります: ${gear_id}` };
+    }
+    seenGearIds.add(gear_id);
+
+    if (!isInteger(item.quantity) || (item.quantity as number) < 1 || (item.quantity as number) > 999) {
+      return { error: `items[${i}].quantity は1〜999の整数で指定してください` };
+    }
+
+    if (!isInteger(item.sort_order) || (item.sort_order as number) < 0) {
+      return { error: `items[${i}].sort_order は0以上の整数で指定してください` };
+    }
+
+    items.push({ gear_id, quantity: item.quantity as number, sort_order: item.sort_order as number });
+  }
+
+  return { data: { items } };
+}
+
+export function validatePatchBody(body: unknown): ValidationResult<PatchGearBody> {
+  if (body === null || typeof body !== 'object') {
+    return { error: 'リクエストボディが不正です' };
+  }
+
+  const b = body as Record<string, unknown>;
+
+  if (!('gear_id' in b) || typeof b.gear_id !== 'string' || b.gear_id.trim() === '') {
+    return { error: 'gear_id は空でない文字列で指定してください' };
+  }
+  const gear_id = b.gear_id.trim();
+
+  if (!('used' in b)) {
+    return { error: 'used は必須です' };
+  }
+  if (b.used !== null && typeof b.used !== 'boolean') {
+    return { error: 'used は boolean または null で指定してください' };
+  }
+  const used = b.used as boolean | null;
+
+  const result: PatchGearBody = { gear_id, used };
+
+  if ('used_quantity' in b && b.used_quantity !== undefined && b.used_quantity !== null) {
+    if (!isInteger(b.used_quantity) || (b.used_quantity as number) < 0 || (b.used_quantity as number) > 999) {
+      return { error: 'used_quantity は0〜999の整数で指定してください' };
+    }
+    result.used_quantity = b.used_quantity as number;
+  }
+
+  if ('note' in b && b.note !== undefined && b.note !== null) {
+    if (typeof b.note !== 'string') {
+      return { error: 'note は文字列で指定してください' };
+    }
+    if (b.note.length > 500) {
+      return { error: 'note は500文字以内で指定してください' };
+    }
+    result.note = b.note;
+  }
+
+  return { data: result };
+}

--- a/src/lib/race-gear-validation.ts
+++ b/src/lib/race-gear-validation.ts
@@ -36,7 +36,11 @@ export function validatePutBody(body: unknown): ValidationResult<PutGearBody> {
   const seenGearIds = new Set<string>();
 
   for (let i = 0; i < b.items.length; i++) {
-    const item = b.items[i] as Record<string, unknown>;
+    const raw = b.items[i];
+    if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+      return { error: `items[${i}] はオブジェクトで指定してください` };
+    }
+    const item = raw as Record<string, unknown>;
 
     if (typeof item.gear_id !== 'string' || item.gear_id.trim() === '') {
       return { error: `items[${i}].gear_id は空でない文字列で指定してください` };

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -360,6 +360,24 @@
     "categoryLight": "Light",
     "categoryPoles": "Poles",
     "categoryNutrition": "Nutrition",
-    "categoryOther": "Other"
+    "categoryOther": "Other",
+    "raceGearButton": "Gear",
+    "raceGearEmpty": "No gear registered",
+    "raceGearNoGear": "Register your gear first to create a packing list",
+    "raceGearAddFromGear": "Add from My Gear",
+    "raceGearCopyFromPrev": "Copy from previous race",
+    "raceGearCopySelect": "Select source race",
+    "raceGearCopyConfirm": "Copy this list",
+    "raceGearNoCandidates": "No gear lists available to copy from",
+    "raceGearSave": "Save",
+    "raceGearSaving": "Saving…",
+    "raceGearSaved": "Saved",
+    "raceGearQuantity": "Qty",
+    "raceGearUsed": "Used",
+    "raceGearNotUsed": "Not used",
+    "raceGearUsedUnknown": "Not recorded",
+    "raceGearUsedQuantity": "Used qty",
+    "raceGearNote": "Note",
+    "raceGearGoToGear": "Register gear"
   }
 }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -378,6 +378,10 @@
     "raceGearUsedUnknown": "Not recorded",
     "raceGearUsedQuantity": "Used qty",
     "raceGearNote": "Note",
-    "raceGearGoToGear": "Register gear"
+    "raceGearGoToGear": "Register gear",
+    "raceGearRemove": "Remove",
+    "raceGearAdd": "Add",
+    "raceGearCancel": "Cancel",
+    "raceGearPatchError": "Failed to save"
   }
 }

--- a/src/messages/ja.json
+++ b/src/messages/ja.json
@@ -360,6 +360,24 @@
     "categoryLight": "ライト",
     "categoryPoles": "ポール",
     "categoryNutrition": "補給食",
-    "categoryOther": "その他"
+    "categoryOther": "その他",
+    "raceGearButton": "装備",
+    "raceGearEmpty": "装備が登録されていません",
+    "raceGearNoGear": "マイギアを登録してから装備リストを作成できます",
+    "raceGearAddFromGear": "マイギアから追加",
+    "raceGearCopyFromPrev": "前回からコピー",
+    "raceGearCopySelect": "コピー元を選択",
+    "raceGearCopyConfirm": "このリストをコピー",
+    "raceGearNoCandidates": "コピー元となる装備リストがありません",
+    "raceGearSave": "保存",
+    "raceGearSaving": "保存中…",
+    "raceGearSaved": "保存しました",
+    "raceGearQuantity": "個数",
+    "raceGearUsed": "使った",
+    "raceGearNotUsed": "使わなかった",
+    "raceGearUsedUnknown": "未記録",
+    "raceGearUsedQuantity": "使用数",
+    "raceGearNote": "メモ",
+    "raceGearGoToGear": "マイギアを登録する"
   }
 }

--- a/src/messages/ja.json
+++ b/src/messages/ja.json
@@ -378,6 +378,10 @@
     "raceGearUsedUnknown": "未記録",
     "raceGearUsedQuantity": "使用数",
     "raceGearNote": "メモ",
-    "raceGearGoToGear": "マイギアを登録する"
+    "raceGearGoToGear": "マイギアを登録する",
+    "raceGearRemove": "削除",
+    "raceGearAdd": "追加",
+    "raceGearCancel": "キャンセル",
+    "raceGearPatchError": "保存に失敗しました"
   }
 }


### PR DESCRIPTION
## Summary

- `/api/user/races/[raceId]/gear` に GET / PUT / PATCH エンドポイントを追加
  - GET: 装備リスト取得。`?source=candidates` でコピー元候補一覧を返す
  - PUT: 装備リスト全置換（gear_id所有者確認、既存のused/noteを引き継ぎ）
  - PATCH: 個別アイテムの使用記録（used / used_quantity / note）を更新
- `RaceGearSection` コンポーネントをマイページの各レース行に追加
  - **レース前**: マイギアから追加、前のレースからコピー、数量編集、保存（PUT）
  - **レース後**: 使用/未使用/未記録トグル、使用数入力、メモ入力（PATCH自動保存）
  - マイギア未登録時はギア登録ページへのリンクを表示

## Test plan

- [x] マイページ → 参加予定レースに「装備」ボタンが表示される
- [x] 「装備」ボタンをクリックするとパネルが展開される
- [x] マイギアが未登録の場合、ギア登録リンクが表示される
- [x] 「マイギアから追加」でギア選択パネルが開き、選択・追加できる
- [ ] 「前のレースからコピー」で過去レースのリストをコピーできる
- [x] 「保存」ボタンで装備リストが保存される
- [ ] 過去のレースでは使用/未使用トグルとメモ入力が表示される
- [x] 全テスト 652件 通過確認済み

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * マイページの各レースで装備リストを管理できるようになりました。
  * レース前は装備の追加・削除・数量編集・保存、過去レースからのコピーに対応しました。
  * レース後は使用状況、使用数、メモを記録・更新できます。
  * マイギア未登録時は登録ページへのリンクを表示します。
  * 日本語・英語の表示に対応しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->